### PR TITLE
python: specify path to tcl-tk during configure and add comments about tkinter module

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -87,6 +87,8 @@ class Python < Formula
       --enable-loadable-sqlite-extensions
       --without-ensurepip
       --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-tcltk-includes="-I#{Formula["tcl-tk"].opt_include}"
+      --with-tcltk-libs="-L#{Formula["tcl-tk"].opt_lib}"
     ]
     args << "--with-dtrace" unless OS.linux?
 
@@ -348,6 +350,11 @@ class Python < Formula
         pip3 install <package>
       They will install into the site-package directory
         #{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}
+
+      The default python3 installation does not include tkinter module and does
+      not support module such as matplotlib TkAGG backend. To get python3 with
+      tkinter module, you need to install tcl-tk then install python3 by running
+        brew install tcl-tk && brew install python3 --build-from-source
 
       See: https://docs.brew.sh/Homebrew-and-Python
     EOS


### PR DESCRIPTION
Resolve issue 11256. This patch will allow python to build with tkInter
module, which supports gui backend modules such as matplotlib, if tcl-tk
is already installed. If tcl-tk is not installed, this falls back to 
previous python build.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----