### PR TITLE
Add jpeg as emacs dependency

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -27,7 +27,7 @@ class Emacs < Formula
   unless OS.mac?
     depends_on "libxml2"
     depends_on "ncurses"
-    depends_on "libjpeg"
+    depends_on "jpeg"
   end
 
   def install

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -27,6 +27,7 @@ class Emacs < Formula
   unless OS.mac?
     depends_on "libxml2"
     depends_on "ncurses"
+    depends_on "libjpeg"
   end
 
   def install


### PR DESCRIPTION
Emacs depends on libjpeg:
ldd /home/linuxbrew/.linuxbrew/bin/emacs
    libjpeg.so.9 => not found

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

    No, I cannot run this command, because running this command will install a lot of ruby gems, some of the ruby gems failed to compile. I'll submit an issue about this. 

- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
