### PR TITLE
Adds GO111MODULE=on environment variable

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -19,6 +19,7 @@ class Terraform < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "on"
     ENV.prepend_create_path "PATH", buildpath/"bin"
 
     dir = buildpath/"src/github.com/hashicorp/terraform"


### PR DESCRIPTION
PR to fix Terraform install we discussed here: https://github.com/Homebrew/linuxbrew-core/pull/12003/files

FYI - It has to with a change in a newer version of Go and specifically related to importing modules between versions (https://github.com/golang/go/wiki/Modules)
