### PR TITLE
Fix a mistake that says `Homebrew` instead of `Linuxbrew`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Linuxbrew Core
-Core formulae for the Homebrew package manager.
+Core formulae for the Linuxbrew package manager.
 
 ## How do I install these formulae?
 
-Just `brew install <formula>`. This is the default tap for Homebrew and is installed by default.
+Just `brew install <formula>`. This is the default tap for Linuxbrew and is installed by default.
 
 ## More Documentation, Troubleshooting, Contributing, Security, Community, Donations, License and Sponsors
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This fixes a mistake that says `Homebrew` instead of `Linuxbrew`