### PR TITLE
 fix bcel-6.3 url in ant.rb

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -15,7 +15,7 @@ class Ant < Formula
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3-bin.tar.gz"
+    url "http://archive.apache.org/dist/commons/bcel/binaries/bcel-6.3-bin.tar.gz"
     sha256 "378a2d81bbf8d660a4a2515ef19dc66e74f8f6aa9495a8a909cd35b17eef3665"
   end
 

--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -15,7 +15,7 @@ class Ant < Formula
   end
 
   resource "bcel" do
-    url "http://archive.apache.org/dist/commons/bcel/binaries/bcel-6.3-bin.tar.gz"
+    url "https://archive.apache.org/dist/commons/bcel/binaries/bcel-6.3-bin.tar.gz"
     sha256 "378a2d81bbf8d660a4a2515ef19dc66e74f8f6aa9495a8a909cd35b17eef3665"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
