### PR TITLE
Make tcl-tk optional in pypy and fix wrong sha256

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -2,7 +2,7 @@ class Pypy < Formula
   desc "Highly performant implementation of Python 2 in Python"
   homepage "https://pypy.org/"
   url "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-src.tar.bz2"
-  sha256 "84ce5bc2867b224e2516ef431d78c6908d0182bc89444f7c1ef707443763754f"
+  sha256 "b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b"
   head "https://bitbucket.org/pypy/pypy", :using => :hg
 
   bottle do

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -23,7 +23,7 @@ class Pypy < Formula
   unless OS.mac?
     depends_on "expat"
     depends_on "libffi"
-    depends_on "tcl-tk"
+    depends_on "tcl-tk" if build.with? "tcl-tk"
     depends_on "zlib"
   end
 

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -49,7 +49,9 @@ class Pypy < Formula
   end
 
   def install
-    ENV.append "CFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+    if OS.mac? && MacOS.sdk_path_if_needed
+      ENV.append "CFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+    end
     # Having PYTHONPATH set can cause the build to fail if another
     # Python is present, e.g. a Homebrew-provided Python 2.x
     # See https://github.com/Homebrew/homebrew/issues/24364


### PR DESCRIPTION
Similar to https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/python.rb#L35

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
