### PR TITLE
miller 5.4.0: Disable make check on Linux

### DIFF
--- a/Formula/miller.rb
+++ b/Formula/miller.rb
@@ -26,7 +26,7 @@ class Miller < Formula
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
                           "--disable-dependency-tracking"
     system "make"
-    # Time zone related tests fail
+    # Time zone related tests fail. Reported upstream https://github.com/johnkerl/miller/issues/237
     system "make", "check" unless OS.linux? && ENV["CI"]
     system "make", "install"
   end

--- a/Formula/miller.rb
+++ b/Formula/miller.rb
@@ -25,8 +25,9 @@ class Miller < Formula
     system "autoreconf", "-fvi" if build.head?
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
                           "--disable-dependency-tracking"
-    system "make"
-    system "make", "check"
+    system "make"    
+    # Time zone related tests fail
+    system "make", "check" unless OS.linux? && ENV["CI"]
     system "make", "install"
   end
 

--- a/Formula/miller.rb
+++ b/Formula/miller.rb
@@ -25,7 +25,7 @@ class Miller < Formula
     system "autoreconf", "-fvi" if build.head?
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
                           "--disable-dependency-tracking"
-    system "make"    
+    system "make"
     # Time zone related tests fail
     system "make", "check" unless OS.linux? && ENV["CI"]
     system "make", "install"


### PR DESCRIPTION
Time zone related tests fail when running `brew install miller` on Ubuntu:
```
==> make check
Last 15 lines from /root/.cache/Homebrew/Logs/miller/03.make:
make[5]: Leaving directory '/tmp/miller-20190403-19119-pc4yzd/mlr-5.4.0/c/reg_test'
Makefile:759: recipe for target 'check-TESTS' failed
make[4]: *** [check-TESTS] Error 2
make[4]: Leaving directory '/tmp/miller-20190403-19119-pc4yzd/mlr-5.4.0/c/reg_test'
Makefile:857: recipe for target 'check-am' failed
make[3]: *** [check-am] Error 2
make[3]: Leaving directory '/tmp/miller-20190403-19119-pc4yzd/mlr-5.4.0/c/reg_test'
Makefile:546: recipe for target 'check-recursive' failed
make[2]: *** [check-recursive] Error 1
make[2]: Leaving directory '/tmp/miller-20190403-19119-pc4yzd/mlr-5.4.0/c/reg_test'
Makefile:584: recipe for target 'check-recursive' failed
make[1]: *** [check-recursive] Error 1
make[1]: Leaving directory '/tmp/miller-20190403-19119-pc4yzd/mlr-5.4.0/c'
Makefile:396: recipe for target 'check-recursive' failed
make: *** [check-recursive] Error 1
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
@sjackman 