### PR TITLE
Add alternative name 'yacc' for program 'byacc'.

### DIFF
--- a/Formula/byacc.rb
+++ b/Formula/byacc.rb
@@ -17,6 +17,9 @@ class Byacc < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--program-prefix=b", "--prefix=#{prefix}", "--man=#{man}"
     system "make", "install"
+
+    bin.install_symlink "byacc" => "yacc"
+    man1.install_symlink "byacc.1" => "yacc.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

`byacc` is the most popular implementation of `yacc` and also the only implementation brew provides. Brew should automatically symlink `yacc` to `byacc`. This is the exact same behavior for homebrew as for example the installation of `gawk`, which is the most popular implementation of `awk`. 

This patch provides that same behaviour for byacc by symlinking yacc to byacc and yacc.1 to byacc.1 for the man pages. 

This patch can indirectly also fix two partially broken formula (as for as I am aware of). These formula are `awk` (original `awk`, not aforementioned `gawk`) and `sc-im`. These two application look for `yacc` during build and will fail if this is not installed. Including `byacc` as a dependency for these two applications will fix this. (I can also make that PR if you want to.)

One question: Will these changes also be merged into homebrew for Mac, or should I make a PR for them seperately. (Or should I only make a PR on homebrew for Mac, which linuxbrew will merge?)