### PR TITLE
cmigemo: Fix build for Linuxbrew

### DIFF
--- a/Formula/cmigemo.rb
+++ b/Formula/cmigemo.rb
@@ -23,6 +23,7 @@ class Cmigemo < Formula
   depends_on "nkf" => :build
 
   def install
+    ENV.deparallelize unless OS.mac?
     chmod 0755, "./configure"
     system "./configure", "--prefix=#{prefix}"
     os = OS.mac? ? "osx" : "gcc"

--- a/Formula/cmigemo.rb
+++ b/Formula/cmigemo.rb
@@ -25,11 +25,12 @@ class Cmigemo < Formula
   def install
     chmod 0755, "./configure"
     system "./configure", "--prefix=#{prefix}"
-    system "make", "osx"
-    system "make", "osx-dict"
+    os = OS.mac? ? "osx" : "gcc"
+    system "make", os
+    system "make", "#{os}-dict"
     system "make", "-C", "dict", "utf-8" if build.stable?
     ENV.deparallelize # Install can fail on multi-core machines unless serialized
-    system "make", "osx-install"
+    system "make", "#{os}-install"
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- `brew test cmigemo`

  ```
  Error: cmigemo defines no test
  ```

  - No test in [homebrew-core/Formula/cmigemo.rb](https://github.com/Homebrew/homebrew-core/blob/d7f4399c7e8f9b1de6899b7ec57b102950c4e7ee/Formula/cmigemo.rb).

- `brew audit --strict cmigemo`

  ```
  cmigemo:
    * C: 1: col 1: A `test do` test block should be added
  Error: 1 problem in 1 formula detected
  ```

  - Same above.

- `brew gist-logs cmigemo`
  - https://gist.github.com/Milly/f14b98939c548684689ad2d7b3d3793b

- Fixed point
  - `cmigemo` has OS dependent make target. Using the `gcc` target, unless OSX.