### PR TITLE
gmp: test for intel hardware before picking intel specific options

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -24,7 +24,7 @@ class Gmp < Formula
 
     if OS.mac?
       args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
-    elsif Hardware::CPU.Intel?
+    elsif Hardware::CPU.intel?
       args << "--build=core2-linux-gnu"
       args << "ABI=32" if Hardware::CPU.is_32_bit?
     end

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -24,9 +24,9 @@ class Gmp < Formula
 
     if OS.mac?
       args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
-    else
+    elsif Hardware::CPU.Intel?
       args << "--build=core2-linux-gnu"
-      args << "ABI=32" if Hardware::CPU.intel? && Hardware::CPU.is_32_bit?
+      args << "ABI=32" if Hardware::CPU.is_32_bit?
     end
 
     system "./configure", *args


### PR DESCRIPTION
Updates #12681

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This updates the `gmp` formula per #12681 to test for the presence of Intel hardware before picking Intel-specific compiler options. 

With this patch I am able to build on arm64 and all tests pass.