### PR TITLE
TravisCI: Use `rvm: default`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: system
+rvm: default
 sudo: required
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,8 @@ before_install:
   - git clone --depth=1 https://github.com/Homebrew/brew "$LINUXBREW/Homebrew"
   - ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/
   - export PATH="$LINUXBREW/bin:$LINUXBREW/sbin:$PATH"
+  # Remove pyenv, phpenv, clang from $PATH
+  - export PATH="$(echo -n "$PATH"|tr ':' $'\n'|grep -Ev 'pyenv|phpenv|clang'|tr $'\n' ':')"
   - export HOMEBREW_DEVELOPER=1
   - export HOMEBREW_FORCE_VENDOR_RUBY=1
   - export HOMEBREW_NO_AUTO_UPDATE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ before_install:
       x11proto-input-dev
       x11proto-kb-dev
       x11proto-xext-dev
-      zlib1g-dev
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis-ci@linuxbrew.sh"
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Currently TravisCI always failure with `rvm: system` on startup (very first, test not started).
Use `rvm: default`.

TravisCI Logs:
```
3.89s$ rvm use system --install --binary --fuzzy
curl: (22) The requested URL returned error: 404 Not Found
Now using system ruby.
** Updating RubyGems to the latest compatible version for security reasons. **
** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **
4.18s$ gem install bundler -v '< 2'
Fetching: bundler-1.17.3.gem (100%)
ERROR:  While executing gem ... (Errno::EACCES)
    Permission denied - /var/lib/gems
The command "gem install bundler -v '< 2'" failed and exited with 1 during .
Your build has been stopped.
```

But PR #5375 (TravisCI: Use rvm: system) is exists...