### PR TITLE
sratoolkit: fix build for linux

### DIFF
--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -6,7 +6,6 @@ class Sratoolkit < Formula
   head "https://github.com/ncbi/sra-tools.git"
 
   bottle do
-    cellar :any
     sha256 "3f096fe6b0e114fa80664808855571f1f4b5a90791d0ff27344045541fabcc1f" => :mojave
     sha256 "eae0fff7e32f0c681c804686b5dc7dacbd8d051cc2538a3344b43c3e3c7c7b8d" => :high_sierra
     sha256 "0f6ea3b9f3138766a401fa0c892c888eeaeabc95409d26669985ce72aca3f123" => :sierra

--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -71,7 +71,7 @@ class Sratoolkit < Formula
     system "make", "install"
 
     # Remove non-executable files.
-    rm_r [bin/"magic", bin/"ncbi"]
+    rm_rf [bin/"magic", bin/"ncbi"]
   end
 
   test do


### PR DESCRIPTION
Fix error message:
```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/fileutils.rb:1452:in `unlink'
Errno::ENOENT: No such file or directory @ unlink_internal - /home/linuxbrew/.linuxbrew/Cellar/sratoolkit/2.9.3/bin/ncbi
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
