### PR TITLE
Fix 'add empty line after guard clause' `brew audit --strict` failures

### DIFF
--- a/Formula/corebird.rb
+++ b/Formula/corebird.rb
@@ -40,6 +40,7 @@ class Corebird < Formula
   test do
     # Fails without an X11 display: Gtk-WARNING **: cannot open display
     return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+
     system "#{bin}/corebird", "--help"
   end
 end

--- a/Formula/ed.rb
+++ b/Formula/ed.rb
@@ -33,6 +33,7 @@ class Ed < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       All commands have been installed with the prefix "g".
       If you need to use these commands with their normal names, you

--- a/Formula/findutils.rb
+++ b/Formula/findutils.rb
@@ -61,6 +61,7 @@ class Findutils < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       All commands have been installed with the prefix "g".
       If you need to use these commands with their normal names, you

--- a/Formula/firebase-cli.rb
+++ b/Formula/firebase-cli.rb
@@ -24,6 +24,7 @@ class FirebaseCli < Formula
   test do
     # The following test requires /usr/bin/expect.
     return unless OS.mac?
+
     (testpath/"test.exp").write <<~EOS
       spawn #{bin}/firebase login:ci --no-localhost
       expect "Paste"

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -51,6 +51,7 @@ class Fontforge < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       This formula only installs the command line utilities.
 

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -266,12 +266,14 @@ class Gcc < Formula
       unless glibc_installed
         target = Utils.popen_read(gcc, "-print-multiarch").chomp
         raise "command failed: #{gcc} -print-multiarch" if $CHILD_STATUS.exitstatus.nonzero?
+
         system_header_dirs += ["/usr/include/#{target}", "/usr/include"]
       end
 
       # Save a backup of the default specs file
       specs_string = Utils.popen_read(gcc, "-dumpspecs")
       raise "command failed: #{gcc} -dumpspecs" if $CHILD_STATUS.exitstatus.nonzero?
+
       specs_orig.write specs_string
 
       # Set the library search path

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -219,12 +219,14 @@ class GccAT49 < Formula
       unless glibc_installed
         target = Utils.popen_read(gcc, "-print-multiarch").chomp
         raise "command failed: #{gcc} -print-multiarch" if $CHILD_STATUS.exitstatus.nonzero?
+
         system_header_dirs += ["/usr/include/#{target}", "/usr/include"]
       end
 
       # Save a backup of the default specs file
       specs_string = Utils.popen_read(gcc, "-dumpspecs")
       raise "command failed: #{gcc} -dumpspecs" if $CHILD_STATUS.exitstatus.nonzero?
+
       specs_orig.write specs_string
 
       # Set the library search path

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -225,12 +225,14 @@ class GccAT5 < Formula
       unless glibc_installed
         target = Utils.popen_read(gcc, "-print-multiarch").chomp
         raise "command failed: #{gcc} -print-multiarch" if $CHILD_STATUS.exitstatus.nonzero?
+
         system_header_dirs += ["/usr/include/#{target}", "/usr/include"]
       end
 
       # Save a backup of the default specs file
       specs_string = Utils.popen_read(gcc, "-dumpspecs")
       raise "command failed: #{gcc} -dumpspecs" if $CHILD_STATUS.exitstatus.nonzero?
+
       specs_orig.write specs_string
 
       # Set the library search path

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -103,6 +103,7 @@ class Glibc < Formula
       # Use the original GCC specs file.
       specs = Pathname.new(Utils.popen_read(ENV.cc, "-print-file-name=specs.orig").chomp)
       raise "The original GCC specs file is missing: #{specs}" unless specs.readable?
+
       ENV["LDFLAGS"] = "-specs=#{specs}"
 
       # Fix error ld: cannot find -lc when upgrading glibc and compiling with a brewed gcc.

--- a/Formula/gnu-indent.rb
+++ b/Formula/gnu-indent.rb
@@ -39,6 +39,7 @@ class GnuIndent < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       GNU "indent" has been installed as "gindent".
       If you need to use it as "indent", you can add a "gnubin" directory

--- a/Formula/gnu-sed.rb
+++ b/Formula/gnu-sed.rb
@@ -36,6 +36,7 @@ class GnuSed < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       GNU "sed" has been installed as "gsed".
       If you need to use it as "sed", you can add a "gnubin" directory

--- a/Formula/gnu-time.rb
+++ b/Formula/gnu-time.rb
@@ -33,6 +33,7 @@ class GnuTime < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       GNU "time" has been installed as "gtime".
       If you need to use it as "time", you can add a "gnubin" directory

--- a/Formula/gnu-units.rb
+++ b/Formula/gnu-units.rb
@@ -35,6 +35,7 @@ class GnuUnits < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       All commands have been installed with the prefix "g".
       If you need to use these commands with their normal names, you

--- a/Formula/gnu-which.rb
+++ b/Formula/gnu-which.rb
@@ -35,6 +35,7 @@ class GnuWhich < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       GNU "which" has been installed as "gwhich".
       If you need to use it as "which", you can add a "gnubin" directory

--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -42,6 +42,7 @@ class Grep < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       All commands have been installed with the prefix "g".
       If you need to use these commands with their normal names, you

--- a/Formula/make.rb
+++ b/Formula/make.rb
@@ -34,6 +34,7 @@ class Make < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       GNU "make" has been installed as "gmake".
       If you need to use it as "make", you can add a "gnubin" directory

--- a/Formula/mednafen.rb
+++ b/Formula/mednafen.rb
@@ -34,6 +34,7 @@ class Mednafen < Formula
   test do
     # Test fails on headless CI: Could not initialize SDL: No available video device
     return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+
     cmd = "#{bin}/mednafen | head -n1 | grep -o '[0-9].*'"
     assert_equal version.to_s, shell_output(cmd).chomp
   end

--- a/Formula/nnn.rb
+++ b/Formula/nnn.rb
@@ -29,6 +29,7 @@ class Nnn < Formula
     # Test fails on CI: Input/output error @ io_fread - /dev/pts/0
     # Fixing it involves pty/ruby voodoo, which is not worth spending time on
     return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+
     # Testing this curses app requires a pty
     require "pty"
 

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -202,6 +202,7 @@ class Ruby < Formula
 
   def caveats
     return unless OS.mac?
+
     <<~EOS
       By default, binaries installed by gem will be placed into:
         #{rubygems_bindir}

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -133,6 +133,7 @@ class Wine < Formula
 
   def openssl_arch_args
     return { :i386 => %w[linux-generic32], :x86_64 => %w[linux-x86_64] } if OS.linux?
+
     {
       :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
       :i386   => %w[darwin-i386-cc],

--- a/Formula/zip.rb
+++ b/Formula/zip.rb
@@ -50,6 +50,7 @@ class Zip < Formula
     assert_predicate testpath/"test.zip", :exist?
     # zip -T needs unzip, disabled under Linux
     return unless OS.mac?
+
     assert_match "test of test.zip OK", shell_output("#{bin}/zip -T test.zip")
 
     # test bzip2 support that should be automatically linked in using the bzip2 library in macOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

:wave:

I compared these formulae with the ones in `homebrew-core` and the offending lines don't exist there (I ran `brew audit --only-cops=EmptyLineAfterGuardClause` to check), so I'm submitting these here to fix Linuxbrew formulae audits.

There are still some `brew audit --strict` failures on these formulae, but these commits fix the ones I was worried about this time - the rest are left for the next contributor (maybe me).

I didn't want to raise a many commit generic "fix all the things" PR, I thought I'd section them up by specific audit failure.