### PR TITLE
Fix source build of apr-util via missing dependencies

### DIFF
--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -3,7 +3,7 @@ class AprUtil < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.6.1.tar.bz2"
   sha256 "d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b"
-  revision OS.mac? ? 1 : 2
+  revision OS.mac? ? 1 : 3
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles"
@@ -11,7 +11,6 @@ class AprUtil < Formula
     sha256 "1bdf0cda4f0015318994a162971505f9807cb0589a4b0cbc7828531e19b6f739" => :high_sierra
     sha256 "75c244c3a34abab343f0db7652aeb2c2ba472e7ad91f13af5524d17bba3001f2" => :sierra
     sha256 "bae285ada445a2b5cc8b43cb8c61a75e177056c6176d0622f6f87b1b17a8502f" => :el_capitan
-    sha256 "f537b7832456438ce06b595199d1bf3f38a0b8800b9469db56b0b084ac1b1ac7" => :x86_64_linux
   end
 
   keg_only :provided_by_macos, "Apple's CLT package contains apr"

--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -20,7 +20,9 @@ class AprUtil < Formula
   depends_on "openssl"
   unless OS.mac?
     depends_on "expat"
+    depends_on "mawk"
     depends_on "sqlite"
+    depends_on "unixodbc"
     depends_on "util-linux" # for libuuid
   end
 


### PR DESCRIPTION
Fixes #4570.

Change-Id: I4f6337f19aa2a64d6aa16f0fdd848f737a954e21

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

https://gist.github.com/sambrightman/d52c2342ffbb4bdd3b4a5c673fb63b60
https://gist.github.com/sambrightman/87a9f6e69429f56abf31a81570a9cd4d

-----
