### PR TITLE
appscale-tools: change PyPi URL to pythonhosted.org for `brew audit`

### DIFF
--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -316,12 +316,12 @@ class AppscaleTools < Formula
 
   unless OS.mac?
     resource "secretstorage" do
-      url "https://pypi.python.org/packages/a5/a5/0830cfe34a4cfd0d1c3c8b614ede1edb2aaf999091ac8548dd19cb352e79/SecretStorage-2.3.1.tar.gz"
+      url "https://files.pythonhosted.org/packages/a5/a5/0830cfe34a4cfd0d1c3c8b614ede1edb2aaf999091ac8548dd19cb352e79/SecretStorage-2.3.1.tar.gz"
       sha256 "3af65c87765323e6f64c83575b05393f9e003431959c9395d1791d51497f29b6"
     end
 
     resource "pyparsing" do
-      url "https://pypi.python.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz"
+      url "https://files.pythonhosted.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz"
       sha256 "0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04"
     end
   end

--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -17,7 +17,10 @@ class AppscaleTools < Formula
   depends_on "openssl"
   depends_on "python@2"
   depends_on "ssh-copy-id"
-  depends_on "libffi" unless OS.mac?
+  unless OS.mac?
+    depends_on "libffi"
+    depends_on "pkg-config" => :build
+  end
 
   resource "retrying" do
     url "https://files.pythonhosted.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz"


### PR DESCRIPTION
- As these are in an `unless OS.mac?` condition, they don't apply to the
  upstream Homebrew formula. These changes fix the following `brew
  audit` errors:
  ```
    * C: 319: col 7: https://pypi.python.org/packages/a5/a5/0830cfe34a4cfd0d1c3c8b614ede1edb2aaf999091ac8548dd19cb352e79/SecretStorage-2.3.1.tar.gz should be `https://files.pythonhosted.org/packages/a5/a5/0830cfe34a4cfd0d1c3c8b614ede1edb2aaf999091ac8548dd19cb352e79/SecretStorage-2.3.1.tar.gz`
  * C: 324: col 7: https://pypi.python.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz should be `https://files.pythonhosted.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz`
  ```


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----