### PR TITLE
ykpers: fix build with an `if OS.mac?` condition

### DIFF
--- a/Formula/ykpers.rb
+++ b/Formula/ykpers.rb
@@ -14,14 +14,16 @@ class Ykpers < Formula
   depends_on "pkg-config" => :build
   depends_on "json-c"
   depends_on "libyubikey"
+  depends_on "libusb" unless OS.mac?
 
   def install
+    backend = OS.mac? ? "osx" : "libusb-1.0"
     libyubikey_prefix = Formula["libyubikey"].opt_prefix
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--with-libyubikey-prefix=#{libyubikey_prefix}",
-                          "--with-backend=osx"
+                          "--with-backend=#{backend}"
     system "make", "check"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
- I tried to install `ykman`, and installing its dependency `ykpers` failed with the error:
  ```
  ykcore_osx.c:36:32: fatal error: IOKit/hid/IOHIDLib.h: No such file or directory
  compilation terminated.
  Makefile:461: recipe for target 'ykcore_osx.lo' failed
  make[1]: *** [ykcore_osx.lo] Error 1
  ```
- The [ykpers configure script](https://github.com/Yubico/yubikey-personalization/blob/master/configure.ac#L71) states that possible values for the `--with-backend` option on `./configure` are "windows", "osx", "libusb" and "libusb-1.0".
- I set this to `libusb-1.0` because it's the value that fixes the problem for me. Worth testing on some other setups, probably!

`brew gist-logs ykpers` output is at https://gist.github.com/b18f35d21601e658f5f160a6f048d097.