### PR TITLE
netpbm: fix for Linuxbrew

### DIFF
--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -21,7 +21,8 @@ class Netpbm < Formula
   depends_on "libpng"
   depends_on "libtiff"
   unless OS.mac?
-    depends_on "flex"
+    depends_on "flex" => :build
+    depends_on "libxml2"
     depends_on "zlib"
   end
 


### PR DESCRIPTION
Fix the following error.

svgtopam.c:36:30: fatal error: libxml/xmlreader.h: No such file or directory


Closes #13015.