### PR TITLE
openjdk/jdk: disable bottles

### DIFF
--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -12,10 +12,7 @@ class Jdk < Formula
     sha256 "90c4ea877e816e3440862cfa36341bc87d05373d53389ec0f2d54d4e8c95daa2"
   end
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "66f84d75594cf1f9a4bc390d9b685efa67dcf3b78ef52fd0ebe3e6cc393404e7" => :x86_64_linux
-  end
+  bottle :unneeded
 
   def install
     odie "Use 'brew cask install java' on Mac OS" if OS.mac?

--- a/Formula/jdk@8.rb
+++ b/Formula/jdk@8.rb
@@ -14,10 +14,7 @@ class JdkAT8 < Formula
     sha256 "1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"
   end
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "3376215f8b0b43525ba4655b7547565214340725862af7d946b906242221d485" => :x86_64_linux
-  end
+  bottle :unneeded
 
   keg_only :versioned_formula
 

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -10,10 +10,7 @@ class Openjdk < Formula
   end
   version "1.8.0-181"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "9d731054e74d9fb88b49719ed28842709922b2ff1b104d4ea756a3e1b2bea64d" => :x86_64_linux
-  end
+  bottle :unneeded
 
   depends_on :linux
 

--- a/Formula/openjdk@10.rb
+++ b/Formula/openjdk@10.rb
@@ -15,6 +15,8 @@ class OpenjdkAT10 < Formula
     sha256 "f3b26abc9990a0b8929781310e14a339a7542adfd6596afb842fa0dd7e3848b2"
   end
 
+  bottle :unneeded
+
   depends_on :linux
 
   def install

--- a/Formula/openjdk@11.rb
+++ b/Formula/openjdk@11.rb
@@ -11,9 +11,7 @@ class OpenjdkAT11 < Formula
     sha256 "3784cfc4670f0d4c5482604c7c513beb1a92b005f569df9bf100e8bef6610f2e"
   end
 
-  bottle do
-    sha256 "2866dc00248063e5736c5675271a2f65e7ab187202d4e217eb3317f280a7474d" => :x86_64_linux
-  end
+  bottle :unneeded
 
   depends_on :linux
 

--- a/Formula/openjdk@9.rb
+++ b/Formula/openjdk@9.rb
@@ -15,6 +15,8 @@ class OpenjdkAT9 < Formula
     sha256 "39362fb9bfb341fcc802e55e8ea59f4664ca58fd821ce956d48e1aa4fb3d2dec"
   end
 
+  bottle :unneeded
+
   depends_on :linux
 
   def install


### PR DESCRIPTION
There is no need to build bottles as these formulae are poured from
binaries instead of built from the source.

Further, our bottle system breaks them as shown in the following:
```
$ ldd $(brew --prefix openjdk)/jre/lib/amd64/server/libjvm.so
Inconsistency detected by ld.so: dl-version.c: 224: _dl_check_map_versions: Assertion `needed != NULL' failed!
```
This issue is fixed when the bottle is disabled.
