### PR TITLE
patchelf: Update the bottle sha256 for Linux

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -9,7 +9,7 @@ class Patchelf < Formula
     sha256 "8f57b65d6a11bfe332e7663b144c0e4e9842291c2b0a4055bd10794b2911dac4" => :mojave
     sha256 "98e221be1ce346f4c33bee1fc87b7dba33aafcc88c98ac061e04a69c9c9e9584" => :high_sierra
     sha256 "2504614537c2837d9668389349586730c38b93a632175e1cf80568b0650eb5aa" => :sierra
-    sha256 "04628ac9ef53920ef0c0d612b40a30c6457e494d269a84e7eed3bf999e2f8951" => :x86_64_linux # glibc 2.13
+    sha256 "988b224305ff3fecadf9bbf5fbe1b18061077be6c896935b2cef29298526f5b8" => :x86_64_linux # glibc 2.13
   end
 
   resource "hellworld" do


### PR DESCRIPTION
Clear the RPATH to fix this error seen when installed with glibc < 2.23
to the standard /home/linuxbrew/.linuxbrew prefix:
```
patchelf/0.10/bin/patchelf: ??Ts?: ELF: zR: Error 18446744073353454743
```

See https://github.com/Homebrew/linuxbrew-core/issues/13148