### PR TITLE
dcos-cli: Build on Linux using `make linux` instead of `make darwin`

### DIFF
--- a/Formula/dcos-cli.rb
+++ b/Formula/dcos-cli.rb
@@ -21,10 +21,11 @@ class DcosCli < Formula
 
     bin_path = buildpath/"src/github.com/dcos/dcos-cli"
 
+    platform = OS.mac? ? "darwin" : "linux"
     bin_path.install Dir["*"]
     cd bin_path do
-      system "make", "darwin"
-      bin.install "build/darwin/dcos"
+      system "make", platform
+      bin.install "build/#{platform}/dcos"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The final checkbox is ticked given that I was able to reproduce and fix issue #12761 and there's an explanation and logs in there. :crossed_fingers:

Fixes #12761.