### PR TITLE
recon-ng: Specify libxml2 and libxslt as dependencies to fix the build

### DIFF
--- a/Formula/recon-ng.rb
+++ b/Formula/recon-ng.rb
@@ -15,6 +15,10 @@ class ReconNg < Formula
 
   # Dependency "mechanize" only support Python 2
   depends_on "python@2" # does not support Python 3
+  unless OS.mac?
+    depends_on "libxml2"
+    depends_on "libxslt"
+  end
 
   ### setup_requires dependencies
   resource "dicttoxml" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Before (issue 12651), this formula would fail to `pip install lxml`, a dependency, with a build error that was hard to decipher. From the pip logs, this failure was due to libxml2 and libxslt being missing.
- This installs them via `depends_on` at build-time for non-MacOS, and `recon-ng` installs and runs successfully.

Fixes #12651.

