### PR TITLE
wireshark: build breaks on Linux without lex and yacc

### DIFF
--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -11,10 +11,6 @@ class Wireshark < Formula
     sha256 "6f12831257770c9d36b042df85f8ba5ed553296f1f36e918cf3097fbec165ea6" => :sierra
   end
 
-  unless OS.mac?
-    depends_on "bison" => :build
-    depends_on "flex" => :build
-  end
   depends_on "cmake" => :build
   depends_on "c-ares"
   depends_on "glib"
@@ -25,6 +21,10 @@ class Wireshark < Formula
   depends_on "libssh"
   depends_on "lua@5.1"
   depends_on "nghttp2"
+  unless OS.mac?
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+  end
 
   def install
     args = std_cmake_args + %W[

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -11,7 +11,9 @@ class Wireshark < Formula
     sha256 "6f12831257770c9d36b042df85f8ba5ed553296f1f36e918cf3097fbec165ea6" => :sierra
   end
 
+  depends_on "bison" => :build if OS.linux?
   depends_on "cmake" => :build
+  depends_on "flex" => :build if OS.linux?
   depends_on "c-ares"
   depends_on "glib"
   depends_on "gnutls"

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -11,9 +11,11 @@ class Wireshark < Formula
     sha256 "6f12831257770c9d36b042df85f8ba5ed553296f1f36e918cf3097fbec165ea6" => :sierra
   end
 
-  depends_on "bison" => :build if OS.linux?
+  unless OS.mac?
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+  end
   depends_on "cmake" => :build
-  depends_on "flex" => :build if OS.linux?
   depends_on "c-ares"
   depends_on "glib"
   depends_on "gnutls"


### PR DESCRIPTION
I've added flex and bison as build-time dependencies. Tested on Ubuntu 18.04.

flex error gist: https://gist.github.com/dab3f0ab458cded206a1a7565f0db43f

bison error gist: https://gist.github.com/080a1f0c6087f6502604f47052783e21

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
