### PR TITLE
augustus: remove macOS-specific build logic

### DIFF
--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -15,9 +15,10 @@ class Augustus < Formula
 
   depends_on "boost" => :build
   depends_on "bamtools"
-  depends_on "gcc"
-  unless OS.mac?
-    depends_on "bamtools"
+
+  if OS.mac?
+    depends_on "gcc"
+  else
     depends_on "zlib"
   end
 
@@ -42,9 +43,11 @@ class Augustus < Formula
     # Clang breaks proteinprofile on macOS. This issue has been first reported
     # to upstream in 2016 (see https://github.com/nextgenusfs/funannotate/issues/3).
     # See also https://github.com/Gaius-Augustus/Augustus/issues/64
-    cd "src" do
-      with_env("HOMEBREW_CC" => "gcc-9") do
-        system "make"
+    if OS.mac?
+      cd "src" do
+        with_env("HOMEBREW_CC" => "gcc-9") do
+          system "make"
+        end
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

@sjackman, CC @iMichka

Is this what you had in mind? Sorry if not, I'm still not 100% clear on how the homebrew/linuxbrew split works.