### PR TITLE
gcc: restore `cellar :any`

### DIFF
--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -10,7 +10,7 @@ class GccAT6 < Formula
 
   # gcc is designed to be portable.
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
+    cellar :any
     sha256 "50d8452d2d87511d2e6d91b0487064d57b07d38c1022dc19fe0a4ccea7f2209e" => :mojave
     sha256 "93dc5c5ca44e01b074941cb96216ad948223dca5d04d354b0bfa11c536ff8e45" => :high_sierra
     sha256 "7737834f564e43eb4eb652accead7405382946bf1113eb10139b4421d385717b" => :sierra

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -10,6 +10,7 @@ class GccAT9 < Formula
 
   # gcc is designed to be portable.
   bottle do
+    cellar :any
     sha256 "4da2eeae62e8c91afff94c80660a734a312efb0390cf9a9898ff9e7a6f662a50" => :x86_64_linux
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

These were accidentally removed.

@sjackman @iMichka I think we may need a new DSL for this, so we could avoid this kind of manual intervention. For example, something similar to the existing `pour_bottle?` DSL:
```ruby
pour_bottle_any_cellar? do
  reason "gcc is design to be portable."
  satisfy { OS.linux? }
end
```