### PR TITLE
libstfl: fix build

### DIFF
--- a/Formula/libstfl.rb
+++ b/Formula/libstfl.rb
@@ -14,10 +14,18 @@ class Libstfl < Formula
 
   depends_on "swig" => :build
   depends_on "ruby"
+  unless OS.mac?
+    depends_on "perl"
+    depends_on "python@2"
+  end
 
   def install
-    ENV.append "LDLIBS", "-liconv"
-    ENV.append "LIBS", "-lncurses -liconv -lruby"
+    if OS.mac?
+      ENV.append "LDLIBS", "-liconv"
+      ENV.append "LIBS", "-lncurses -liconv -lruby"
+    else
+      ENV.append "LIBS", "-lncurses -lruby"
+    end
 
     %w[
       stfl.pc.in
@@ -41,8 +49,12 @@ class Libstfl < Formula
       s.change_make_var! "PYTHON_SITEARCH", lib/"python2.7/site-packages"
       s.gsub! "lib-dynload/", ""
       s.gsub! "ncursesw", "ncurses"
-      s.gsub! "gcc", "gcc -undefined dynamic_lookup #{`python-config --cflags`.chomp}"
-      s.gsub! "-lncurses", "-lncurses -liconv"
+      if OS.mac?
+        s.gsub! "gcc", "gcc -undefined dynamic_lookup #{`python-config --cflags`.chomp}"
+        s.gsub! "-lncurses", "-lncurses -liconv"
+      else
+        s.gsub! "gcc", "gcc #{`python-config --cflags`.chomp}"
+      end
     end
 
     # Fails race condition of test:
@@ -52,7 +64,7 @@ class Libstfl < Formula
 
     system "make"
 
-    inreplace "perl5/Makefile", "Network/Library", libexec/"lib/perl5"
+    inreplace "perl5/Makefile", "Network/Library", libexec/"lib/perl5" if OS.mac?
     system "make", "install", "prefix=#{prefix}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This is a _draft_ PR so we don't lose track of trying to fix #12868 given the [Discourse](https://discourse.brew.sh/t/formula-libstfl-0-24-building-fails-with-ld-cannot-find-liconv/4777) thread by the issue author and @sjackman appears stalled, but the issue is still open. I think it seemed deceptively simple from the original issue. :sweat_smile:

I still can't get it working, though. Both locally on Ubuntu and in a CentOS 7 Docker container I get the same error on this branch:

```
==> Installing libstfl
==> Downloading http://www.clifford.at/stfl/stfl-0.24.tar.gz
Already downloaded: /home/hb/.cache/Homebrew/downloads/37b9bb2c2a9f1cc09f40e99cf87c007ad0536bd7a779c5dada1103e66a015ce3--stfl-0.24.tar.gz
==> make
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
perl5/Makefile:
  expected replacement of "Network/Library" with #<Pathname:/home/hb/.linuxbrew/Cellar/libstfl/0.24_8/libexec/lib/perl5>
```

Doing a `brew install --interactive libstfl`, I can't even find what it's trying to replace, or even the `perl5/Makefile`, so that's probably a problem.