### PR TITLE
stoken: Fix build for Linux

### DIFF
--- a/Formula/stoken.rb
+++ b/Formula/stoken.rb
@@ -14,6 +14,7 @@ class Stoken < Formula
 
   depends_on "pkg-config" => :build
   depends_on "nettle"
+  depends_on "libxml2" unless OS.mac?
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
- This formula is a dependency of `openconnect`, which failed when I
  tried to `brew install openconnect`.
- The error was:
  ```
  src/sdtid.c:32:27: fatal error: libxml/parser.h: No such file or directory
  ```

Gist logs: https://gist.github.com/issyl0/6df56364e3dddbf1246f05608225e2df