### PR TITLE
vtk: fix and improve on issue introduced in #11337

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -34,16 +34,6 @@ class Vtk < Formula
   end
 
   def install
-    unless OS.mac?
-      linux_ldpath = `/sbin/ldconfig -v 2>/dev/null | grep -v ^$'\t'`
-      if linux_ldpath.include? "/usr/lib/#{RUBY_PLATFORM}:"
-        linux_lib = "/usr/lib/#{RUBY_PLATFORM}"
-      elsif linux_ldpath.include? "/usr/lib64:"
-        linux_lib = "/usr/lib64"
-      else
-        linux_lib = "/usr/lib"
-      end
-    end
     dylib = OS.mac? ? "dylib" : "so"
 
     python_executable = `which python3`.strip
@@ -87,8 +77,6 @@ class Vtk < Formula
       args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/lib#{python_version}.a'"
     elsif File.exist? "#{python_prefix}/lib/lib#{python_version}.#{dylib}"
       args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/lib#{python_version}.#{dylib}'"
-    elsif !OS.mac? && File.exist?("#{linux_lib}/lib#{python_version}.#{dylib}")
-      args << "-DPYTHON_LIBRARY='#{linux_lib}/lib#{python_version}.#{dylib}'"
     else
       odie "No libpythonX.Y.{#{dylib}|a} file found!"
     end
@@ -98,16 +86,6 @@ class Vtk < Formula
       system "make"
       system "make", "install"
     end
-
-    # Avoid hard-coding Python's Cellar paths
-    inreplace Dir["#{lib}/cmake/**/vtkPython.cmake"].first,
-      Formula["python"].prefix.realpath,
-      Formula["python"].opt_prefix
-
-    # Avoid hard-coding HDF5's Cellar path
-    inreplace Dir["#{lib}/cmake/**/vtkhdf5.cmake"].first,
-      Formula["hdf5"].prefix.realpath,
-      Formula["hdf5"].opt_prefix
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

> luho@marvin:~$ brew install vtk
> /home/luho/.linuxbrew/Homebrew/Library/Homebrew/brew.sh: line 4: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
> ==> Downloading https://www.vtk.org/files/release/8.2/VTK-8.2.0.tar.gz
> Already downloaded: /home/luho/.cache/Homebrew/downloads/bfbea40437b17f2734e32acfebf51e9d00c1dd8a34d63ac7410c77fdb46883e9--VTK-8.2.0.tar.gz
> Error: An exception occurred within a child process:
> &nbsp;&nbsp;NameError: undefined local variable or method `python_executable' for #<Formulary::FormulaNamespaced0780f3b8bd268fdd6760383b0108a87::Vtk:0x0000000003986c48>