### PR TITLE
pcsc-lite: Fix build

### DIFF
--- a/Formula/pcsc-lite.rb
+++ b/Formula/pcsc-lite.rb
@@ -5,6 +5,7 @@ class PcscLite < Formula
   sha256 "5a27262586eff39cfd5c19aadc8891dd71c0818d3d629539bd631b958be689c9"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "be4068d6d357c142d4978b1325cb1c534fcc369cba2bbbe44fb3eaceb8fdd501" => :mojave
     sha256 "0ed981ad7244d50d3084cef08991c5662658cd321d24784b2a6c2f8586f8f205" => :high_sierra
     sha256 "16167530e755c8c59a43b72433e9e1aba53b14f4f7364e85fc3159ecdc8ce75b" => :sierra
@@ -14,12 +15,20 @@ class PcscLite < Formula
   keg_only :provided_by_macos,
     "pcsc-lite interferes with detection of macOS's PCSC.framework"
 
+  unless OS.mac?
+    depends_on "pkg-config" => :build
+    depends_on "libusb"
+  end
+
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
-                          "--disable-libsystemd"
+    args = %W[--disable-dependency-tracking
+              --disable-silent-rules
+              --prefix=#{prefix}
+              --sysconfdir=#{etc}
+              --disable-libsystemd]
+    args << "--disable-libudev" unless OS.mac?
+
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- This depends on "pkg-config".
- It also depends on `sudo apt-get install libudev-dev`, which then
  fails under `brew test-bot-docker`, unless I pass the
  `--disable-libsystemd` argument.
- The `--disable-libsystemd` argument further produces an error about
  `libusb.so`, hence the inclusion of _another_ dependency, `libusb`.

Worth noting that I'm investigating this failure because it's [apparently a dependency for the `ykman` formula](https://github.com/Yubico/yubikey-manager#pip) - there'll be a separate PR for `ykman` when I've fixed all the things.