### PR TITLE
istioctl rev+1 (making it buildable on linux)

### DIFF
--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -5,7 +5,6 @@ class Istioctl < Formula
       :tag      => "1.2.2",
       :revision => "cd4a148f37dc386986d6a6d899778849e686beea"
 
-
   bottle do
     cellar :any_skip_relocation
     sha256 "a22c0b1940f87fce7f6f68637f047392f621d2fdfdac86107d2aa012b85ce96f" => :mojave

--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -4,6 +4,7 @@ class Istioctl < Formula
   url "https://github.com/istio/istio.git",
       :tag      => "1.2.2",
       :revision => "cd4a148f37dc386986d6a6d899778849e686beea"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -5,6 +5,7 @@ class Istioctl < Formula
       :tag      => "1.2.2",
       :revision => "cd4a148f37dc386986d6a6d899778849e686beea"
 
+
   bottle do
     cellar :any_skip_relocation
     sha256 "a22c0b1940f87fce7f6f68637f047392f621d2fdfdac86107d2aa012b85ce96f" => :mojave
@@ -20,7 +21,11 @@ class Istioctl < Formula
     ENV["ISTIO_VERSION"] = version.to_s
 
     srcpath = buildpath/"src/istio.io/istio"
-    outpath = buildpath/"out/darwin_amd64/release"
+    if OS.mac?
+      outpath = buildpath/"out/darwin_amd64/release"
+    else
+      outpath = buildpath/"out/linux_amd64/release"
+    end
     srcpath.install buildpath.children
 
     cd srcpath do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
