### PR TITLE
Fix ternary operator in revision lines for two formulae

### DIFF
--- a/Formula/libxml++3.rb
+++ b/Formula/libxml++3.rb
@@ -3,7 +3,7 @@ class Libxmlxx3 < Formula
   homepage "https://libxmlplusplus.sourceforge.io/"
   url "https://download.gnome.org/sources/libxml++/3.0/libxml++-3.0.1.tar.xz"
   sha256 "19dc8d21751806c015179bc0b83f978e65c878724501bfc0b6c1bcead29971a6"
-  revision OS.mac? 1 : 2
+  revision OS.mac? ? 1 : 2
 
   bottle do
     cellar :any

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -3,7 +3,7 @@ class Newt < Formula
   homepage "https://pagure.io/newt"
   url "https://pagure.io/releases/newt/newt-0.52.20.tar.gz"
   sha256 "8d66ba6beffc3f786d4ccfee9d2b43d93484680ef8db9397a4fb70b5adbb6dbc"
-  revision OS.mac? 1 : 2
+  revision OS.mac? ? 1 : 2
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

These were failing on `brew update`:

```
$ brew update
Updated Homebrew from f4a6012a9 to b0183d30c.
Error: libxml++3: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/libxml++3.rb:6: syntax error, unexpected ':', expecting keyword_end
  revision OS.mac? 1 : 2
```

Fixes https://github.com/Homebrew/brew/issues/6239