### PR TITLE
onedrive 2.3.5 (new formula)

### DIFF
--- a/Formula/onedrive.rb
+++ b/Formula/onedrive.rb
@@ -1,0 +1,23 @@
+class Onedrive < Formula
+  desc "Folder synchronization with OneDrive"
+  homepage "https://github.com/abraunegg/onedrive"
+  url "https://github.com/abraunegg/onedrive/archive/v2.3.5.tar.gz"
+  sha256 "db8426faeaa93168a300b46b5a3890b5b69937658f093c36d3d1eabb223afdb7"
+
+  depends_on "ldc" => :build
+  depends_on "pkg-config" => :build
+  depends_on "curl-openssl"
+  depends_on "sqlite"
+
+  def install
+    ENV["DC"] = "ldc2"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+    bash_completion.install "contrib/completions/complete.bash"
+    zsh_completion.install "contrib/completions/complete.zsh" => "_onedrive"
+  end
+
+  test do
+    system "#{bin}/onedrive", "--version"
+  end
+end


### PR DESCRIPTION
OneDrive is the cloud storage system of Microsoft. This formula provides
the command line client specialising in synchronizing with OneDrive cloud
storage.

Since onedrive use the inotify subsystem of the linux kernel, it cannot
be used on OSX.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
