### PR TITLE
gettext: fix for Linuxbrew

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -4,38 +4,20 @@ class Gettext < Formula
   url "https://ftp.gnu.org/gnu/gettext/gettext-0.20.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gettext/gettext-0.20.1.tar.xz"
   sha256 "53f02fbbec9e798b0faaf7c73272f83608e835c6288dd58be6c9bb54624a3800"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "fa2096f80238b8f4d9f3724d526626ab4db5c0586f3746ee13fc66e5a625aa1a" => :mojave
     sha256 "10dd5c2b9c6613b5310f95931d7233a8b7947c541433fcc5891ce837c45595a0" => :high_sierra
     sha256 "85c7bf74ba9b0209a08f2b87d69b54d03ec21985ad0bb7b9aeeda30c195529f8" => :sierra
-    sha256 "c1a033eb5b4c9221f8a00fea8d37ed13419966a4268037b20f7c81d94fef32f2" => :x86_64_linux
   end
 
   keg_only :shadowed_by_macos,
     "macOS provides the BSD gettext library & some software gets confused if both are in the library path"
 
-  unless OS.mac?
-    depends_on "ncurses"
-    depends_on "zlib" # for libxml2
-    # libxml2 is vendored here to break a cyclic dependency:
-    # python -> tcl-tk -> xorg -> libxpm -> gettext -> libxml2 -> python
-    resource("libxml2") do
-      url "http://xmlsoft.org/sources/libxml2-2.9.7.tar.gz"
-      mirror "ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz"
-      sha256 "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c"
-    end
-  end
+  depends_on "ncurses" unless OS.mac?
 
   def install
-    resource("libxml2").stage do
-      system "./configure", "--disable-dependency-tracking",
-                            "--prefix=#{libexec}",
-                            "--without-python",
-                            "--without-lzma"
-      system "make", "install"
-    end unless OS.mac?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--disable-debug",
@@ -52,7 +34,9 @@ class Gettext < Formula
                           "--without-git",
                           "--without-cvs",
                           "--without-xz",
-                          ("--with-libxml2-prefix=#{libexec}" unless OS.mac?),
+                          # Use vendored libxml2 to break a cyclic dependency:
+                          # python -> tcl-tk -> xorg -> libxpm -> gettext -> libxml2 -> python
+                          ("--with-included-libxml" unless OS.mac?),
                           ("--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}" if OS.mac?)
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Fix the following error:
format-kde-kuit.c:43:28: fatal error: libxml/parser.h: No such file or directory

`gettext` offers vendored libxml2. Use it instead of compiling libxml2 by our own.

Closes #13827.
