### PR TITLE
Switch unless OS.mac? dependencies to uses_from_macos

### DIFF
--- a/Formula/a2ps.rb
+++ b/Formula/a2ps.rb
@@ -21,7 +21,7 @@ class A2ps < Formula
     satisfy { HOMEBREW_PREFIX.to_s == desired_prefix }
   end
 
-  depends_on "gperf" unless OS.mac?
+  uses_from_macos "gperf"
 
   # Software was last updated in 2007.
   # https://svn.macports.org/ticket/20867

--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -17,8 +17,8 @@ class Advancecomp < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  depends_on "bzip2" unless OS.mac?
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/advancemenu.rb
+++ b/Formula/advancemenu.rb
@@ -14,7 +14,7 @@ class Advancemenu < Formula
   end
 
   depends_on "sdl"
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   conflicts_with "advancemame", :because => "both install `advmenu` binaries"
 

--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -36,7 +36,7 @@ class Agda < Formula
   depends_on "cabal-install" => [:build, :test]
   depends_on "emacs"
   depends_on "ghc"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     # install Agda core

--- a/Formula/aide.rb
+++ b/Formula/aide.rb
@@ -21,7 +21,7 @@ class Aide < Formula
   depends_on "libgcrypt"
   depends_on "libgpg-error"
   depends_on "pcre"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
   depends_on "bison" => :build unless OS.mac?
   depends_on "flex" => :build unless OS.mac?
 

--- a/Formula/algol68g.rb
+++ b/Formula/algol68g.rb
@@ -14,7 +14,7 @@ class Algol68g < Formula
     sha256 "e6df75baac2f1d858939d509465a0c04cc99b167f60d9790857038c74e2fb74b" => :x86_64_linux
   end
 
-  depends_on "postgresql" unless OS.mac?
+  uses_from_macos "postgresql"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/analog.rb
+++ b/Formula/analog.rb
@@ -20,7 +20,7 @@ class Analog < Formula
   depends_on "gd"
   depends_on "jpeg"
   depends_on "libpng"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     libs = "-lz"

--- a/Formula/apt-dater.rb
+++ b/Formula/apt-dater.rb
@@ -19,7 +19,7 @@ class AptDater < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "popt"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "autoreconf", "-ivf"

--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -21,7 +21,7 @@ class Arabica < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "boost"
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   def install
     system "autoreconf", "-fvi"

--- a/Formula/arping.rb
+++ b/Formula/arping.rb
@@ -17,7 +17,7 @@ class Arping < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libnet"
-  depends_on "libpcap" unless OS.mac?
+  uses_from_macos "libpcap"
 
   def install
     system "./bootstrap.sh"

--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -16,7 +16,7 @@ class Assimp < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Fix "unzip.c:150:11: error: unknown type name 'z_crc_t'"
   # Upstream PR from 12 Dec 2017 "unzip: fix build with older zlib"

--- a/Formula/atomicparsley.rb
+++ b/Formula/atomicparsley.rb
@@ -18,7 +18,7 @@ class Atomicparsley < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Fix Xcode 9 pointer warnings
   # https://bitbucket.org/wez/atomicparsley/issues/52/xcode-9-build-failure

--- a/Formula/augeas.rb
+++ b/Formula/augeas.rb
@@ -22,7 +22,7 @@ class Augeas < Formula
 
   depends_on "pkg-config" => :build
   depends_on "readline"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     args = %W[--disable-debug --disable-dependency-tracking --prefix=#{prefix}]

--- a/Formula/autogen.rb
+++ b/Formula/autogen.rb
@@ -16,7 +16,7 @@ class Autogen < Formula
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "guile"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     # Uses GNU-specific mktemp syntax: https://sourceforge.net/p/autogen/bugs/189/

--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -14,7 +14,7 @@ class Autojump < Formula
     sha256 "922ca87c1c1f1cb50bb7a8d68d06c0709ea5ed6e5aa71ecd5b72eb370fcc7449" => :x86_64_linux
   end
 
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     system "./install.py", "-d", prefix, "-z", zsh_completion

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -17,7 +17,7 @@ class Avfs < Formula
   depends_on "openssl"
   depends_on :osxfuse if OS.mac?
   depends_on "xz"
-  depends_on "libfuse" unless OS.mac?
+  uses_from_macos "libfuse"
 
   # Fix scripts to work on Mac OS X.
   # Nothing the patch fixes has been changed in 1.0.2, so still necessary.

--- a/Formula/avian.rb
+++ b/Formula/avian.rb
@@ -18,7 +18,7 @@ class Avian < Formula
   end
 
   depends_on :java => "1.8"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     if OS.mac?

--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -18,7 +18,7 @@ class AvroC < Formula
   depends_on "jansson"
   depends_on "snappy"
   depends_on "xz"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/aws-elasticbeanstalk.rb
+++ b/Formula/aws-elasticbeanstalk.rb
@@ -13,7 +13,7 @@ class AwsElasticbeanstalk < Formula
     sha256 "c51ecef2685f2fc9c50b1fa6b3e77fbaf54d81b126b416a9c68009797862fa96" => :x86_64_linux
   end
 
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   resource "backports.ssl_match_hostname" do
     url "https://files.pythonhosted.org/packages/76/21/2dc61178a2038a5cb35d14b61467c6ac632791ed05131dda72c20e7b9e23/backports.ssl_match_hostname-3.5.0.1.tar.gz"

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -19,7 +19,7 @@ class AwsSdkCpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
   depends_on CIRequirement
 
   def install

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -20,7 +20,7 @@ class Awscli < Formula
   # Sierra
   depends_on "python"
 
-  depends_on "libyaml" unless OS.mac?
+  uses_from_macos "libyaml"
 
   def install
     venv = virtualenv_create(libexec, "python3")

--- a/Formula/bamtools.rb
+++ b/Formula/bamtools.rb
@@ -15,7 +15,7 @@ class Bamtools < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     mkdir "build" do

--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -14,7 +14,7 @@ class Bat < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath

--- a/Formula/bazaar.rb
+++ b/Formula/bazaar.rb
@@ -22,7 +22,7 @@ class Bazaar < Formula
     apply "patches/27_fix_sec_ssh"
   end
 
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     ENV.deparallelize # Builds aren't parallel-safe

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -16,7 +16,7 @@ class Binutils < Formula
              "because Apple provides the same tools and binutils is poorly supported on macOS"
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/bison.rb
+++ b/Formula/bison.rb
@@ -14,7 +14,7 @@ class Bison < Formula
 
   keg_only :provided_by_macos, "some formulae require a newer version of bison"
 
-  depends_on "m4" unless OS.mac?
+  uses_from_macos "m4"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/blockhash.rb
+++ b/Formula/blockhash.rb
@@ -16,7 +16,7 @@ class Blockhash < Formula
 
   depends_on "pkg-config" => :build
   depends_on "imagemagick"
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   resource "testdata" do
     url "https://raw.githubusercontent.com/commonsmachinery/blockhash/ce08b465b658c4e886d49ec33361cee767f86db6/testdata/clipper_ship.jpg"

--- a/Formula/brogue.rb
+++ b/Formula/brogue.rb
@@ -15,7 +15,7 @@ class Brogue < Formula
     sha256 "9e01e39ea1e103323f0a090d5a82aae9fe100e85efb8d22cacc9d1f8b652cf37" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   # put the highscores file in HOMEBREW_PREFIX/var/brogue/ instead of a
   # version-dependent location.

--- a/Formula/burp.rb
+++ b/Formula/burp.rb
@@ -35,7 +35,7 @@ class Burp < Formula
   depends_on "pkg-config" => :build
   depends_on "librsync"
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     resource("uthash").stage do

--- a/Formula/bvi.rb
+++ b/Formula/bvi.rb
@@ -14,7 +14,7 @@ class Bvi < Formula
     sha256 "8259c8f5e2928b0ec8bae46c9390f082b5f02a6278ef907cbc74d7ce9babb228" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"

--- a/Formula/bwa.rb
+++ b/Formula/bwa.rb
@@ -13,7 +13,7 @@ class Bwa < Formula
     sha256 "543858a704eb3d584f464d78d092e92f015b36cb289e2e0949cba3494feccfcc" => :x86_64_linux
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "make"

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -14,7 +14,7 @@ class CabalInstall < Formula
   end
 
   depends_on "ghc"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     cd "cabal-install" if build.head?

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -22,7 +22,7 @@ class Ccache < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog" if build.head?

--- a/Formula/ccls.rb
+++ b/Formula/ccls.rb
@@ -17,7 +17,7 @@ class Ccls < Formula
   depends_on :macos => :high_sierra # C++ 17 is required
 
   # C++17 is required
-  depends_on "gcc@9" unless OS.mac?
+  uses_from_macos "gcc@9"
 
   fails_with :gcc => "4"
   fails_with :gcc => "5"

--- a/Formula/cdk.rb
+++ b/Formula/cdk.rb
@@ -14,7 +14,7 @@ class Cdk < Formula
     sha256 "ef6bbf2aa9ef13b15b14f3a8038ba769aef6ca45582800b970a6a01d89f1c4c2" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--with-ncurses"

--- a/Formula/check.rb
+++ b/Formula/check.rb
@@ -13,7 +13,7 @@ class Check < Formula
     sha256 "d34a6b9db7235c4e9233626201c99da1f2bd5c30aca4389a3ab1b813b81e936a" => :x86_64_linux
   end
 
-  depends_on "gawk" unless OS.mac?
+  uses_from_macos "gawk"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/chezscheme.rb
+++ b/Formula/chezscheme.rb
@@ -12,7 +12,7 @@ class Chezscheme < Formula
   end
 
   depends_on :x11 => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   # Fixes bashism in makefiles/installsh
   # Remove on next release

--- a/Formula/clib.rb
+++ b/Formula/clib.rb
@@ -15,7 +15,7 @@ class Clib < Formula
     sha256 "d44eea7bb3437fea93982839cb3f898b808b8307c9248bd51feb2a7649facc85" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     ENV["PREFIX"] = prefix

--- a/Formula/clucene.rb
+++ b/Formula/clucene.rb
@@ -18,7 +18,7 @@ class Clucene < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Portability fixes for 10.9+
   # Upstream ticket: https://sourceforge.net/p/clucene/bugs/219/

--- a/Formula/cnats.rb
+++ b/Formula/cnats.rb
@@ -16,7 +16,7 @@ class Cnats < Formula
   depends_on "libevent"
   depends_on "libuv"
   depends_on "openssl"
-  depends_on "protobuf-c" unless OS.mac?
+  uses_from_macos "protobuf-c"
 
   def install
     system "cmake", ".", "-DNATS_INSTALL_PREFIX=#{prefix}",

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -23,7 +23,7 @@ class Collectd < Formula
   depends_on "libtool"
   depends_on "net-snmp"
   depends_on "riemann-client"
-  depends_on "perl" unless OS.mac?
+  uses_from_macos "perl"
   depends_on "riemann-client"
 
   def install

--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -19,7 +19,7 @@ class Cryptol < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
   depends_on "z3"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     install_cabal_package :using => ["alex", "happy"]

--- a/Formula/cscope.rb
+++ b/Formula/cscope.rb
@@ -13,7 +13,7 @@ class Cscope < Formula
     sha256 "f2b2a031558cffb1e8fc759945cbefd3ac9702400fedeabef65dbec8e970ab11" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -29,7 +29,7 @@ class Curl < Formula
   keg_only :provided_by_macos
 
   depends_on "pkg-config" => :build
-  depends_on "openssl" unless OS.mac?
+  uses_from_macos "openssl"
 
   def install
     system "./buildconf" if build.head?

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -17,7 +17,7 @@ class Dcmtk < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "openssl"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     mkdir "build" do

--- a/Formula/deja-gnu.rb
+++ b/Formula/deja-gnu.rb
@@ -18,7 +18,7 @@ class DejaGnu < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "expect" unless OS.mac?
+  uses_from_macos "expect"
 
   def install
     ENV.deparallelize # Or fails on Mac Pro

--- a/Formula/dhex.rb
+++ b/Formula/dhex.rb
@@ -13,7 +13,7 @@ class Dhex < Formula
     sha256 "e9acf5875c20249ac61ecf9884713525aab0ae56d86f42155713f4151b1e72ff" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     inreplace "Makefile", "$(DESTDIR)/man", "$(DESTDIR)/share/man"

--- a/Formula/dialog.rb
+++ b/Formula/dialog.rb
@@ -13,7 +13,7 @@ class Dialog < Formula
     sha256 "99d0de68d49761bdf135cf073c8874f853681166b33548e20a292003fdbf3b48" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/diamond.rb
+++ b/Formula/diamond.rb
@@ -13,7 +13,7 @@ class Diamond < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -20,7 +20,7 @@ class DiffPdf < Formula
   depends_on "poppler"
   depends_on "wxmac"
   depends_on :x11 if OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -14,7 +14,7 @@ class Docbook < Formula
     sha256 "8898bf1783b50d7da4d63b966b82e0a51be1d16829be045287ba95fbdbb4da4b" => :x86_64_linux
   end
 
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   resource "xml412" do
     url "https://docbook.org/xml/4.1.2/docbkx412.zip"

--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -17,7 +17,7 @@ class Docbook2x < Formula
   end
 
   depends_on "docbook"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   def install
     inreplace "perl/db2x_xsltproc.pl", "http://docbook2x.sf.net/latest/xslt", "#{share}/docbook2X/xslt"

--- a/Formula/dub.rb
+++ b/Formula/dub.rb
@@ -16,7 +16,7 @@ class Dub < Formula
 
   depends_on "dmd" => :build
   depends_on "pkg-config"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     ENV["GITVER"] = version.to_s

--- a/Formula/duo_unix.rb
+++ b/Formula/duo_unix.rb
@@ -15,7 +15,7 @@ class DuoUnix < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "openssl"
-  depends_on "linuxbrew/extra/linux-pam" unless OS.mac?
+  uses_from_macos "linuxbrew/extra/linux-pam"
 
   def install
     system "./bootstrap"

--- a/Formula/dwarf.rb
+++ b/Formula/dwarf.rb
@@ -15,7 +15,7 @@ class Dwarf < Formula
 
   depends_on "flex"
   depends_on "readline"
-  depends_on "bison" unless OS.mac?
+  uses_from_macos "bison"
 
   def install
     %w[src/libdwarf.c doc/dwarf.man doc/xdwarf.man.html].each do |f|

--- a/Formula/ejdb.rb
+++ b/Formula/ejdb.rb
@@ -16,7 +16,7 @@ class Ejdb < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "bzip2" unless OS.mac?
+  uses_from_macos "bzip2"
 
   def install
     mkdir "build" do

--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -16,7 +16,7 @@ class Exa < Formula
 
   depends_on "cmake" => :build
   depends_on "rust" => :build
-  depends_on "libgit2" unless OS.mac?
+  uses_from_macos "libgit2"
 
   def install
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/exempi.rb
+++ b/Formula/exempi.rb
@@ -14,7 +14,7 @@ class Exempi < Formula
   end
 
   depends_on "boost"
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -22,7 +22,7 @@ class Expat < Formula
   keg_only :provided_by_macos
 
   # On Ubuntu 14, fix the error: You do not have support for any sources of high quality entropy
-  depends_on "libbsd" unless OS.mac?
+  uses_from_macos "libbsd"
 
   def install
     cd "expat" if build.head?

--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -19,7 +19,7 @@ class Expect < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "tcl-tk" unless OS.mac?
+  uses_from_macos "tcl-tk"
 
   def install
     args = %W[

--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -13,7 +13,7 @@ class Fail2ban < Formula
 
   depends_on "help2man" => :build
   depends_on "sphinx-doc" => :build
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"

--- a/Formula/fdclone.rb
+++ b/Formula/fdclone.rb
@@ -13,7 +13,7 @@ class Fdclone < Formula
   end
 
   depends_on "nkf" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/86107cf/fdclone/3.01b.patch"

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -21,7 +21,7 @@ class Fish < Formula
 
   depends_on "cmake" => :build
   depends_on "pcre2"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     # In Homebrew's 'superenv' sed's path will be incompatible, so

--- a/Formula/fits.rb
+++ b/Formula/fits.rb
@@ -15,7 +15,7 @@ class Fits < Formula
 
   depends_on "ant" => :build
   depends_on :java => "1.7+"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "ant", "clean-compile-jar", "-noinput"

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -28,7 +28,7 @@ class Folly < Formula
   depends_on "xz"
   depends_on "zstd"
 
-  depends_on "python" unless OS.mac?
+  uses_from_macos "python"
 
   # Known issue upstream. They're working on it:
   # https://github.com/facebook/folly/pull/445

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -26,7 +26,7 @@ class Fontforge < Formula
   depends_on "libtool"
   depends_on "libuninameslist"
   depends_on "pango"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     ENV["PYTHON_CFLAGS"] = `python3-config --cflags`.chomp

--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -15,7 +15,7 @@ class Fossil < Formula
   end
 
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     args = [

--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -14,7 +14,7 @@ class FreeradiusServer < Formula
 
   depends_on "openssl"
   depends_on "talloc"
-  depends_on "perl" unless OS.mac?
+  uses_from_macos "perl"
 
   def install
     ENV.deparallelize

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -42,7 +42,7 @@ class Freerdp < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on :x11 if OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -24,7 +24,7 @@ class Freetds < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "unixodbc"
-  depends_on "readline" unless OS.mac?
+  uses_from_macos "readline"
 
   def install
     args = %W[

--- a/Formula/ftgl.rb
+++ b/Formula/ftgl.rb
@@ -16,7 +16,7 @@ class Ftgl < Formula
   end
 
   depends_on "freetype"
-  depends_on "linuxbrew/xorg/glu" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/glu"
 
   def install
     # If doxygen is installed, the docs may still fail to build.

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -15,7 +15,7 @@ class Fzf < Formula
   end
 
   depends_on "go" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -50,7 +50,7 @@ class Gcc < Formula
   depends_on "isl" if OS.mac?
   depends_on "libmpc"
   depends_on "mpfr"
-  depends_on "isl@0.18" unless OS.mac?
+  uses_from_macos "isl@0.18"
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip

--- a/Formula/gconf.rb
+++ b/Formula/gconf.rb
@@ -22,7 +22,7 @@ class Gconf < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "orbit"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     # Needed by intltool (xml::parser)

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -21,7 +21,7 @@ class GdkPixbuf < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "shared-mime-info" unless OS.mac?
+  uses_from_macos "shared-mime-info"
 
   # gdk-pixbuf has an internal version number separate from the overall
   # version number that specifies the location of its module and cache

--- a/Formula/get_iplayer.rb
+++ b/Formula/get_iplayer.rb
@@ -15,7 +15,7 @@ class GetIplayer < Formula
   depends_on "atomicparsley"
   depends_on "ffmpeg"
   depends_on :macos => :yosemite if OS.mac?
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   resource "IO::Socket::IP" do
     url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/IO-Socket-IP-0.39.tar.gz"

--- a/Formula/ghi.rb
+++ b/Formula/ghi.rb
@@ -15,7 +15,7 @@ class Ghi < Formula
     sha256 "9a6ddc8d9c63ba0fe0d6417dae8cbf6b7f53fec7ded853799dcfa6579c1d8961" => :x86_64_linux
   end
 
-  depends_on "ruby" unless OS.mac?
+  uses_from_macos "ruby"
 
   resource "multi_json" do
     url "https://rubygems.org/gems/multi_json-1.12.1.gem"

--- a/Formula/gifsicle.rb
+++ b/Formula/gifsicle.rb
@@ -20,7 +20,7 @@ class Gifsicle < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   conflicts_with "giflossy",
     :because => "both install an `gifsicle` binary"

--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -16,7 +16,7 @@ class Ginac < Formula
   depends_on "pkg-config" => :build
   depends_on "cln"
   depends_on "readline"
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     # Reduce memory usage for CircleCI.

--- a/Formula/git-cinnabar.rb
+++ b/Formula/git-cinnabar.rb
@@ -14,7 +14,7 @@ class GitCinnabar < Formula
   end
 
   depends_on "mercurial"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   conflicts_with "git-remote-hg", :because => "both install `git-remote-hg` binaries"
 

--- a/Formula/git-ftp.rb
+++ b/Formula/git-ftp.rb
@@ -15,7 +15,7 @@ class GitFtp < Formula
 
   depends_on "pandoc" => :build
   depends_on "libssh2"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   resource "curl" do
     url "https://curl.haxx.se/download/curl-7.62.0.tar.bz2"

--- a/Formula/git-lfs.rb
+++ b/Formula/git-lfs.rb
@@ -14,7 +14,7 @@ class GitLfs < Formula
   end
 
   depends_on "go" => :build
-  depends_on "ruby" unless OS.mac?
+  uses_from_macos "ruby"
 
   # System Ruby uses old TLS versions no longer supported by RubyGems.
   depends_on "ruby" => :build if MacOS.version <= :sierra

--- a/Formula/gl2ps.rb
+++ b/Formula/gl2ps.rb
@@ -16,7 +16,7 @@ class Gl2ps < Formula
 
   depends_on "cmake" => :build
   depends_on "libpng"
-  depends_on "freeglut" unless OS.mac?
+  uses_from_macos "freeglut"
 
   def install
     # Prevent linking against X11's libglut.dylib when it's present

--- a/Formula/glib-networking.rb
+++ b/Formula/glib-networking.rb
@@ -19,7 +19,7 @@ class GlibNetworking < Formula
   depends_on "glib"
   depends_on "gnutls"
   depends_on "gsettings-desktop-schemas"
-  depends_on "libidn" unless OS.mac?
+  uses_from_macos "libidn"
 
   link_overwrite "lib/gio/modules"
 

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -19,7 +19,7 @@ class Glib < Formula
   depends_on "libffi"
   depends_on "pcre"
   depends_on "python"
-  depends_on "util-linux" unless OS.mac? # for libmount.so
+  uses_from_macos "util-linux" # for libmount.so
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=673135 Resolved as wontfix,
   # but needed to fix an assumption about the location of the d-bus machine

--- a/Formula/globus-toolkit.rb
+++ b/Formula/globus-toolkit.rb
@@ -16,7 +16,7 @@ class GlobusToolkit < Formula
   depends_on "pkg-config" => :build
   depends_on "libtool"
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     ENV.deparallelize

--- a/Formula/gnome-doc-utils.rb
+++ b/Formula/gnome-doc-utils.rb
@@ -20,7 +20,7 @@ class GnomeDocUtils < Formula
   depends_on "gettext"
   depends_on "libxml2"
   depends_on "python@2"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   def install
     # Needed by intltool (xml::parser)

--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -24,7 +24,7 @@ class Gnupg < Formula
   depends_on "libusb"
   depends_on "npth"
   depends_on "pinentry"
-  depends_on "libidn" unless OS.mac?
+  uses_from_macos "libidn"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -19,7 +19,7 @@ class Gnutls < Formula
   depends_on "nettle"
   depends_on "p11-kit"
   depends_on "unbound"
-  depends_on "autogen" unless OS.mac?
+  uses_from_macos "autogen"
 
   def install
     args = %W[

--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -30,7 +30,7 @@ class Goffice < Formula
   depends_on "librsvg"
   depends_on "pango"
   depends_on "pcre"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   def install
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]

--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -15,7 +15,7 @@ class Gromacs < Formula
   depends_on "fftw"
   depends_on "gsl"
   depends_on "gcc" # for OpenMP
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     # Non-executable GMXRC files should be installed in DATADIR

--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -22,7 +22,7 @@ class GtkDoc < Formula
   depends_on "libxml2"
   depends_on "python"
   depends_on "source-highlight"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   resource "Pygments" do
     url "https://files.pythonhosted.org/packages/1d/55/55cd82a72af652d71eb14f318e2d12d2fd14ded43d6fd105e50ed395198c/Pygments-2.4.0.tar.gz"

--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -30,7 +30,7 @@ class Guile < Formula
   depends_on "libunistring"
   depends_on "pkg-config" # guile-config is a wrapper around pkg-config.
   depends_on "readline"
-  depends_on "gperf" unless OS.mac?
+  uses_from_macos "gperf"
 
   def install
     system "./autogen.sh" unless build.stable?

--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -15,7 +15,7 @@ class H2o < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     # https://github.com/Homebrew/homebrew-core/pull/1046

--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -19,7 +19,7 @@ class HaskellStack < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Build using a stack config that matches the default Homebrew version of GHC
   resource "stack_lts_12_yaml" do

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -19,7 +19,7 @@ class Hdf5 < Formula
   depends_on "libtool" => :build
   depends_on "gcc" # for gfortran
   depends_on "szip"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     inreplace %w[c++/src/h5c++.in fortran/src/h5fc.in tools/src/misc/h5cc.in],

--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -17,7 +17,7 @@ class Hfstospell < Formula
   depends_on "icu4c"
   depends_on "libarchive"
   depends_on "libxml++"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   # Fix "error: no template named 'auto_ptr' in namespace 'std'"
   # Upstream PR 20 Jun 2018 "C++14 (C++1y) should be the highest supported standard."

--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -18,7 +18,7 @@ class Hledger < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   resource "hledger_web" do
     url "https://hackage.haskell.org/package/hledger-web-1.14.1/hledger-web-1.14.1.tar.gz"

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -18,7 +18,7 @@ class Httpd < Formula
   depends_on "nghttp2"
   depends_on "openssl"
   depends_on "pcre"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     # fixup prefix references in favour of opt_prefix references

--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -15,8 +15,8 @@ class Icecast < Formula
   depends_on "pkg-config" => :build
   depends_on "libvorbis"
   depends_on "openssl"
-  depends_on "curl" unless OS.mac?
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "curl"
+  uses_from_macos "libxslt"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -30,9 +30,9 @@ class Imagemagick < Formula
   depends_on "webp"
   depends_on "xz"
 
-  depends_on "bzip2" unless OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "bzip2"
+  uses_from_macos "linuxbrew/xorg/xorg"
+  uses_from_macos "libxml2"
 
   skip_clean :la
 

--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -19,7 +19,7 @@ class Imlib2 < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on :x11 if OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     args = %W[

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -18,7 +18,7 @@ class Io < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     ENV.deparallelize

--- a/Formula/ipbt.rb
+++ b/Formula/ipbt.rb
@@ -15,7 +15,7 @@ class Ipbt < Formula
     sha256 "afa03a7eb3907602141e1ac129aadaaf620ae0cf530ae90c56cb7821974e5be8" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -22,7 +22,7 @@ class Irssi < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "openssl"
-  depends_on "perl" unless OS.mac? || build.without?("perl") # for libperl.so
+  uses_from_macos "perl" || build.without?("perl") # for libperl.so
 
   def install
     ENV.delete "HOMEBREW_SDKROOT" if MacOS.version == :high_sierra

--- a/Formula/ispell.rb
+++ b/Formula/ispell.rb
@@ -15,7 +15,7 @@ class Ispell < Formula
     sha256 "c8bbcdc12d3e90e63949f6f284d8e8ebc2c723ed53251fe4619d600896345bfb" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     ENV.deparallelize

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -25,7 +25,7 @@ class Jack < Formula
   depends_on "berkeley-db"
   depends_on "libsamplerate"
   depends_on "libsndfile"
-  depends_on "util-linux" unless OS.mac? # for libuuid
+  uses_from_macos "util-linux" # for libuuid
 
   def install
     if OS.mac?

--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -27,7 +27,7 @@ class Knot < Formula
   depends_on :macos => :yosemite if OS.mac? # due to AT_REMOVEDIR
   depends_on "protobuf-c"
   depends_on "userspace-rcu"
-  depends_on "libedit" unless OS.mac?
+  uses_from_macos "libedit"
 
   def install
     system "autoreconf", "-fvi" if build.head?

--- a/Formula/konoha.rb
+++ b/Formula/konoha.rb
@@ -25,7 +25,7 @@ class Konoha < Formula
   depends_on "pcre"
   depends_on "python"
   depends_on "sqlite"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     mkdir "build" do

--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -15,7 +15,7 @@ class Krb5 < Formula
   keg_only :provided_by_macos
 
   depends_on "openssl"
-  depends_on "bison" unless OS.mac?
+  uses_from_macos "bison"
 
   def install
     cd "src" do

--- a/Formula/lame.rb
+++ b/Formula/lame.rb
@@ -13,7 +13,7 @@ class Lame < Formula
     sha256 "293b74a7490a120e88ad55b4b663e8596636a98dbd6b7f54f1222f0a3246d9d3" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     # Fix undefined symbol error _lame_init_old

--- a/Formula/ldns.rb
+++ b/Formula/ldns.rb
@@ -16,7 +16,7 @@ class Ldns < Formula
 
   depends_on "swig" => :build
   depends_on "openssl"
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     args = %W[

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -20,7 +20,7 @@ class Ledger < Formula
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "python@2"
-  depends_on "groff" unless OS.mac?
+  uses_from_macos "groff"
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.

--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -15,7 +15,7 @@ class Less < Formula
   end
 
   depends_on "pcre"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--with-regex=pcre"

--- a/Formula/lftp.rb
+++ b/Formula/lftp.rb
@@ -15,7 +15,7 @@ class Lftp < Formula
   depends_on "libidn"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libass.rb
+++ b/Formula/libass.rb
@@ -27,7 +27,7 @@ class Libass < Formula
   depends_on "freetype"
   depends_on "fribidi"
   depends_on "harfbuzz"
-  depends_on "fontconfig" unless OS.mac?
+  uses_from_macos "fontconfig"
 
   def install
     system "autoreconf", "-i" if build.head?

--- a/Formula/libbi.rb
+++ b/Formula/libbi.rb
@@ -18,7 +18,7 @@ class Libbi < Formula
   depends_on "gsl"
   depends_on "netcdf"
   depends_on "qrupdate"
-  depends_on "perl" unless OS.mac?
+  uses_from_macos "perl"
 
   resource "Test::Simple" do
     url "https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302133.tar.gz"

--- a/Formula/libbluray.rb
+++ b/Formula/libbluray.rb
@@ -26,7 +26,7 @@ class Libbluray < Formula
   depends_on "pkg-config" => :build
   depends_on "fontconfig"
   depends_on "freetype"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     if OS.mac?

--- a/Formula/libcroco.rb
+++ b/Formula/libcroco.rb
@@ -18,7 +18,7 @@ class Libcroco < Formula
   depends_on "glib"
 
   # Fix error: No package 'libxml-2.0' found
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libedit.rb
+++ b/Formula/libedit.rb
@@ -16,7 +16,7 @@ class Libedit < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -13,7 +13,7 @@ class Libgcrypt < Formula
   end
 
   depends_on "libgpg-error"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   def install
     # Temporary hack to get libgcrypt building on macOS 10.12 and 10.11 with XCode 8.

--- a/Formula/libgpm.rb
+++ b/Formula/libgpm.rb
@@ -16,7 +16,7 @@ class Libgpm < Formula
   depends_on "libtool" => :build
   depends_on "bison" => :build
   depends_on "texinfo" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   patch :DATA
   patch do

--- a/Formula/libgsf.rb
+++ b/Formula/libgsf.rb
@@ -24,7 +24,7 @@ class Libgsf < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     # Needed by intltool (xml::parser)

--- a/Formula/libgweather.rb
+++ b/Formula/libgweather.rb
@@ -19,7 +19,7 @@ class Libgweather < Formula
   depends_on "geocode-glib"
   depends_on "gtk+3"
   depends_on "libsoup"
-  depends_on "glibc" unless OS.mac? # for zoneinfo
+  uses_from_macos "glibc" # for zoneinfo
 
   def install
     # Needed by intltool (xml::parser)

--- a/Formula/libical.rb
+++ b/Formula/libical.rb
@@ -16,7 +16,7 @@ class Libical < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "icu4c"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "cmake", ".", "-DBDB_LIBRARY=BDB_LIBRARY-NOTFOUND",

--- a/Formula/libjson-rpc-cpp.rb
+++ b/Formula/libjson-rpc-cpp.rb
@@ -19,7 +19,7 @@ class LibjsonRpcCpp < Formula
   depends_on "hiredis"
   depends_on "jsoncpp"
   depends_on "libmicrohttpd"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/liblwgeom.rb
+++ b/Formula/liblwgeom.rb
@@ -26,7 +26,7 @@ class Liblwgeom < Formula
   depends_on "geos"
   depends_on "json-c"
   depends_on "proj"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     # See postgis.rb for comments about these settings

--- a/Formula/libmetalink.rb
+++ b/Formula/libmetalink.rb
@@ -16,7 +16,7 @@ class Libmetalink < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/liboping.rb
+++ b/Formula/liboping.rb
@@ -13,7 +13,7 @@ class Liboping < Formula
     sha256 "c85669755c8afdc54ec31e0ba30e49589c84cd0ed2ad2b0988e97135d5381fc1" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/libosmium.rb
+++ b/Formula/libosmium.rb
@@ -15,7 +15,7 @@ class Libosmium < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   resource "protozero" do
     url "https://github.com/mapbox/protozero/archive/v1.6.3.tar.gz"

--- a/Formula/libpng.rb
+++ b/Formula/libpng.rb
@@ -22,7 +22,7 @@ class Libpng < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libquvi.rb
+++ b/Formula/libquvi.rb
@@ -15,7 +15,7 @@ class Libquvi < Formula
 
   depends_on "pkg-config" => :build
   depends_on "lua@5.1"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   resource "scripts" do
     url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi-scripts/libquvi-scripts-0.4.14.tar.xz"

--- a/Formula/librdkafka.rb
+++ b/Formula/librdkafka.rb
@@ -19,7 +19,7 @@ class Librdkafka < Formula
   depends_on "lzlib"
   depends_on "openssl"
   depends_on "zstd"
-  depends_on "python" unless OS.mac?
+  uses_from_macos "python"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/libstrophe.rb
+++ b/Formula/libstrophe.rb
@@ -20,7 +20,7 @@ class Libstrophe < Formula
   depends_on "pkg-config" => :build
   depends_on "check"
   depends_on "openssl"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "./bootstrap.sh"

--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -20,7 +20,7 @@ class Libsvg < Formula
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libpng"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/libtecla.rb
+++ b/Formula/libtecla.rb
@@ -15,7 +15,7 @@ class Libtecla < Formula
     sha256 "d51094034ca406b255ddd2a44c9eeb078ace5502b5bb9b9421e8260a0beb1e10" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     ENV.deparallelize

--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -15,7 +15,7 @@ class Libtiff < Formula
   end
 
   depends_on "jpeg"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Patches are taken from latest Fedora package, which is currently
   # libtiff-4.0.10-2.fc30.src.rpm and whose changelog is available at

--- a/Formula/libwebsockets.rb
+++ b/Formula/libwebsockets.rb
@@ -16,7 +16,7 @@ class Libwebsockets < Formula
   depends_on "libevent"
   depends_on "libuv"
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "cmake", ".", *std_cmake_args,

--- a/Formula/libxlsxwriter.rb
+++ b/Formula/libxlsxwriter.rb
@@ -12,7 +12,7 @@ class Libxlsxwriter < Formula
     sha256 "212ed6216f90977a3cd0bb173a51f6061263db2a3391a3c3fcf0d09df80ed176" => :sierra
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "make", "install", "INSTALL_DIR=#{prefix}", "V=1"

--- a/Formula/libxml++.rb
+++ b/Formula/libxml++.rb
@@ -15,7 +15,7 @@ class Libxmlxx < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glibmm"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     ENV.cxx11

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -26,7 +26,7 @@ class Libxml2 < Formula
   keg_only :provided_by_macos
 
   depends_on "python"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Fix crash when using Python 3 using Fedora's patch.
   # Reported upstream:

--- a/Formula/links.rb
+++ b/Formula/links.rb
@@ -18,7 +18,7 @@ class Links < Formula
   depends_on "librsvg"
   depends_on "libtiff"
   depends_on "openssl"
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     args = %W[

--- a/Formula/lrzip.rb
+++ b/Formula/lrzip.rb
@@ -16,8 +16,8 @@ class Lrzip < Formula
 
   depends_on "pkg-config" => :build
   depends_on "lzo"
-  depends_on "zlib" unless OS.mac?
-  depends_on "bzip2" unless OS.mac?
+  uses_from_macos "zlib"
+  uses_from_macos "bzip2"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/lynx.rb
+++ b/Formula/lynx.rb
@@ -14,7 +14,7 @@ class Lynx < Formula
   end
 
   depends_on "openssl"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -25,7 +25,7 @@ class Mapserver < Formula
   depends_on "postgresql"
   depends_on "proj"
   depends_on "protobuf-c"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     # Harfbuzz support requires fribidi and fribidi support requires

--- a/Formula/mariadb-connector-c.rb
+++ b/Formula/mariadb-connector-c.rb
@@ -13,7 +13,7 @@ class MariadbConnectorC < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   conflicts_with "mysql", "mariadb", "percona-server",
                  :because => "both install plugins"

--- a/Formula/mdp.rb
+++ b/Formula/mdp.rb
@@ -13,7 +13,7 @@ class Mdp < Formula
     sha256 "506939f0a3c49d673c7644b25d734a1f63bb108775ba56cb7dcc2d711cfdeff1" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "make"

--- a/Formula/mediaconch.rb
+++ b/Formula/mediaconch.rb
@@ -18,8 +18,8 @@ class Mediaconch < Formula
   depends_on "jansson"
   depends_on "libevent"
   depends_on "sqlite"
-  depends_on "libxslt" unless OS.mac?
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "libxslt"
+  uses_from_macos "curl"
 
   def install
     cd "ZenLib/Project/GNU/Library" do

--- a/Formula/megatools.rb
+++ b/Formula/megatools.rb
@@ -18,7 +18,7 @@ class Megatools < Formula
   depends_on "glib"
   depends_on "glib-networking"
   depends_on "openssl"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/mighttpd2.rb
+++ b/Formula/mighttpd2.rb
@@ -17,7 +17,7 @@ class Mighttpd2 < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     install_cabal_package

--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -17,7 +17,7 @@ class Mikutter < Formula
   depends_on "libidn"
   depends_on "ruby"
   depends_on "terminal-notifier" if OS.mac?
-  depends_on "xz" unless OS.mac? # get liblzma compression algorithm library from XZutils
+  uses_from_macos "xz" # get liblzma compression algorithm library from XZutils
 
   resource "addressable" do
     url "https://rubygems.org/gems/addressable-2.6.0.gem"

--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -12,7 +12,7 @@ class MinimalRacket < Formula
     sha256 "64d0e61fff733d5ec69d0fb48aca0366cce9aab20975e3063ebf99779785c065" => :x86_64_linux
   end
 
-  depends_on "libffi" unless OS.mac?
+  uses_from_macos "libffi"
 
   # these two files are amended when (un)installing packages
   skip_clean "lib/racket/launchers.rktd", "lib/racket/mans.rktd"

--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -18,7 +18,7 @@ class Minizip < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/moe.rb
+++ b/Formula/moe.rb
@@ -14,7 +14,7 @@ class Moe < Formula
     sha256 "a0ce31f8dfb6c90856d76f0a8fd6e12e2f24762207cf3ee35fc926a94fa99fbe" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     # Fix compilation bug with Xcode 9

--- a/Formula/mongrel2.rb
+++ b/Formula/mongrel2.rb
@@ -26,7 +26,7 @@ class Mongrel2 < Formula
   end
 
   depends_on "zeromq"
-  depends_on "sqlite" unless OS.mac?
+  uses_from_macos "sqlite"
 
   def install
     # Build in serial. See:

--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -16,7 +16,7 @@ class Mosquitto < Formula
   depends_on "pkg-config" => :build
   depends_on "libwebsockets"
   depends_on "openssl"
-  depends_on "util-linux" unless OS.mac? # for libuuid
+  uses_from_macos "util-linux" # for libuuid
 
   def install
     system "cmake", ".", *std_cmake_args, "-DWITH_WEBSOCKETS=ON"

--- a/Formula/mruby.rb
+++ b/Formula/mruby.rb
@@ -16,7 +16,7 @@ class Mruby < Formula
   end
 
   depends_on "bison" => :build
-  depends_on "ruby" unless OS.mac?
+  uses_from_macos "ruby"
 
   def install
     system "make"

--- a/Formula/mujs.rb
+++ b/Formula/mujs.rb
@@ -15,7 +15,7 @@ class Mujs < Formula
     sha256 "26c5dfe0c6411a662b44fd08fcf0797d5b0edb202823fbdd28185965ec8fabc4" => :x86_64_linux
   end
 
-  depends_on "readline" unless OS.mac?
+  uses_from_macos "readline"
 
   def install
     system "make", "release"

--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -14,7 +14,7 @@ class Multitail < Formula
     sha256 "9e71d116effb1ae96a596b2f39a78e8b82a5678c7dceda901e2a61a6ab64838e" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "make", "-f", OS.mac? ? "makefile.macosx" : "Makefile", "multitail", "DESTDIR=#{HOMEBREW_PREFIX}"

--- a/Formula/myman.rb
+++ b/Formula/myman.rb
@@ -18,7 +18,7 @@ class Myman < Formula
   depends_on "coreutils" => :build
   depends_on "gnu-sed" => :build
   depends_on "groff" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     ENV["RMDIR"] = "grmdir"

--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -18,7 +18,7 @@ class MysqlClient < Formula
   depends_on "cmake" => :build
 
   depends_on "openssl"
-  depends_on "libedit" unless OS.mac?
+  uses_from_macos "libedit"
 
   def install
     # https://bugs.mysql.com/bug.php?id=87348

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -23,7 +23,7 @@ class Mysql < Formula
   depends_on "openssl"
 
   # Fix error: Cannot find system editline libraries.
-  depends_on "libedit" unless OS.mac?
+  uses_from_macos "libedit"
 
   conflicts_with "mysql-cluster", "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -14,7 +14,7 @@ class MysqlAT57 < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl"
-  depends_on "libedit" unless OS.mac?
+  uses_from_macos "libedit"
 
   def datadir
     var/"mysql"

--- a/Formula/nano.rb
+++ b/Formula/nano.rb
@@ -14,7 +14,7 @@ class Nano < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "ncurses"
-  depends_on "libmagic" unless OS.mac?
+  uses_from_macos "libmagic"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/ncdu.rb
+++ b/Formula/ncdu.rb
@@ -19,7 +19,7 @@ class Ncdu < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "autoreconf", "-i" if build.head?

--- a/Formula/ncview.rb
+++ b/Formula/ncview.rb
@@ -18,7 +18,7 @@ class Ncview < Formula
   depends_on "netcdf"
   depends_on "udunits"
   depends_on :x11 if OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     # Bypass compiler check (which fails due to netcdf's nc-config being

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -17,7 +17,7 @@ class Netcdf < Formula
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
   depends_on "hdf5"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   resource "cxx" do
     url "https://github.com/Unidata/netcdf-cxx4/archive/v4.3.0.tar.gz"

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -15,7 +15,7 @@ class Newt < Formula
   depends_on "gettext"
   depends_on "popt"
   depends_on "s-lang"
-  depends_on "python" unless OS.mac?
+  uses_from_macos "python"
 
   def install
     args = ["--prefix=#{prefix}", "--without-tcl"]

--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -28,7 +28,7 @@ class Nghttp2 < Formula
   depends_on "libev"
   depends_on "libevent"
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   unless OS.mac?
     patch do

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -15,7 +15,7 @@ class Ninja < Formula
     sha256 "8a6394bada3b77e13ec39d6ad097afdfece17e28e65a6b4e4f7cd06c9f3d4d29" => :x86_64_linux
   end
 
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     system "python", "configure.py", "--bootstrap"

--- a/Formula/nload.rb
+++ b/Formula/nload.rb
@@ -16,7 +16,7 @@ class Nload < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   # crash on F2 and garbage in adapter name, see https://sourceforge.net/p/nload/bugs/8/ reported on 2014-04-03
   patch :p0 do

--- a/Formula/nnn.rb
+++ b/Formula/nnn.rb
@@ -14,7 +14,7 @@ class Nnn < Formula
   end
 
   depends_on "readline"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/nvi.rb
+++ b/Formula/nvi.rb
@@ -16,7 +16,7 @@ class Nvi < Formula
 
   depends_on "xz" => :build # Homebrew bug. Shouldn't need declaring explicitly.
   depends_on "berkeley-db"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   # Patches per MacPorts
   # The first corrects usage of BDB flags.

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -53,7 +53,7 @@ class Octave < Formula
   depends_on "suite-sparse"
   depends_on "sundials"
   depends_on "texinfo"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   # Dependencies use Fortran, leading to spurious messages about GCC
   cxxstdlib_check :skip

--- a/Formula/opam.rb
+++ b/Formula/opam.rb
@@ -15,7 +15,7 @@ class Opam < Formula
   end
 
   depends_on "ocaml" => [:build, :test]
-  depends_on "unzip" unless OS.mac?
+  uses_from_macos "unzip"
 
   def install
     ENV.deparallelize

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -27,7 +27,7 @@ class Opencv < Formula
   depends_on "python"
   depends_on "python@2"
   depends_on "tbb"
-  depends_on "openblas" unless OS.mac?
+  uses_from_macos "openblas"
 
   resource "contrib" do
     url "https://github.com/opencv/opencv_contrib/archive/4.1.0.tar.gz"

--- a/Formula/openexr.rb
+++ b/Formula/openexr.rb
@@ -15,7 +15,7 @@ class Openexr < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ilmbase"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   resource "exr" do
     url "https://github.com/openexr/openexr-images/raw/master/TestImages/AllHalfValues.exr"

--- a/Formula/optipng.rb
+++ b/Formula/optipng.rb
@@ -14,7 +14,7 @@ class Optipng < Formula
     sha256 "583e39421ee8cba284602103d524f6d9c6abc46d5319415b54f4919b1819017f" => :x86_64_linux
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--with-system-zlib",

--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -17,7 +17,7 @@ class Osc < Formula
   depends_on "swig" => :build
   depends_on "openssl" # For M2Crypto
   depends_on "python@2"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   resource "pycurl" do
     url "https://files.pythonhosted.org/packages/12/3f/557356b60d8e59a1cce62ffc07ecc03e4f8a202c86adae34d895826281fb/pycurl-7.43.0.tar.gz"

--- a/Formula/osmium-tool.rb
+++ b/Formula/osmium-tool.rb
@@ -13,7 +13,7 @@ class OsmiumTool < Formula
   depends_on "cmake" => :build
   depends_on "libosmium" => :build
   depends_on "boost"
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.

--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -24,8 +24,8 @@ class Pcre < Formula
 
   option "without-check", "Skip build-time tests (not recommended)"
 
-  depends_on "bzip2" unless OS.mac?
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
     args = %W[

--- a/Formula/pianobar.rb
+++ b/Formula/pianobar.rb
@@ -22,7 +22,7 @@ class Pianobar < Formula
   depends_on "libao"
   depends_on "libgcrypt"
   depends_on "mad"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     # Discard Homebrew's CFLAGS as Pianobar reportedly doesn't like them

--- a/Formula/pigz.rb
+++ b/Formula/pigz.rb
@@ -13,7 +13,7 @@ class Pigz < Formula
     sha256 "447fa9c08dd2a52e68ece9408522cfdc6abd940467394de96b91bce20c2b2538" => :x86_64_linux
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     inreplace "Makefile", "-lm", "-lz -lm" unless OS.mac?

--- a/Formula/pinentry.rb
+++ b/Formula/pinentry.rb
@@ -18,7 +18,7 @@ class Pinentry < Formula
   depends_on "pkg-config" => :build
   depends_on "libassuan"
   depends_on "libgpg-error"
-  depends_on "libsecret" unless OS.mac?
+  uses_from_macos "libsecret"
 
   def install
     args = %W[

--- a/Formula/plotutils.rb
+++ b/Formula/plotutils.rb
@@ -20,7 +20,7 @@ class Plotutils < Formula
   end
 
   depends_on "libpng"
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     # Fix usage of libpng to be 1.5 compatible

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -27,7 +27,7 @@ class Poppler < Formula
   depends_on "nss"
   depends_on "openjpeg"
   depends_on "qt"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   conflicts_with "pdftohtml", "pdf2image", "xpdf",
     :because => "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"

--- a/Formula/pqiv.rb
+++ b/Formula/pqiv.rb
@@ -20,7 +20,7 @@ class Pqiv < Formula
   depends_on "libspectre"
   depends_on "poppler"
   depends_on "webp"
-  depends_on "libtiff" unless OS.mac?
+  uses_from_macos "libtiff"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -31,7 +31,7 @@ class Profanity < Formula
   depends_on "openssl"
   depends_on "readline"
   depends_on "terminal-notifier" if OS.mac?
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     system "./bootstrap.sh" if build.head?

--- a/Formula/quex.rb
+++ b/Formula/quex.rb
@@ -13,7 +13,7 @@ class Quex < Formula
     sha256 "2cdca8078eb1bb9f6fad0d155a1046af18c3987bb879cd60f4ed0d0883b70de0" => :x86_64_linux
   end
 
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     libexec.install "quex", "quex-exe.py"

--- a/Formula/ranger.rb
+++ b/Formula/ranger.rb
@@ -7,7 +7,7 @@ class Ranger < Formula
 
   bottle :unneeded
 
-  depends_on "python" unless OS.mac?
+  uses_from_macos "python"
 
   def install
     man1.install "doc/ranger.1"

--- a/Formula/raptor.rb
+++ b/Formula/raptor.rb
@@ -15,7 +15,7 @@ class Raptor < Formula
     sha256 "a04c8786feb2bc0715a9e3b1f1f306311840c1cae53a4251eb0dae25da22065e" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -21,7 +21,7 @@ class Readline < Formula
     defaulting this GNU Readline installation to keg-only
   EOS
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/recutils.rb
+++ b/Formula/recutils.rb
@@ -12,7 +12,7 @@ class Recutils < Formula
     sha256 "111ee4bf1d770f006189b126835f5b1767beccd98ac544303cb3a63017b5f0bb" => :x86_64_linux
   end
 
-  depends_on "libgcrypt" unless OS.mac?
+  uses_from_macos "libgcrypt"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/reminiscence.rb
+++ b/Formula/reminiscence.rb
@@ -21,7 +21,7 @@ class Reminiscence < Formula
   depends_on "libmodplug"
   depends_on "libogg"
   depends_on "sdl2"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   resource "tremor" do
     url "https://git.xiph.org/tremor.git",

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -16,7 +16,7 @@ class Rethinkdb < Formula
   depends_on "boost" => :build
 
   depends_on "openssl"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   # Fix error with Xcode 9, patch merged upstream:
   # https://github.com/rethinkdb/rethinkdb/pull/6450

--- a/Formula/roswell.rb
+++ b/Formula/roswell.rb
@@ -13,7 +13,7 @@ class Roswell < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     system "./bootstrap"

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -23,7 +23,7 @@ class Ruby < Formula
   depends_on "libyaml"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Should be updated only when Ruby is updated (if an update is available).
   # The exception is Rubygem security fixes, which mandate updating this

--- a/Formula/s-lang.rb
+++ b/Formula/s-lang.rb
@@ -16,7 +16,7 @@ class SLang < Formula
   end
 
   depends_on "libpng"
-  depends_on "pcre" unless OS.mac?
+  uses_from_macos "pcre"
 
   def install
     png = Formula["libpng"]

--- a/Formula/samtools.rb
+++ b/Formula/samtools.rb
@@ -14,7 +14,7 @@ class Samtools < Formula
   end
 
   depends_on "htslib"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -22,7 +22,7 @@ class SaneBackends < Formula
   depends_on "net-snmp"
   depends_on "openssl"
   depends_on "pkg-config" => :build
-  depends_on "libpng" unless OS.mac?
+  uses_from_macos "libpng"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/sbcl.rb
+++ b/Formula/sbcl.rb
@@ -11,7 +11,7 @@ class Sbcl < Formula
     sha256 "dbfa22857e864516eaff01c722269bf68222d5c57f6da2ccb4fa584eba868cbe" => :x86_64_linux
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Current binary versions are listed at https://sbcl.sourceforge.io/platform-table.html
   resource "bootstrap64" do

--- a/Formula/scons.rb
+++ b/Formula/scons.rb
@@ -12,7 +12,7 @@ class Scons < Formula
     sha256 "3816ec9020f451ebd64c81b186cafaaef60258a8363837f9e01b8018a46c531a" => :x86_64_linux
   end
 
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     unless OS.mac?

--- a/Formula/screen.rb
+++ b/Formula/screen.rb
@@ -36,7 +36,7 @@ class Screen < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     cd "src" if build.head?

--- a/Formula/scrollkeeper.rb
+++ b/Formula/scrollkeeper.rb
@@ -12,7 +12,7 @@ class Scrollkeeper < Formula
 
   depends_on "docbook"
   depends_on "gettext"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   conflicts_with "rarian",
     :because => "scrollkeeper and rarian install the same binaries."

--- a/Formula/seqtk.rb
+++ b/Formula/seqtk.rb
@@ -4,7 +4,7 @@ class Seqtk < Formula
   url "https://github.com/lh3/seqtk/archive/v1.3.tar.gz"
   sha256 "5a1687d65690f2f7fa3f998d47c3c5037e792f17ce119dab52fff3cfdca1e563"
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -26,7 +26,7 @@ class ShadowsocksLibev < Formula
   depends_on "libsodium"
   depends_on "mbedtls"
   depends_on "pcre"
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"

--- a/Formula/shared-mime-info.rb
+++ b/Formula/shared-mime-info.rb
@@ -24,7 +24,7 @@ class SharedMimeInfo < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     # Needed by intltool (xml::parser)

--- a/Formula/shmux.rb
+++ b/Formula/shmux.rb
@@ -13,7 +13,7 @@ class Shmux < Formula
     sha256 "b9f5655875e42cc02cdc82f49a3aa29d2b9b3af7f5eff7f8c9dd8ffbe14262ed" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/sickle.rb
+++ b/Formula/sickle.rb
@@ -13,7 +13,7 @@ class Sickle < Formula
     sha256 "844f7c565e7d2cce34318080b0fd4eeb25bcead46fb7ed5c673b54aebdc368c5" => :x86_64_linux
   end
 
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "make"

--- a/Formula/sl.rb
+++ b/Formula/sl.rb
@@ -16,7 +16,7 @@ class Sl < Formula
     sha256 "4496112f89e9706de41635e99f28775a8366b0e4daa7a9d46d2ba4f28a3b971c" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "make", "-e"

--- a/Formula/spigot.rb
+++ b/Formula/spigot.rb
@@ -14,7 +14,7 @@ class Spigot < Formula
     sha256 "fbdf5d1ebb41ea8cc4c346f04368bfb08356609673b41fd82a1f7923a056efcc" => :x86_64_linux
   end
 
-  depends_on "gmp" unless OS.mac?
+  uses_from_macos "gmp"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/splint.rb
+++ b/Formula/splint.rb
@@ -15,7 +15,7 @@ class Splint < Formula
     sha256 "cd1436875ca596ff9100db6dd03022815b1a534c13b457a5b695efef58a5a5cc" => :x86_64_linux
   end
 
-  depends_on "flex" unless OS.mac?
+  uses_from_macos "flex"
 
   # fix compiling error of osd.c
   patch :DATA

--- a/Formula/sqlite.rb
+++ b/Formula/sqlite.rb
@@ -18,7 +18,7 @@ class Sqlite < Formula
   keg_only :provided_by_macos, "macOS provides an older sqlite3"
 
   depends_on "readline"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     ENV.append "CPPFLAGS", "-DSQLITE_ENABLE_COLUMN_METADATA=1"

--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -16,7 +16,7 @@ class Squashfs < Formula
   depends_on "lz4"
   depends_on "lzo"
   depends_on "xz"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Patch necessary to emulate the sigtimedwait process otherwise we get build failures
   # Also clang fixes, extra endianness knowledge and a bundle of other macOS fixes.

--- a/Formula/stella.rb
+++ b/Formula/stella.rb
@@ -17,7 +17,7 @@ class Stella < Formula
   depends_on :xcode => :build if OS.mac?
   depends_on "sdl2"
   depends_on "libpng"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
   # Stella is using c++14
   fails_with :gcc => "4.8" unless OS.mac?
 

--- a/Formula/stoken.rb
+++ b/Formula/stoken.rb
@@ -15,7 +15,7 @@ class Stoken < Formula
 
   depends_on "pkg-config" => :build
   depends_on "nettle"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     args = %W[

--- a/Formula/sundials.rb
+++ b/Formula/sundials.rb
@@ -19,7 +19,7 @@ class Sundials < Formula
   depends_on "open-mpi"
   depends_on "openblas"
   depends_on "suite-sparse"
-  depends_on "python" unless OS.mac?
+  uses_from_macos "python"
 
   def install
     blas = "-L#{Formula["openblas"].opt_lib} -lopenblas"

--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -20,7 +20,7 @@ class Swift < Formula
   # https://github.com/apple/swift#system-requirements
   depends_on :xcode => ["10.0", :build] if OS.mac?
 
-  depends_on "icu4c" unless OS.mac?
+  uses_from_macos "icu4c"
 
   # This formula is expected to have broken/missing linkage to
   # both UIKit.framework and AssetsLibrary.framework. This is

--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -19,7 +19,7 @@ class Sysbench < Formula
   depends_on "pkg-config" => :build
   depends_on "mysql-client"
   depends_on "openssl"
-  depends_on "vim" unless OS.mac? # needed for xxd
+  uses_from_macos "vim" # needed for xxd
 
   def install
     system "./autogen.sh"

--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -18,7 +18,7 @@ class Tasksh < Formula
 
   depends_on "cmake" => :build
   depends_on "task"
-  depends_on "readline" unless OS.mac?
+  uses_from_macos "readline"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/tcsh.rb
+++ b/Formula/tcsh.rb
@@ -13,7 +13,7 @@ class Tcsh < Formula
     sha256 "0ad3df1f53e6b210f6ebd0f2d47cfd8dc71607ac8aa460c432150cfb25ba7572" => :x86_64_linux
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"

--- a/Formula/telegram-cli.rb
+++ b/Formula/telegram-cli.rb
@@ -21,7 +21,7 @@ class TelegramCli < Formula
   depends_on "libevent"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   # Look for the configuration file under /usr/local/etc rather than /etc on OS X.
   # Pull Request: https://github.com/vysheng/tg/pull/1306

--- a/Formula/texinfo.rb
+++ b/Formula/texinfo.rb
@@ -18,7 +18,7 @@ class Texinfo < Formula
     version of these files
   EOS
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/tinc.rb
+++ b/Formula/tinc.rb
@@ -13,7 +13,7 @@ class Tinc < Formula
 
   depends_on "lzo"
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}",

--- a/Formula/tldr.rb
+++ b/Formula/tldr.rb
@@ -17,7 +17,7 @@ class Tldr < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libzip"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   conflicts_with "tealdeer", :because => "both install `tldr` binaries"
 

--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -17,7 +17,7 @@ class Tor < Formula
   depends_on "libevent"
   depends_on "libscrypt"
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     args = %W[

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -14,7 +14,7 @@ class Travis < Formula
   end
 
   depends_on "ruby" if !OS.mac? || MacOS.version <= :sierra
-  depends_on "libffi" unless OS.mac?
+  uses_from_macos "libffi"
 
   resource "addressable" do
     url "https://rubygems.org/gems/addressable-2.4.0.gem"

--- a/Formula/ttyd.rb
+++ b/Formula/ttyd.rb
@@ -19,7 +19,7 @@ class Ttyd < Formula
   depends_on "json-c"
   depends_on "libwebsockets"
   depends_on "openssl"
-  depends_on "vim" unless OS.mac? # needed for xxd
+  uses_from_macos "vim" # needed for xxd
 
   def install
     cmake_args = std_cmake_args + ["-DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}"]

--- a/Formula/udunits.rb
+++ b/Formula/udunits.rb
@@ -13,7 +13,7 @@ class Udunits < Formula
     sha256 "7fabdc9fadd7cc82f75de69b1e31fb14b5d999d64394bce419b1f4a6341f8d63" => :x86_64_linux
   end
 
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -14,7 +14,7 @@ class Unbound < Formula
 
   depends_on "libevent"
   depends_on "openssl"
-  depends_on "expat" unless OS.mac?
+  uses_from_macos "expat"
 
   def install
     args = %W[

--- a/Formula/unixodbc.rb
+++ b/Formula/unixodbc.rb
@@ -16,7 +16,7 @@ class Unixodbc < Formula
 
   conflicts_with "virtuoso", :because => "Both install `isql` binaries."
 
-  depends_on "libtool" unless OS.mac?
+  uses_from_macos "libtool"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/unzip.rb
+++ b/Formula/unzip.rb
@@ -17,7 +17,7 @@ class Unzip < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "bzip2" unless OS.mac?
+  uses_from_macos "bzip2"
 
   # Upstream is unmaintained so we use the Debian patchset:
   # https://packages.debian.org/sid/unzip

--- a/Formula/upx.rb
+++ b/Formula/upx.rb
@@ -51,7 +51,7 @@ class Upx < Formula
   end
 
   depends_on "ucl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     (buildpath/"src/lzma-sdk").install resource("lzma-sdk") if build.stable?

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -18,7 +18,7 @@ class Vim < Formula
   depends_on "perl"
   depends_on "python"
   depends_on "ruby"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   conflicts_with "ex-vi",
     :because => "vim and ex-vi both install bin/ex and bin/view"

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -34,7 +34,7 @@ class Vips < Formula
   depends_on "pango"
   depends_on "poppler"
   depends_on "webp"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     args = %W[

--- a/Formula/volatility.rb
+++ b/Formula/volatility.rb
@@ -22,7 +22,7 @@ class Volatility < Formula
   depends_on "jpeg"
   depends_on "python@2" # does not support Python 3
   depends_on "yara"
-  depends_on "gmp" unless OS.mac? # for pycrypto
+  uses_from_macos "gmp" # for pycrypto
 
   resource "distorm3" do
     url "https://files.pythonhosted.org/packages/28/f9/8ff25a8f3edb581b5bc0efbed6382dcca22e5e7eff39464346c629105739/distorm3-3.3.4.zip"

--- a/Formula/vorbis-tools.rb
+++ b/Formula/vorbis-tools.rb
@@ -18,7 +18,7 @@ class VorbisTools < Formula
   depends_on "libao"
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     # Fix `brew linkage --test` "Missing libraries: /usr/lib/libnetwork.dylib"

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -14,7 +14,7 @@ class Wimlib < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     # fuse requires librt, unavailable on OSX

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -26,7 +26,7 @@ class Wine < Formula
   depends_on "pkg-config" => :build
   depends_on :macos => :el_capitan if OS.mac?
   # libusb depends on libudev
-  depends_on "systemd" unless OS.mac?
+  uses_from_macos "systemd"
 
   resource "mono" do
     url "https://dl.winehq.org/wine/wine-mono/4.7.5/wine-mono-4.7.5.msi"

--- a/Formula/wiredtiger.rb
+++ b/Formula/wiredtiger.rb
@@ -13,7 +13,7 @@ class Wiredtiger < Formula
   end
 
   depends_on "snappy"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--with-builtins=snappy,zlib",

--- a/Formula/xclip.rb
+++ b/Formula/xclip.rb
@@ -17,7 +17,7 @@ class Xclip < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on :x11 if OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/xdotool.rb
+++ b/Formula/xdotool.rb
@@ -18,7 +18,7 @@ class Xdotool < Formula
   depends_on "libxkbcommon"
 
   depends_on :x11 if OS.mac?
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  uses_from_macos "linuxbrew/xorg/xorg"
 
   def install
     # Work around an issue with Xcode 8 on El Capitan, which

--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -19,7 +19,7 @@ class XercesC < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "curl" unless OS.mac?
+  uses_from_macos "curl"
 
   def install
     ENV.cxx11

--- a/Formula/xmake.rb
+++ b/Formula/xmake.rb
@@ -12,7 +12,7 @@ class Xmake < Formula
     sha256 "d5159e8d6979900ac5865b3f4fa707d841af1ae5a5478cf460c4c3ca61c0f8c5" => :sierra
   end
 
-  depends_on "readline" unless OS.mac?
+  uses_from_macos "readline"
 
   def install
     system "./install", "output"

--- a/Formula/xml2.rb
+++ b/Formula/xml2.rb
@@ -16,7 +16,7 @@ class Xml2 < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/xmlstarlet.rb
+++ b/Formula/xmlstarlet.rb
@@ -15,7 +15,7 @@ class Xmlstarlet < Formula
     sha256 "88b419a7af11d19f44e0450b8f50ae1c56a75d4b04124ad612e2ea15db557f3f" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/xmlto.rb
+++ b/Formula/xmlto.rb
@@ -20,7 +20,7 @@ class Xmlto < Formula
   # Doesn't strictly depend on GNU getopt, but macOS system getopt(1)
   # does not support longopts in the optstring, so use GNU getopt.
   depends_on "gnu-getopt"
-  depends_on "libxslt" unless OS.mac?
+  uses_from_macos "libxslt"
 
   # xmlto forces --nonet on xsltproc, which causes it to fail when
   # DTDs/entities aren't available locally.

--- a/Formula/xrootd.rb
+++ b/Formula/xrootd.rb
@@ -16,7 +16,7 @@ class Xrootd < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl"
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     mkdir "build" do

--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -23,7 +23,7 @@ class Yaz < Formula
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
-  depends_on "libxml2" unless OS.mac?
+  uses_from_macos "libxml2"
 
   def install
     system "./buildconf.sh" if build.head?

--- a/Formula/ykpers.rb
+++ b/Formula/ykpers.rb
@@ -15,7 +15,7 @@ class Ykpers < Formula
   depends_on "pkg-config" => :build
   depends_on "json-c"
   depends_on "libyubikey"
-  depends_on "libusb" unless OS.mac?
+  uses_from_macos "libusb"
 
   def install
     backend = OS.mac? ? "osx" : "libusb-1.0"

--- a/Formula/yle-dl.rb
+++ b/Formula/yle-dl.rb
@@ -15,7 +15,7 @@ class YleDl < Formula
 
   depends_on "python"
   depends_on "rtmpdump"
-  depends_on "libxslt" unless OS.mac? # To be able to build the lxml resource
+  uses_from_macos "libxslt" # To be able to build the lxml resource
 
   resource "AdobeHDS.php" do
     # NOTE: yle-dl always installs the HEAD version of AdobeHDS.php. We use a specific commit.

--- a/Formula/zile.rb
+++ b/Formula/zile.rb
@@ -17,7 +17,7 @@ class Zile < Formula
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build
   depends_on "bdw-gc"
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/zork.rb
+++ b/Formula/zork.rb
@@ -14,7 +14,7 @@ class Zork < Formula
     sha256 "b4437e9cc54b1c8861dd43342e8726fc5a346d3ce1070aba8d72ec2eaf3deed3" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "ncurses" unless OS.mac?
+  uses_from_macos "ncurses"
 
   def install
     system "make", "DATADIR=#{share}", "BINDIR=#{bin}"

--- a/Formula/zpython.rb
+++ b/Formula/zpython.rb
@@ -35,7 +35,7 @@ class Zpython < Formula
   end
 
   depends_on "autoconf" => :build
-  depends_on "python@2" unless OS.mac?
+  uses_from_macos "python@2"
   depends_on "zsh"
 
   def install

--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -16,7 +16,7 @@ class ZshSyntaxHighlighting < Formula
     sha256 "c6c1f6dae42a0900820c22d538c12e6be6b81c0c690c8e73724121fa0ccb2d24" => :x86_64_linux
   end
 
-  depends_on "zsh" unless OS.mac?
+  uses_from_macos "zsh"
 
   def install
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -19,7 +19,7 @@ class Zsh < Formula
 
   depends_on "ncurses"
   depends_on "pcre"
-  depends_on "texinfo" unless OS.mac?
+  uses_from_macos "texinfo"
 
   resource "htmldoc" do
     url "https://downloads.sourceforge.net/project/zsh/zsh-doc/5.7.1/zsh-5.7.1-doc.tar.xz"

--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -14,7 +14,7 @@ class Zstd < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "zlib" unless OS.mac?
+  uses_from_macos "zlib"
 
   def install
     system "make", "install", "PREFIX=#{prefix}/"


### PR DESCRIPTION
This is a mass-fix changing all

```ruby
depends_on "something" unless OS.mac?
```

to

```ruby
uses_from_macos "something"
```