### PR TITLE
snapcraft: Fix build for Linux

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -20,6 +20,7 @@ class Snapcraft < Formula
   depends_on "python"
   depends_on "squashfs"
   depends_on "xdelta"
+  depends_on "libffi" unless OS.mac?
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/15/d4/2f888fc463d516ff7bf2379a4e9a552fef7f22a94147655d9b1097108248/certifi-2018.1.18.tar.gz"
@@ -177,6 +178,11 @@ class Snapcraft < Formula
   end
 
   def install
+    unless OS.mac?
+      libffi = Formula["libffi"]
+      ENV.prepend "CPPFLAGS", "-I#{libffi.lib}/libffi-#{libffi.version}/include"
+    end
+
     virtualenv_install_with_resources
   end
 

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -184,12 +184,12 @@ class Snapcraft < Formula
     end
 
     resource "distutils-extra" do
-      url "http://deb.debian.org/debian/pool/main/p/python-distutils-extra/python-distutils-extra_2.38.orig.tar.gz"
+      url "https://deb.debian.org/debian/pool/main/p/python-distutils-extra/python-distutils-extra_2.38.orig.tar.gz"
       sha256 "3d100d5d3492f40b3e7a6a4500f71290bfa91e2c50dc31ba8e3ff9b5d82ca153"
     end
 
     resource "python-apt" do
-      url "http://deb.debian.org/debian/pool/main/p/python-apt/python-apt_1.8.4.tar.xz"
+      url "https://deb.debian.org/debian/pool/main/p/python-apt/python-apt_1.8.4.tar.xz"
       sha256 "7831b3fd0093af5b76393f0d2610cb76c1d44e7aa438837779f9355a9174a220"
     end
   end

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -189,8 +189,8 @@ class Snapcraft < Formula
     end
 
     resource "python-apt" do
-      url "https://deb.debian.org/debian/pool/main/p/python-apt/python-apt_1.8.4.tar.xz"
-      sha256 "7831b3fd0093af5b76393f0d2610cb76c1d44e7aa438837779f9355a9174a220"
+      url "https://launchpad.net/ubuntu/+archive/primary/+files/python-apt_1.1.0~beta1build1.tar.xz"
+      sha256 "8d0a855299b8eb114476bdc7bef1b6fd6b35a4ee7ae90d4d56a2018977784148"
     end
   end
 

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -189,8 +189,8 @@ class Snapcraft < Formula
     end
 
     resource "python-apt" do
-      url "https://launchpad.net/ubuntu/+archive/primary/+files/python-apt_1.1.0~beta1build1.tar.xz"
-      sha256 "8d0a855299b8eb114476bdc7bef1b6fd6b35a4ee7ae90d4d56a2018977784148"
+      url "https://salsa.debian.org/apt-team/python-apt/-/archive/1.9.0/python-apt-1.9.0.tar.gz"
+      sha256 "6b0bdff48600266fcac1bebd57f04d6241dae32781396217612369421f5d0519"
     end
   end
 

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -177,6 +177,23 @@ class Snapcraft < Formula
     sha256 "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
   end
 
+  unless OS.mac?
+    resource "sphinx" do
+      url "https://files.pythonhosted.org/packages/89/1e/64c77163706556b647f99d67b42fced9d39ae6b1b86673965a2cd28037b5/Sphinx-2.1.2.tar.gz"
+      sha256 "f9a79e746b87921cabc3baa375199c6076d1270cee53915dbd24fdbeaaacc427"
+    end
+
+    resource "distutils-extra" do
+      url "http://deb.debian.org/debian/pool/main/p/python-distutils-extra/python-distutils-extra_2.38.orig.tar.gz"
+      sha256 "3d100d5d3492f40b3e7a6a4500f71290bfa91e2c50dc31ba8e3ff9b5d82ca153"
+    end
+
+    resource "python-apt" do
+      url "http://deb.debian.org/debian/pool/main/p/python-apt/python-apt_1.8.4.tar.xz"
+      sha256 "7831b3fd0093af5b76393f0d2610cb76c1d44e7aa438837779f9355a9174a220"
+    end
+  end
+
   def install
     unless OS.mac?
       libffi = Formula["libffi"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Fixes #14107.
- The `cffi` package was failing to install for snapcraft because we
  were missing a dependency and its location:
  ```
  ==> /home/linuxbrew/.linuxbrew/Cellar/snapcraft/3.3/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /tmp/snapcraft--cffi-20190705-15295-1gqcfqj/cffi-1.11.4
  Last 15 lines from /root/.cache/Homebrew/Logs/snapcraft/04.pip:
  Removed build tracker '/tmp/pip-req-tracker-6j1hbkub'
  ERROR: Command "/home/linuxbrew/.linuxbrew/Cellar/snapcraft/3.3/libexec/bin/python3.7 -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-req-build-yui2p5h7/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-v8780eqo/install-record.txt --single-version-externally-managed --compile --install-headers /home/linuxbrew/.linuxbrew/Cellar/snapcraft/3.3/libexec/include/site/python3.7/cffi" failed with error code 1 in /tmp/pip-req-build-yui2p5h7/
  ```