### PR TITLE
msmtp: Fix build for Linux

### DIFF
--- a/Formula/msmtp.rb
+++ b/Formula/msmtp.rb
@@ -5,7 +5,6 @@ class Msmtp < Formula
   sha256 "e5dd7fe95bc8e2f5eea3e4894ec9628252f30bd700a7fd1a568b10efa91129f7"
 
   bottle do
-    cellar :any
     sha256 "08f80b3e19167436903b1d1f4f967e57cfdd41aca8a335b0837d46c67aca9f86" => :mojave
     sha256 "47e8e6a151a310438507162258850a02cc7a86540ced579596484bfd3e4b2f63" => :high_sierra
     sha256 "9cbb35af98b6fa957726dc08baab05a4acf6c509416affda39718f10ae4b8576" => :sierra

--- a/Formula/msmtp.rb
+++ b/Formula/msmtp.rb
@@ -13,6 +13,7 @@ class Msmtp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gnutls"
+  uses_from_macos "libsecret"
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Fixes #13134.
- Gist logs from issue 13134: https://gist.github.com/CaptainQuirk/c7a1e0e8d51285ccb624766fda3f31d6
- This was failing to find the `libsecret` headers.
- Now use the new `uses_from_macos` syntax to specify dependencies to be
  installed on Linux.