### PR TITLE
Revert "Remove JDK formulae (jdk, jdk@8 and jdk@7)"

### DIFF
--- a/Aliases/jdk@9
+++ b/Aliases/jdk@9
@@ -1,0 +1,1 @@
+../Formula/jdk.rb

--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -1,0 +1,43 @@
+class Jdk < Formula
+  desc "Java Platform, Standard Edition Development Kit (JDK)"
+  homepage "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
+  # tag "linuxbrew"
+
+  version "9.0.4"
+  version_scheme 1
+  if OS.mac?
+    url "http://java.com/"
+  else
+    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-9.0.4_linux-x64_bin.tar.gz"
+    sha256 "90c4ea877e816e3440862cfa36341bc87d05373d53389ec0f2d54d4e8c95daa2"
+  end
+
+  bottle :unneeded
+
+  def install
+    odie "Use 'brew cask install java' on Mac OS" if OS.mac?
+    prefix.install Dir["*"]
+  end
+
+  def caveats; <<~EOS
+    By installing and using JDK you agree to the
+    Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
+    http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
+  end
+
+  test do
+    (testpath/"Hello.java").write <<~EOS
+      class Hello
+      {
+        public static void main(String[] args)
+        {
+          System.out.println("Hello Homebrew");
+        }
+      }
+    EOS
+    system bin/"javac", "Hello.java"
+    assert_predicate testpath/"Hello.class", :exist?, "Failed to compile Java program!"
+    assert_equal "Hello Homebrew\n", shell_output("#{bin}/java Hello")
+  end
+end

--- a/Formula/jdk@7.rb
+++ b/Formula/jdk@7.rb
@@ -1,0 +1,36 @@
+class JdkAT7 < Formula
+  desc "Java Platform, Standard Edition Development Kit (JDK)"
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"
+  # tag "linuxbrew"
+
+  version "1.7.0-80"
+  if OS.linux?
+    url "https://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz"
+    sha256 "bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623"
+  elsif OS.mac?
+    url "https://java.com/"
+  end
+
+  bottle :unneeded
+
+  keg_only :versioned_formula
+
+  def install
+    odie "Use 'brew cask install Caskroom/versions/java7' on Mac OS" if OS.mac?
+    prefix.install Dir["*"]
+    share.mkdir
+    share.install prefix/"man"
+  end
+
+  def caveats; <<~EOS
+    By installing and using JDK you agree to the
+      Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
+      http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
+  end
+
+  test do
+    system "#{bin}/java", "-version"
+    system "#{bin}/javac", "-version"
+  end
+end

--- a/Formula/jdk@8.rb
+++ b/Formula/jdk@8.rb
@@ -1,0 +1,49 @@
+class JdkAT8 < Formula
+  desc "Java Platform, Standard Edition Development Kit (JDK)"
+  homepage "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
+  # tag "linuxbrew"
+
+  version "1.8.0-181"
+  if OS.mac?
+    url "http://java.com/"
+  else
+    url "http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.tar.gz",
+      :cookies => {
+        "oraclelicense" => "accept-securebackup-cookie",
+      }
+    sha256 "1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"
+  end
+
+  bottle :unneeded
+
+  keg_only :versioned_formula
+
+  def install
+    odie "Use 'brew cask install java' on Mac OS" if OS.mac?
+    prefix.install Dir["*"]
+    share.mkdir
+    share.install prefix/"man"
+  end
+
+  def caveats; <<~EOS
+    By installing and using JDK you agree to the
+    Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
+    http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
+  end
+
+  test do
+    (testpath/"Hello.java").write <<~EOS
+      class Hello
+      {
+        public static void main(String[] args)
+        {
+          System.out.println("Hello Homebrew");
+        }
+      }
+    EOS
+    system bin/"javac", "Hello.java"
+    assert_predicate testpath/"Hello.class", :exist?, "Failed to compile Java program!"
+    assert_equal "Hello Homebrew\n", shell_output("#{bin}/java Hello")
+  end
+end


### PR DESCRIPTION
Reverts Homebrew/linuxbrew-core#14127

- Once this was merged, everything that `depends_on :java` (that I tested - `hbase`, `logstash`, to name a few) was failing with `UnsatisfiedRequirements: Unsatisfied requirements failed this build`. :scream:
- Looking at what `depends_on :java` does, it has a Linux-specific override for what Java _means_ in https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/os/linux/requirements/java_requirement.rb. I'll dig deeper, but in the meantime, revert this so it doesn't cause pain to users.