### PR TITLE
mongodb@3.6: remove duplicated xcode dependency

### DIFF
--- a/Formula/mongodb@3.6.rb
+++ b/Formula/mongodb@3.6.rb
@@ -20,7 +20,6 @@ class MongodbAT36 < Formula
   depends_on "pkg-config" => :build
   depends_on "scons" => :build
   depends_on :xcode => ["8.3.2", :build] if OS.mac?
-  depends_on :xcode => ["8.3.2", :build]
 
   depends_on "openssl"
   depends_on "python@2"


### PR DESCRIPTION
- [~] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- ~~[ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~~
- ~~[ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~~
- ~~[ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~~
- ~~[ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~~

-----

I didn’t try to install the formula, but got an error while running a simple `brew info mongodb@3.6` on Linux. Removing this duplicate fixes the issue.

https://gist.github.com/bfontaine/f761de616c039ac5e54b19626dc589b6