### PR TITLE
libsoup: set install_rpath for meson to keep rpath

### DIFF
--- a/Formula/libsoup.rb
+++ b/Formula/libsoup.rb
@@ -9,7 +9,6 @@ class Libsoup < Formula
     sha256 "8336aa92e8a2638745181f159f848b264bec952ecb5571eb36a3dbe62da3a016" => :mojave
     sha256 "f157867c692050ca95d78b048c01a1f1ada8a8c53c3a65e83397de2a3ae92af8" => :high_sierra
     sha256 "e8dbd05c6f0eeb707192192c6e1c370678ee63db12963dc1329e61e62b302398" => :sierra
-    sha256 "be44ad148ec154bb4ed4bd4aac08e166a931dc98d823647a60e62711d423b8dd" => :x86_64_linux
   end
 
   depends_on "gobject-introspection" => :build
@@ -34,20 +33,13 @@ class Libsoup < Formula
     end
 
     mkdir "build" do
-      system "meson", "--prefix=#{prefix}", ".."
+      if OS.mac?
+        system "meson", "--prefix=#{prefix}", ".."
+      else
+        system "meson", "--prefix=#{prefix}", "--libdir=#{lib}", ".."
+      end
       system "ninja", "-v"
       system "ninja", "install", "-v"
-    end
-
-    unless OS.mac?
-      # move lib64 to lib and symlink lib64 -> lib
-      lib64 = Pathname.new "#{lib}64"
-      if lib64.directory?
-        mkdir_p lib
-        system "mv #{lib64}/* #{lib}/"
-        rmdir lib64
-        prefix.install_symlink "lib" => "lib64"
-      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

Temporary solution for https://github.com/Homebrew/linuxbrew-core/issues/14202

-----