### PR TITLE
graphviz: add dependencies

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -5,14 +5,13 @@ class Graphviz < Formula
   url "https://www.mirrorservice.org/sites/distfiles.macports.org/graphviz/graphviz-2.40.1.tar.gz"
   mirror "https://fossies.org/linux/misc/graphviz-2.40.1.tar.gz"
   sha256 "ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421"
-  revision OS.mac? ? 1 : 2
+  revision OS.mac? ? 1 : 3
   version_scheme 1
 
   bottle do
     sha256 "c3e2b2f06d1a2190405ccb16cde3cbddb8bf0be080fb84448a0c43f473eef39f" => :mojave
     sha256 "2972d06c626e9a7d39c06d0376b1b425cae55d0e5d5a56d6f1440783d7e76890" => :high_sierra
     sha256 "3336446bf3ad335583744a88549b19a0bae2fd427270863476c2590a575ff021" => :sierra
-    sha256 "e63c1d9fbdf1319225657a5f4ec04d58ef7db8e334499956d91dad19947cbaf9" => :x86_64_linux
   end
 
   head do
@@ -28,6 +27,12 @@ class Graphviz < Formula
   depends_on "gts"
   depends_on "libpng"
   depends_on "libtool"
+  unless OS.mac?
+    depends_on "gtk+"
+    depends_on "librsvg"
+    depends_on "poppler"
+    depends_on "tcl-tk"
+  end
 
   def install
     # Only needed when using superenv, which causes qfrexp and qldexp to be


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

The default of options like pangocairo and tcl are yes/on now and it
seems most likely the users need to use these options anyway, which is
what the upstream expects obviously. I suggest specify these
dependencies explicitly so this formula can compile

-----