### PR TITLE
docker-compose: Fix build for Linux

### DIFF
--- a/Formula/docker-compose.rb
+++ b/Formula/docker-compose.rb
@@ -17,8 +17,11 @@ class DockerCompose < Formula
 
   depends_on "libyaml"
   depends_on "python"
+  uses_from_macos "libffi"
 
   def install
+    ENV.prepend "CPPFLAGS", "-I#{Formula["libffi"].lib}/libffi-#{Formula["libffi"].version}/include" unless OS.mac?
+
     system "./script/build/write-git-sha" if build.head?
     venv = virtualenv_create(libexec, "python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Fixes #14131.
- Error:
  ```
  gcc-5 -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/home/linuxbrew/.linuxbrew/opt/python/include/python3.7m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.7/c/_cffi_backend.o
  c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
  ```
- I've added the `libffi` dependency and specified its location.
- Gist logs: none, 'cause this was only reproducible in Docker for me,
  but see the error in issue 14131 or in the failed bottle PR 14028.