### PR TITLE
argon2: fix lib path for Linuxbrew

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -3,7 +3,7 @@ class Argon2 < Formula
   homepage "https://github.com/P-H-C/phc-winner-argon2"
   url "https://github.com/P-H-C/phc-winner-argon2/archive/20190702.tar.gz"
   sha256 "daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c"
-  revision 1
+  revision OS.mac? ? 1 : 2
   head "https://github.com/P-H-C/phc-winner-argon2.git"
 
   bottle do
@@ -11,13 +11,12 @@ class Argon2 < Formula
     sha256 "a76192a41826619fc399e7f6de5e6cb1c8a5fbe6bea4f2c1554daa830fa0e296" => :mojave
     sha256 "830016982e60870f50b3f6fc9a215d8cc4bda6061595f4883f7c11ab19ecba39" => :high_sierra
     sha256 "21889ac6ed40c792f1b372b5aa0d6b3be1be86577a4c1b06b08569124d2d0da2" => :sierra
-    sha256 "9611e026354c0c02b5aa5ba216a7d96b65d063e3bfcf6504a55a88fcb0a2bcdb" => :x86_64_linux
   end
 
   def install
-    system "make", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}"
+    system "make", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}", ("LIBRARY_REL=lib" unless OS.mac?)
     system "make", "test"
-    system "make", "install", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}"
+    system "make", "install", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}", ("LIBRARY_REL=lib" unless OS.mac?)
     doc.install "argon2-specs.pdf"
   end
 


### PR DESCRIPTION
else their makefile will put the .so files in lib/x86_64-linux-gnu

