### PR TITLE
azure pipelines: do not allow to fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,23 +37,19 @@ jobs:
       git checkout -b test
       git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
       git checkout pr
+    displayName: Setup taps and checkout
+  - bash: |
       cd /tmp/bottles
       sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
-    displayName: Run test-bot
-    continueOnError: true
+      cp *.bottle.* $(Build.ArtifactStagingDirectory)
+    displayName: Run test bot and copy json & bottle files
     env:
       HOMEBREW_DEVELOPER: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_VERBOSE: 1
       HOMEBREW_VERBOSE_USING_DOTS: 1
-  - bash: |
-      cd /tmp/bottles
-      cp *.bottle.* $(Build.ArtifactStagingDirectory)
-    displayName: Copy json & bottle files
-    continueOnError: true
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: bottle-linux
       targetPath: $(Build.ArtifactStagingDirectory)
     displayName: Publish bottle-linux
-    continueOnError: true


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
