### PR TITLE
Using test-bot --skip-recursive-dependents, build a bottle for bzip2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           brew install patchelf
           brew tap linuxbrew/extra
           brew tap linuxbrew/xorg
-          brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
+          brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old --skip-recursive-dependents
       - store_artifacts:
           path: /tmp/bottles
           destination: bottles

--- a/Formula/bzip2.rb
+++ b/Formula/bzip2.rb
@@ -1,3 +1,4 @@
+# Build a bottle for Linuxbrew
 class Bzip2 < Formula
   desc "Freely available high-quality data compressor"
   homepage "https://sourceware.org/bzip2/"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: Setup taps and checkout
   - bash: |
       cd /tmp/bottles
-      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
+      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old --skip-recursive-dependents
       cp *.bottle.* $(Build.ArtifactStagingDirectory)
     displayName: Run test bot and copy json & bottle files
     env:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

##### This sets `brew test-bot --skip-recursive-dependents` and these changes will go into master when this is merged. I'll do a revert PR when this is done for those two config changes. If anyone gets to this before me, please be aware!

- Let's see if this helps us not hit the 5h CircleCI timeout...