### PR TITLE
ykman: Fix build for Linux

### DIFF
--- a/Formula/ykman.rb
+++ b/Formula/ykman.rb
@@ -19,6 +19,11 @@ class Ykman < Formula
   depends_on "openssl"
   depends_on "python"
   depends_on "ykpers"
+  unless OS.mac?
+    depends_on "pkg-config" => :build
+    depends_on "libffi"
+    depends_on "pcsc-lite"
+  end
 
   resource "asn1crypto" do
     url "https://files.pythonhosted.org/packages/fc/f1/8db7daa71f414ddabfa056c4ef792e1461ff655c2ae2928a2b675bfed6b4/asn1crypto-0.24.0.tar.gz"
@@ -81,6 +86,13 @@ class Ykman < Formula
   end
 
   def install
+    unless OS.mac?
+      ENV.prepend "CPPFLAGS", "-I#{Formula["libffi"].lib}/libffi-#{Formula["libffi"].version}/include"
+
+      resource("pyscard").stage do
+        ENV.append "CFLAGS", "-I#{Formula["pcsc-lite"].opt_include}/PCSC"
+      end
+    end
     virtualenv_install_with_resources
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Gist logs: https://gist.github.com/issyl0/23027f65189be0a46d3033ca24ef6808
- The Linux build depends on pcsc-lite, according to the README.
- The Python packages themselves struggled to find libffi and pcsc-lite's `winscard.h` headers.