### PR TITLE
kubeseal: Fix v0.8.0 sha256 value

### DIFF
--- a/Formula/kubeseal.rb
+++ b/Formula/kubeseal.rb
@@ -2,7 +2,7 @@ class Kubeseal < Formula
   desc "Kubernetes controller and tool for one-way encrypted Secrets"
   homepage "https://github.com/bitnami-labs/sealed-secrets"
   url "https://github.com/bitnami-labs/sealed-secrets/archive/v0.8.0.tar.gz"
-  sha256 "7f66b393b152da7000707f87560bea2ecba68ba53fed642b31fc334cbec13a3b"
+  sha256 "177db4073f840ca05f52a910cb3a3ee7ed8f48c2f76bad6d8cb03e50574fdb21"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- This was failing on CI and local installs with a Checksum Mismatch
  error.
- It hasn't been fixed upstream in Homebrew/homebrew-core, because
  Homebrew/homebrew-core has already moved to 0.8.1. We've not caught up
  merging all the things yet.