### PR TITLE
glib: Build a bottle for Linuxbrew (`--skip-recursive-dependents`)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           brew install patchelf
           brew tap linuxbrew/extra
           brew tap linuxbrew/xorg
-          brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
+          brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old --skip-recursive-dependents
       - store_artifacts:
           path: /tmp/bottles
           destination: bottles

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -1,3 +1,4 @@
+# Build a bottle for Linuxbrew
 class Glib < Formula
   desc "Core application library for C"
   homepage "https://developer.gnome.org/glib/"
@@ -55,16 +56,16 @@ class Glib < Formula
               "giomoduledir=#{HOMEBREW_PREFIX}/lib/gio/modules",
               "giomoduledir=${libdir}/gio/modules"
 
-  # `pkg-config --libs glib-2.0` includes -lintl, and gettext itself does not
-  # have a pkgconfig file, so we add gettext lib and include paths here.
-  gettext = Formula["gettext"].opt_prefix
-  lintl = OS.mac? ? " -lintl": ""
-  inreplace lib+"pkgconfig/glib-2.0.pc" do |s|
-    s.gsub! "Libs:#{lintl} -L${libdir} -lglib-2.0",
-            "Libs: -L${libdir} -lglib-2.0 -L#{gettext}/lib#{lintl}"
-    s.gsub! "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
-            "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
-  end
+    # `pkg-config --libs glib-2.0` includes -lintl, and gettext itself does not
+    # have a pkgconfig file, so we add gettext lib and include paths here.
+    gettext = Formula["gettext"].opt_prefix
+    lintl = OS.mac? ? " -lintl": ""
+    inreplace lib+"pkgconfig/glib-2.0.pc" do |s|
+      s.gsub! "Libs:#{lintl} -L${libdir} -lglib-2.0",
+              "Libs: -L${libdir} -lglib-2.0 -L#{gettext}/lib#{lintl}"
+      s.gsub! "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
+              "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
+    end
   end
 
   def post_install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: Setup taps and checkout
   - bash: |
       cd /tmp/bottles
-      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
+      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old --skip-recursive-dependents
       cp *.bottle.* $(Build.ArtifactStagingDirectory)
     displayName: Run test bot and copy json & bottle files
     env:


### PR DESCRIPTION
- I chose to use `--skip-recursive-dependents` because it's a _big old_
  formula that a lot of other formulae depend on.
- Also fix the inconsistent indentation `brew style` error.