### PR TITLE
fakeroot: Fix build for Linux

### DIFF
--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -36,31 +36,33 @@ class Fakeroot < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
 
-    # Yosemite introduces an openat function, which has variadic arguments,
-    # which the "fancy" wrapping scheme used by fakeroot does not handle. So we
-    # have to patch the generated file after it is generated.
-    # Patch has been submitted with detailed explanation to
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766649
-    system "make", "wraptmpf.h"
-    (buildpath/"patch-for-wraptmpf-h").write <<~EOS
-      diff --git a/wraptmpf.h b/wraptmpf.h
-      index dbfccc9..0e04771 100644
-      --- a/wraptmpf.h
-      +++ b/wraptmpf.h
-      @@ -575,6 +575,10 @@ static __inline__ int next_mkdirat (int dir_fd, const char *pathname, mode_t mod
-       #endif /* HAVE_MKDIRAT */
-       #ifdef HAVE_OPENAT
-       extern int openat (int dir_fd, const char *pathname, int flags, ...);
-      +static __inline__ int next_openat (int dir_fd, const char *pathname, int flags, mode_t mode) __attribute__((always_inline));
-      +static __inline__ int next_openat (int dir_fd, const char *pathname, int flags, mode_t mode) {
-      +  return openat (dir_fd, pathname, flags, mode);
-      +}
+    if OS.mac?
+      # Yosemite introduces an openat function, which has variadic arguments,
+      # which the "fancy" wrapping scheme used by fakeroot does not handle. So we
+      # have to patch the generated file after it is generated.
+      # Patch has been submitted with detailed explanation to
+      # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766649
+      system "make", "wraptmpf.h"
+      (buildpath/"patch-for-wraptmpf-h").write <<~EOS
+        diff --git a/wraptmpf.h b/wraptmpf.h
+        index dbfccc9..0e04771 100644
+        --- a/wraptmpf.h
+        +++ b/wraptmpf.h
+        @@ -575,6 +575,10 @@ static __inline__ int next_mkdirat (int dir_fd, const char *pathname, mode_t mod
+         #endif /* HAVE_MKDIRAT */
+         #ifdef HAVE_OPENAT
+         extern int openat (int dir_fd, const char *pathname, int flags, ...);
+        +static __inline__ int next_openat (int dir_fd, const char *pathname, int flags, mode_t mode) __attribute__((always_inline));
+        +static __inline__ int next_openat (int dir_fd, const char *pathname, int flags, mode_t mode) {
+        +  return openat (dir_fd, pathname, flags, mode);
+        +}
 
-       #endif /* HAVE_OPENAT */
-       #ifdef HAVE_RENAMEAT
-    EOS
+         #endif /* HAVE_OPENAT */
+         #ifdef HAVE_RENAMEAT
+      EOS
 
-    system "patch < patch-for-wraptmpf-h"
+      system "patch < patch-for-wraptmpf-h"
+    end
 
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Fixes #14520.
- Error message:
  ```
  ==> ./configure --disable-static --disable-silent-rules --prefix=/home/linuxbrew/.linuxbrew/Cellar/fakeroot/1.23
  ==> make wraptmpf.h
  ==> patch < patch-for-wraptmpf-h
  Last 15 lines from /home/gusbemacbe/.cache/Homebrew/Logs/fakeroot/03.patch:
  2019-07-30 03:17:16 -0300

  patch < patch-for-wraptmpf-h

  patching file wraptmpf.h
  Hunk #1 FAILED at 575.
  1 out of 1 hunk FAILED -- saving rejects to file wraptmpf.h.rej
  ```
- The `wraptmpf.h` patch is only applicable to macOS.