### PR TITLE
Remove linuxbrew.bintray.com `root_url`s

### DIFF
--- a/Formula/abyss.rb
+++ b/Formula/abyss.rb
@@ -6,7 +6,6 @@ class Abyss < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "b3b0b70dd3911e0a94689f1ff4c0066a77f1698d6644e948a70b6cc073d2bcae" => :mojave
     sha256 "465013b8098487135b82083d9a73562d27dd856a1a9707d9a7946032e9828e02" => :high_sierra

--- a/Formula/activemq-cpp.rb
+++ b/Formula/activemq-cpp.rb
@@ -5,7 +5,6 @@ class ActivemqCpp < Formula
   sha256 "6bd794818ae5b5567dbdaeb30f0508cc7d03808a4b04e0d24695b2501ba70c15"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "ca87456dfeee8d1b999d883a01db5a657996f31973cc2b516bfc2d704136028a" => :mojave
     sha256 "8bd27f343a7669f51d84068727be531fd65b98bc9567b161aaf025c1884a1809" => :high_sierra

--- a/Formula/adwaita-icon-theme.rb
+++ b/Formula/adwaita-icon-theme.rb
@@ -5,7 +5,6 @@ class AdwaitaIconTheme < Formula
   sha256 "698db6e407bb987baec736c6a30216dfc0317e3ca2403c7adf3a5aa46c193286"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "40bdecea5ba2547c6e1b18c002c55cb36929927bb292a1a0a2b118c1c518492a" => :mojave
     sha256 "40bdecea5ba2547c6e1b18c002c55cb36929927bb292a1a0a2b118c1c518492a" => :high_sierra

--- a/Formula/aescrypt-packetizer.rb
+++ b/Formula/aescrypt-packetizer.rb
@@ -5,7 +5,6 @@ class AescryptPacketizer < Formula
   sha256 "5051394529bf3f99c42b57f755b2269e6abaae8b0e3fd90869c4b0bb58f5f1c7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "063038d7a6789ce5052fa1f7bf1be43ab9cd5c4157d5f9d1d37a91382b007958" => :mojave
     sha256 "ad36c0bff9d673c364b18795669f51329d8e7c5ea862af2ef3614051976cf601" => :high_sierra

--- a/Formula/afflib.rb
+++ b/Formula/afflib.rb
@@ -5,7 +5,6 @@ class Afflib < Formula
   sha256 "5481cd5d8dbacd39d0c531a68ae8afcca3160c808770d66dcbf5e9b5be3e8199"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "8777c09fb89f6ef70f6324fe9765a2dfc1c3d9a86fcd0b583d9c8f2465be61f1" => :mojave
     sha256 "09d2326ac0d816477129b38f85af29b8f2ab42448b76f603ec77bf8b64aebb24" => :high_sierra

--- a/Formula/afio.rb
+++ b/Formula/afio.rb
@@ -6,7 +6,6 @@ class Afio < Formula
   head "https://github.com/kholtman/afio.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "a0f6de009260949cb2199851b08f77fb82b99b92cd1c9e680cd557ed2515b42f" => :mojave
     sha256 "38f4da84d7056b33a6b7685f5206c32691ea673824faf3a971045feee8f52d93" => :high_sierra

--- a/Formula/agedu.rb
+++ b/Formula/agedu.rb
@@ -7,7 +7,6 @@ class Agedu < Formula
   head "https://git.tartarus.org/simon/agedu.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "5396979e91e666e508f42292185a535ce7c05e2ab58cc737bd71cfa8a8075098" => :mojave
     sha256 "a2870dd2c261fb6b0b2e8f4737e3e78766ee81bfd4d91f5d866382ce926150d7" => :high_sierra

--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -8,7 +8,6 @@ class Algernon < Formula
   head "https://github.com/xyproto/algernon.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "ac2fac7c0662d6864f2dc2e99fbae53041463a67b5e55bb3922deb487daf7382" => :mojave
     sha256 "db60d68e16302c740d2581fb113bbee08438ecf2706ce5cb91abc04b643d1ccc" => :high_sierra

--- a/Formula/ansifilter.rb
+++ b/Formula/ansifilter.rb
@@ -5,7 +5,6 @@ class Ansifilter < Formula
   sha256 "e2eee3912718b226d3217e2848e5c5a447bf30b7fbb9f0ebc8dd4ddfeb4797af"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "78a752145456f9be0bf7eb0639c0797ee61f262d3305c95ebd3efafd43568176" => :mojave
     sha256 "0038d6bc9d690591df08c050a63fac325174df8c6cb64264524199f4b0c000c5" => :high_sierra

--- a/Formula/apachetop.rb
+++ b/Formula/apachetop.rb
@@ -5,7 +5,6 @@ class Apachetop < Formula
   sha256 "1cbbfd1bf12275fb21e0cb6068b9050b2fee8c276887054a015bf103a1ae9cc6"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "90dcbabb24c87f8cc0571a0cf1e6e559019c3af7f9502f09c4a0f98b7dafa038" => :mojave
     sha256 "f11376a3c66e0c038d0bedb25e105414a27a26a766f1b138e2cd9fdac44e4e4f" => :high_sierra

--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -6,7 +6,6 @@ class AprUtil < Formula
   revision OS.mac? ? 1 : 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "e4927892e16a3c9cf0d037c1777a6e5728fef2f5abfbc0af3d0d444e9d6a1d2b" => :mojave
     sha256 "1bdf0cda4f0015318994a162971505f9807cb0589a4b0cbc7828531e19b6f739" => :high_sierra
     sha256 "75c244c3a34abab343f0db7652aeb2c2ba472e7ad91f13af5524d17bba3001f2" => :sierra

--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -5,7 +5,6 @@ class Apr < Formula
   sha256 "e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "3a245185ed7280d1a19e7c639786b4c21dd0088878be8ac87ca58510eb5c9cc1" => :mojave
     sha256 "4d01f24009ea389e2c8771c5c0bc069ae09c0f5812d7fdb0d0079106c3fc0838" => :high_sierra

--- a/Formula/arpack.rb
+++ b/Formula/arpack.rb
@@ -7,7 +7,6 @@ class Arpack < Formula
   head "https://github.com/opencollab/arpack-ng.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "bbeb3eecad1a628a980cad61c9da6553696e53ccc9e9d18e42b933b3e0db1053" => :mojave
     sha256 "428918b64b9519135f9ed5800ee849e0c5ed45aaabfbe12d7db49d31fb25725a" => :high_sierra

--- a/Formula/asio.rb
+++ b/Formula/asio.rb
@@ -6,7 +6,6 @@ class Asio < Formula
   head "https://github.com/chriskohlhoff/asio.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "dafc1e63f716ff0117f0676c711e8946b7044e09847014fb8bec168ca04ec32f" => :mojave
     sha256 "ef5f33e16009ed897a3e70190312830be84df11c59ce3c45c2e1542f3054877d" => :high_sierra

--- a/Formula/aurora.rb
+++ b/Formula/aurora.rb
@@ -5,7 +5,6 @@ class Aurora < Formula
   sha256 "90ac08b7c960aa24ee0c8e60759e398ef205f5b48c2293dd81d9c2f17b24ca42"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     rebuild 1
     sha256 "3d0f318def46f1bed3f7e16af66c2d1eddb6fdb305dd68d797d3c6cdbf99c13f" => :mojave

--- a/Formula/autoconf-archive.rb
+++ b/Formula/autoconf-archive.rb
@@ -6,7 +6,6 @@ class AutoconfArchive < Formula
   sha256 "17195c833098da79de5778ee90948f4c5d90ed1a0cf8391b4ab348e2ec511e3f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "37d5baf229236e25cc249934f6e052f3c99fe2b2c0fbf799c35e3b46ae861520" => :mojave
     sha256 "37d5baf229236e25cc249934f6e052f3c99fe2b2c0fbf799c35e3b46ae861520" => :high_sierra

--- a/Formula/autogen.rb
+++ b/Formula/autogen.rb
@@ -6,7 +6,6 @@ class Autogen < Formula
   sha256 "f8a13466b48faa3ba99fe17a069e71c9ab006d9b1cfabe699f8c60a47d5bb49a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "693b555483cf3f1e67516e45b31ad7718f041c97349ef655e28d55b1918b4e3f" => :mojave
     sha256 "7b79a5aa968c4d95660efb7a30bfb2c747dde2eefb1cf95efdc9fea7847b9151" => :high_sierra
     sha256 "19891a89ee7465e2690d34494e2ee41afee0dfda661a0c1c7407d283438e911e" => :sierra

--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -6,7 +6,6 @@ class Autojump < Formula
   head "https://github.com/wting/autojump.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "5576b3f2b9fcb2a236d6ac22b163af03994edb98b69c997ed5a88db85c8d0a15" => :mojave
     sha256 "5576b3f2b9fcb2a236d6ac22b163af03994edb98b69c997ed5a88db85c8d0a15" => :high_sierra

--- a/Formula/autopep8.rb
+++ b/Formula/autopep8.rb
@@ -7,7 +7,6 @@ class Autopep8 < Formula
   sha256 "4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "f20261fb78a887b3c30a55ae517547b5d6d9c8a1d82a7bbfa04613db0649be16" => :mojave
     sha256 "1bcfa4d6f774c8c945c8519985138a94b639937bc8f2efe12eb397f8a2bbf5df" => :high_sierra

--- a/Formula/autossh.rb
+++ b/Formula/autossh.rb
@@ -6,7 +6,6 @@ class Autossh < Formula
   sha256 "5fc3cee3361ca1615af862364c480593171d0c54ec156de79fc421e31ae21277"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "2674ee43690b5d99490a0979359fdefa52033650b935547a6353de726f916275" => :mojave
     sha256 "f88fcb32499fff8aa2899c85fc39dc6678ebed2849791a4312d427d9073b6b98" => :high_sierra

--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -5,7 +5,6 @@ class AvroC < Formula
   sha256 "80568644384828b7f926efe76965907c8fff0c49e02301bfe8b2cb7965fa08b2"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "72fbe9c22be502351d5dcffcb37a97c754f3bb3057742bf31b185b0a0f1d5eb4" => :mojave
     sha256 "6a8b708a052cd04ffb7135b4d69b0f6b6a60ac83dc071622dfaf241f26998c79" => :high_sierra

--- a/Formula/aws-iam-authenticator.rb
+++ b/Formula/aws-iam-authenticator.rb
@@ -5,7 +5,6 @@ class AwsIamAuthenticator < Formula
   sha256 "d077ce973e5917fab7cbad46bc2d19264e8d0ae23321afd97b1bc481075a31fa"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "524c545b1b500aa81a578371f59c487a31f6b20463731051cc5f3e30551b8b63" => :mojave
     sha256 "7c773fefb0506db8b95ed918ff639ede96b58a4d0d2a51d2faf941f30a61ad84" => :high_sierra

--- a/Formula/backupninja.rb
+++ b/Formula/backupninja.rb
@@ -6,7 +6,6 @@ class Backupninja < Formula
   sha256 "abe444d0c7520ede7847b9497da4b1253a49579f59293b043c47b1dd9833280a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "39df0693351a58ac9f406d6c16ab9c15ddb5d96ddf7ac9e98cf94061ccffe9a8" => :mojave
     sha256 "39df0693351a58ac9f406d6c16ab9c15ddb5d96ddf7ac9e98cf94061ccffe9a8" => :high_sierra

--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -34,7 +34,6 @@ class Bash < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "07f1f20a0fd6a8b06cd66d9aa6bd26d4d5afe5bd79b5354b081493bb9ee28943" => :mojave
     sha256 "bf87f6875d02d049f651da3c31c2b5db66bb8324ce28641f18e0768112de72ac" => :high_sierra
     sha256 "68ca9e0ac8c1dfe45c4f9e9ff25fa44080b827f4634a7ff5cc5fc6e65a302d62" => :sierra

--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -5,7 +5,6 @@ class BdwGc < Formula
   sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "05219d7d030791e3c3e3751b36a603a710cce86dc63c97cc64ea6743b8828406" => :mojave
     sha256 "280e51afa899236777022c30b756fb4b87e034b9e23a5526c183fe3d0e24731c" => :high_sierra

--- a/Formula/bedtools.rb
+++ b/Formula/bedtools.rb
@@ -5,7 +5,6 @@ class Bedtools < Formula
   sha256 "0f3e5990b5713388531de699d43d195f1535a5772d832acfd47baa151a3a7e59"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "6c9819a00f8d56e97500c0eef57a3363fd18c4439ce18ac66c5b0d6638b1bd88" => :mojave
     sha256 "e1a7e656b89c764f9331a1924ef4b6113769051a260fb76c2a1eee8b4a39cf84" => :high_sierra

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -7,7 +7,6 @@ class BerkeleyDb < Formula
   sha256 "fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "bda67250f858b348c8e537ff22b63f69b561eadbb7c04153a87b291eab7eb617" => :mojave
     sha256 "0904c59965847bc4d02ac3bea47898a50cb7020f95cc22f58981ccd583b40419" => :high_sierra

--- a/Formula/bibtexconv.rb
+++ b/Formula/bibtexconv.rb
@@ -6,7 +6,6 @@ class Bibtexconv < Formula
   head "https://github.com/dreibh/bibtexconv.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "6f6011d0f4881805977ee882cdead5e69222b3a8d119d27ef9b3895f8e63b288" => :mojave
     sha256 "96eda092763e70b1af132b834a5f8bb9c9f12ad6f2f0802e3c09d18ebf2f6115" => :high_sierra

--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -6,7 +6,6 @@ class Blast < Formula
   sha256 "a390cc2d7a09422759fc178db84de9def822cbe485916bbb2ec0d215dacdc257"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "e07f0dafa79bd72359cf467ba8cf8e51d76665c1571128dc7cc5d7857c5b92d8" => :mojave
     sha256 "3de6646d96d9fdbf6b76fdf57a14612c8eebbfa1327f0d42e0402b516b6298ec" => :high_sierra
     sha256 "57f2e2f9c65aa5364eb72a9bbdf6948a30af2975a53445a4b43203f56395da7c" => :sierra

--- a/Formula/burp.rb
+++ b/Formula/burp.rb
@@ -13,7 +13,6 @@ class Burp < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "3db87f3ffbd42fbf4cd122393abb5e8d0971c92f164dd5276e865d4b1de25be6" => :mojave
     sha256 "599ab71a1111c212dd7a840c0efe212ee11f01dad2537a21c1636d9c24ac5ea4" => :high_sierra
     sha256 "0ed8e8db9c0358582be4e8a28476057dc18325b0d868c4554c3200ce9a6844cd" => :sierra

--- a/Formula/bwfmetaedit.rb
+++ b/Formula/bwfmetaedit.rb
@@ -6,7 +6,6 @@ class Bwfmetaedit < Formula
   sha256 "58bab975d5cd5860246acad7260b07404f9cb453fc2f4acdd35ab4f5cf1d0d5b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "84b882f74d83bb3e15132b2b702f8264ac865f043136c5b69a11a07fa9ce13be" => :mojave
     sha256 "0201e1bf51774f427210f28d27235c45e472571f76d3c82f840dc5c41cf47dd5" => :high_sierra

--- a/Formula/cabextract.rb
+++ b/Formula/cabextract.rb
@@ -5,7 +5,6 @@ class Cabextract < Formula
   sha256 "afc253673c8ef316b4d5c29cc4aa8445844bee14afffbe092ee9469405851ca7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "cd27b939a0191d4dfff8ae13300b260b5ae01c563a21613718160012a982d5e8" => :mojave
     sha256 "c77caa7c32b4320f9e887abeea99261345e83f03e2c321ec9e99ddd9c75f5d98" => :high_sierra

--- a/Formula/camlp4.rb
+++ b/Formula/camlp4.rb
@@ -8,7 +8,6 @@ class Camlp4 < Formula
   head "https://github.com/ocaml/camlp4.git", :branch => "trunk"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "4052c0b687d48ea6aebcdd44159d2a3ef187e70776727b53071bea13d144aec5" => :mojave
     sha256 "2916c776974e59cd6b8813208f538736456dc6c59fdced7eb360fba1a3bb23af" => :high_sierra

--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -5,7 +5,6 @@ class Cassandra < Formula
   sha256 "5d598e23c3ffc4db0301ec2b313061e3208fae0f9763d4b47888237dd9069987"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "d3095afa053d64cb3c7f02e193df760029c0b475c7b9de2fab1531370d30ae94" => :mojave
     sha256 "b85177946477a400d6bbfa2cf0cae6536542657055167a833b2752657044378a" => :high_sierra

--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -5,7 +5,6 @@ class CassandraAT21 < Formula
   sha256 "992080ce42bb90173b1a910edffadc7f917b5a6e598db5154ff32ae8e2d00ad3"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "47ca86c5d1cf581e53f47e51d7ca79c42b65dec999f66776c64278603f6e3def" => :mojave
     sha256 "8c6e02cd3c1310eed4e3263df8a17ee9260482f2e5cae6ce2a440ea7a5252fdd" => :high_sierra

--- a/Formula/cassandra@2.2.rb
+++ b/Formula/cassandra@2.2.rb
@@ -5,7 +5,6 @@ class CassandraAT22 < Formula
   sha256 "38b5a1785cb2957147cb4d8852b819160485dac91c417dc0c38440a6021e5dac"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "cf3ba2451f3a9c9bee6131234e1e4305d2e5394dc672cf851df5f3689594ef90" => :mojave
     sha256 "aa2080584701f1a204bd1fcb51579a351d009f20fb5c29bbb22ad57f53e3a538" => :high_sierra

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -6,7 +6,6 @@ class Castxml < Formula
   head "https://github.com/CastXML/castxml.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "3a87a080247a21ab0f05db2dafb826664bb88426563507bb6a00d9c465d41e62" => :mojave
     sha256 "295056ef0feae25c6f00c1e7e669f7f017bc3242c4cbdb0d6c95b34568b31655" => :high_sierra

--- a/Formula/cdk.rb
+++ b/Formula/cdk.rb
@@ -6,7 +6,6 @@ class Cdk < Formula
   sha256 "adad7870988d44b95df57722ab8dffc587d035183eb6b12a9500ebed4d8dba25"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c786783f05f2aa98019d5142c7c8a019cf9caee471fa41aa7ba360d0b8cb6b6e" => :mojave
     sha256 "706723393e31a2969cb8686726426e72eaee75e848d60082c67da7daa1929ac5" => :high_sierra

--- a/Formula/chapel.rb
+++ b/Formula/chapel.rb
@@ -5,7 +5,6 @@ class Chapel < Formula
   sha256 "c2b68a20d87cc382c2f73dd1ecc6a4f42fb2f590b0b10fbc577382dd35c9e9bd"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "566175e438251b20ede1a382c3bf9adf6190a0795ddadbd424fa0e359ef587f8" => :mojave
     sha256 "20ae69dac7474ca917e4753b6c9e7ce1761c4b054f950abfad99fce05332fd52" => :high_sierra
     sha256 "f61ca08127d16681f68aabe1c1f6f0c695f4d557b1daa11c21ad06762359fb3f" => :sierra

--- a/Formula/check_postgres.rb
+++ b/Formula/check_postgres.rb
@@ -6,7 +6,6 @@ class CheckPostgres < Formula
   head "https://github.com/bucardo/check_postgres.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "eed2892822abe3b006befc6f7933040b8deec32074c9729408c6c4f4765efce8" => :mojave
     sha256 "eed2892822abe3b006befc6f7933040b8deec32074c9729408c6c4f4765efce8" => :high_sierra

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -18,7 +18,6 @@ class ClangFormat < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "e21e425f294cb6daf81dce2de430401dbc00369fc7cc2c3ff76770eee50b149f" => :mojave
     sha256 "2937b78b833fa1ad75a170e31d90fda274b400bad21e509797fe1d6fa95812fd" => :high_sierra

--- a/Formula/cli53.rb
+++ b/Formula/cli53.rb
@@ -5,7 +5,6 @@ class Cli53 < Formula
   sha256 "6b9fcce93071782f9cdfe1a05f098aa08e83f317a0685c2a7f09bafb7d74d24f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "8b2b742de7a1c984e9f89feaf08fdc51c0e33de1b85756309d3d01eee6f1cd92" => :mojave
     sha256 "c4bb7bc057db2d1eb5d1d1db7b9bc12ed84d35fa66af7876cdf1b6ab70196a24" => :high_sierra

--- a/Formula/cloc.rb
+++ b/Formula/cloc.rb
@@ -6,7 +6,6 @@ class Cloc < Formula
   head "https://github.com/AlDanial/cloc.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "661f3c3b8eb7e0a348e36b5b1b7aebf2b579eec5ae078e7f2d2c64ab302a3644" => :mojave
     sha256 "15a38a7a5172213f2c1577a0aef34260203d5e0c25d38c6a4a2252990a9c9414" => :high_sierra

--- a/Formula/cmark.rb
+++ b/Formula/cmark.rb
@@ -5,7 +5,6 @@ class Cmark < Formula
   sha256 "2558ace3cbeff85610de3bda32858f722b359acdadf0c4691851865bb84924a6"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "8687e5aeca18f2c952c5f475569ad90f077d49c3e45477cad0babd68b040a6cb" => :mojave
     sha256 "81e1fe130cae57abb515a8916140b3b2718f4f9ae778fe059d454d51cc24e1b3" => :high_sierra

--- a/Formula/cmigemo.rb
+++ b/Formula/cmigemo.rb
@@ -11,7 +11,6 @@ class Cmigemo < Formula
     patch :DATA
   end
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "28db47c1cedcff4dc6ee2d48bd07a147ae18f400e035e6a583d6b8e6cb36dfa1" => :mojave
     sha256 "a56e9422e30145d388649e9c85bf814adb58688c2c5e374385f4260b8daa049a" => :high_sierra

--- a/Formula/cmocka.rb
+++ b/Formula/cmocka.rb
@@ -6,7 +6,6 @@ class Cmocka < Formula
   head "https://git.cryptomilk.org/projects/cmocka.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "a05bfdbe08b08dc01db59d0c2c724b2a58c4f9e12c260dc5865e27dd456e7771" => :mojave
     sha256 "c4fc9fe8a73b23206c0db8907c2f67dea482d689afea18c5e746556aff8098b5" => :high_sierra

--- a/Formula/coffeescript.rb
+++ b/Formula/coffeescript.rb
@@ -8,7 +8,6 @@ class Coffeescript < Formula
   head "https://github.com/jashkenas/coffeescript.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "9c1bf5218600450ce9f3e8ed18e762f38d066d313f2d7ad198c8c0ffd7a7ad38" => :mojave
     sha256 "46c1294c0ddabe9e77e83a1a43e2ce26c91c88f8831c0134fd4806704fc6838c" => :high_sierra

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -7,7 +7,6 @@ class ConsulTemplate < Formula
   head "https://github.com/hashicorp/consul-template.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "7559cba6cb21be7511ef392022525f592a357598093f1169b90a6e5305b14ba9" => :mojave
     sha256 "06faa71caea243c485c42cc7e5401b973462ae191bb3a5fd89527a6dcaa0beec" => :high_sierra

--- a/Formula/container-diff.rb
+++ b/Formula/container-diff.rb
@@ -5,7 +5,6 @@ class ContainerDiff < Formula
   sha256 "4bdd73a81b6f7a988cf270236471016525d0541f5fe04286043f3db28e4b250c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "31af3976b5c63927f934d3155de81d6b6a241bae7244d103012d0d7cbfbeded7" => :mojave
     sha256 "6002efa7d3d475f95c9bec04896e338a99da5bd333f6fc0ccd20ca80eb6e9726" => :high_sierra

--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -6,7 +6,6 @@ class Coreutils < Formula
   sha256 "ff7a9c918edce6b4f4b2725e3f9b37b0c4d193531cac49a48b56c4d0d3a9e9fd"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "f11898e59abf1c9ea9807ab15c7cdfc930bbfe1df14e432e5d2a89f11c405445" => :mojave
     sha256 "8ceacbb21daeeb2c526d28789fe8d703d437bb72a382a7c3a3c024901f17cae6" => :high_sierra
     sha256 "3451c10504ed3cc49893e84e6f3e09a0457cd28eb953482489548dfb593d098f" => :sierra

--- a/Formula/coturn.rb
+++ b/Formula/coturn.rb
@@ -5,7 +5,6 @@ class Coturn < Formula
   sha256 "e020ce90ea0301213451d37099185ff25d93f97fa0f2b48bf21b2946fc3696a4"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "0965e2d618dc990376fe852dc24c748a789c320381c3d935f8f557ce30df9304" => :mojave
     sha256 "64d8d65360234067a875bc90db41ab69127641f847c1450a2f0cc71869de20a1" => :high_sierra
     sha256 "9813765ffeb2d1dbb8738a8695ef34473fadec04307561791856de68feea7e03" => :sierra

--- a/Formula/cscope.rb
+++ b/Formula/cscope.rb
@@ -5,7 +5,6 @@ class Cscope < Formula
   sha256 "c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "0a8c76e372e2c965e654b5024cbf872931e6204b7e2ba79623d5d7d002cd3c2f" => :mojave
     sha256 "ae7b5f716debeb937c3472add41f69c7176e9c4a9a0668090afd63313eabbe86" => :high_sierra

--- a/Formula/ctop.rb
+++ b/Formula/ctop.rb
@@ -6,7 +6,6 @@ class Ctop < Formula
     :revision => "70bd2ae3a3476969cae3c7f921d38b130ceec648"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     rebuild 1
     sha256 "2e2f235137e94a3480bf54a0ef951665756736e38db7e0d61bee478e03d550ce" => :mojave

--- a/Formula/datamash.rb
+++ b/Formula/datamash.rb
@@ -6,7 +6,6 @@ class Datamash < Formula
   sha256 "fa44dd2d5456bcb94ef49dfc6cfe62c83fd53ac435119a85d34e6812f6e6472a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "c6df5d507e7486fd57449ff0a7c53fe7dda265c27ffbc3becef14fc7ecb5b0a2" => :mojave
     sha256 "10bf8d835e2cc4401875db546d0336563f259fb9fc5cae86e58d91ede2cff943" => :high_sierra
     sha256 "35bf3994eb36de7e6f7c9e7010322c58aeb44e42676060c5b28d92f97789dfab" => :sierra

--- a/Formula/davix.rb
+++ b/Formula/davix.rb
@@ -8,7 +8,6 @@ class Davix < Formula
   head "https://github.com/cern-it-sdc-id/davix.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "85564894b2b7eb8f1896a815e1b3b9fe0bdcd1598060ec3872ec1fa0806f96d7" => :mojave
     sha256 "702eb13a7e16c4f73904f064bedce4a9e13a95d72b5428e5684ad3f5bb9566e9" => :high_sierra

--- a/Formula/dfmt.rb
+++ b/Formula/dfmt.rb
@@ -7,7 +7,6 @@ class Dfmt < Formula
   head "https://github.com/dlang-community/dfmt.git", :branch => "v0.x.x", :shallow => false
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "3f27ea93b418c2a4c163e94f03f7aa504b2116ebc3cffa88eadd30e2075c257d" => :mojave
     sha256 "e4e2fccd219314a3797ae105c8b2a766cd5fda0da0fee2bd492e506d53f48d7a" => :high_sierra

--- a/Formula/dhex.rb
+++ b/Formula/dhex.rb
@@ -5,7 +5,6 @@ class Dhex < Formula
   sha256 "52730bcd1cf16bd4dae0de42531be9a4057535ec61ca38c0804eb8246ea6c41b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "2d6043ce881b7b407fa40691639c25c72d73a427fcdd39a56e0683f48b16b328" => :mojave
     sha256 "bfc2aa6c73ffff61a471b4dd8e183e493781a5c34baeddffc56fa89b0542a9bd" => :high_sierra

--- a/Formula/dialog.rb
+++ b/Formula/dialog.rb
@@ -5,7 +5,6 @@ class Dialog < Formula
   sha256 "38c0855b3f59281a44ff15bfa2150070d89daa3a4e2cda1139f6399eeeeca924"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "42c1283bcba7c5b6453e183ad27e0ca6e0451e327326641aa41b06b9eb184417" => :mojave
     sha256 "b39742f9b80b844e69952c06d3369bbb326ddda6db9b58f1964e86d730643931" => :high_sierra

--- a/Formula/diffstat.rb
+++ b/Formula/diffstat.rb
@@ -6,7 +6,6 @@ class Diffstat < Formula
   sha256 "7f09183644ed77a156b15346bbad4e89c93543e140add9dab18747e30522591f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "f2ddd2775174056c48eab541d32b99cfd2cc586e0227c4f2eec4b15bf5ce7128" => :mojave
     sha256 "ac1e5199d1776d52adc03842b378da475f1db1282150ed9ce22c365a5b0cf7dd" => :high_sierra

--- a/Formula/direnv.rb
+++ b/Formula/direnv.rb
@@ -6,7 +6,6 @@ class Direnv < Formula
   head "https://github.com/direnv/direnv.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "548dc9aab0d941ce4bb15b5f5b0de0c70308cdebc2c6af8d54a644e57e71ffa5" => :mojave
     sha256 "eb6c47a8999d698a81032a4d5f60053ea898251575a79e95fcaeb35dcb15c6cb" => :high_sierra

--- a/Formula/distcc.rb
+++ b/Formula/distcc.rb
@@ -6,7 +6,6 @@ class Distcc < Formula
   head "https://github.com/distcc/distcc.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     rebuild 1
     sha256 "cc6733686bc22b48972455982fe93656bcc27f3f4fea1d202c42316a2baceb6a" => :mojave
     sha256 "e0e26dfa751cc3790a81de8ed8bda041a36ff487cbc9c18790e11a1d487893ae" => :high_sierra

--- a/Formula/dnsviz.rb
+++ b/Formula/dnsviz.rb
@@ -7,7 +7,6 @@ class Dnsviz < Formula
   sha256 "a81ff254c23718cd6f364b03bf6e9c80468fa4663fd5be66043de7b0bece1cab"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "f55b130eee33b503ea3b4c88ba34c952ae58a070c632fdac326962199c9ef5b6" => :mojave
     sha256 "6324be158374f9b93e287ada9dfe33c2aef01b05a4bacc78fea47719f69d2db9" => :high_sierra

--- a/Formula/draco.rb
+++ b/Formula/draco.rb
@@ -5,7 +5,6 @@ class Draco < Formula
   sha256 "a3ac692397574166ad99493ff1efcd7b5c69b580e7eb4500d5d181b2f676aa6e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c1bae68f6c01adcce21376bd26f66e9274fa5e733eed5b2e1e032a61e2641cef" => :mojave
     sha256 "fd67b398a18f03ed070ceb6cd3dccd58ce761e2030f6bc75599df3fb49a4d8bf" => :high_sierra

--- a/Formula/dssim.rb
+++ b/Formula/dssim.rb
@@ -5,7 +5,6 @@ class Dssim < Formula
   sha256 "1bc9abec552fc64d3951340d95f68212d30e6473a93694db25cf16a0baa9d854"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c03454b7582f988de44af524a342e016b3bf63937496450365c758809e79a224" => :mojave
     sha256 "f1284c6d8db31ce548232d0e7c0d4204249555ee5a9c92958b2c8bea4deee832" => :high_sierra

--- a/Formula/dtc.rb
+++ b/Formula/dtc.rb
@@ -5,7 +5,6 @@ class Dtc < Formula
   sha256 "c672e443c9f7e39f5a7c8e602da6777f9ad55ad70de87de300a43828c8050172"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "a153daba5d7e2d361cc072a310379a939c8a83986584a1899edba80371e04b56" => :mojave
     sha256 "d64946a773558b22387e1e251185180d386b592828d87c166fa43dbd35cdbf1f" => :high_sierra

--- a/Formula/easyrpg-player.rb
+++ b/Formula/easyrpg-player.rb
@@ -5,7 +5,6 @@ class EasyrpgPlayer < Formula
   sha256 "d364a272aa3e14adfb696b537d957541c9fff9df9a4e3948a24d42ad89b9bf7d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "83f79e7c021e82a781d50f3d7f731a2a4fbafc3dd166c5bdb2941859331982e4" => :mojave
     sha256 "75e146b0e863c2638c34e4d97affc301638cb6b041cf1b4a05aac1e93c7eead7" => :high_sierra

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -6,7 +6,6 @@ class Emacs < Formula
   sha256 "151ce69dbe5b809d4492ffae4a4b153b2778459de6deb26f35691e1281a9c58e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "dc49de7034346e692662d10ebacd75ea257d61ebba6f57699b855f158e4a7eda" => :mojave
     sha256 "de836e0766066201968c2dd0ef25ff4458ee532a61dc4ed9d7d8fb284b395b8d" => :high_sierra
     sha256 "6b07616447d66a8066c08591400dc8fed75d44bf51f81de2e1208635e03204c6" => :sierra

--- a/Formula/erlang@19.rb
+++ b/Formula/erlang@19.rb
@@ -6,7 +6,6 @@ class ErlangAT19 < Formula
   sha256 "11a914176a33068226644f4e999ecc6e965ab1c60a324d90020f164641631fae"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "98b7447b423b81ef4decf068032120dc5f1aab601b33067a1bc188ce33f8ce70" => :mojave
     sha256 "c6ebeeadc73c476dcc51267c3c8a3df12836b8f70be383464e67846f3dc2c5a2" => :high_sierra

--- a/Formula/eslint.rb
+++ b/Formula/eslint.rb
@@ -7,7 +7,6 @@ class Eslint < Formula
   sha256 "3ee88df148b40720c2fe2b1e1c3fa90b2eb2a512902c48897df7a905115608c1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "515bf308de15a20874bfa0234c5de79ae8bc78bbba9189015f08f260a37ea9f3" => :mojave
     sha256 "23c51a24aa1dd926b42183ba58372fcfc2092190638c245ec5a59e6cd8922c40" => :high_sierra

--- a/Formula/etcd.rb
+++ b/Formula/etcd.rb
@@ -6,7 +6,6 @@ class Etcd < Formula
   head "https://github.com/etcd-io/etcd.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "1767fd0f8122f4d4b29b19fdec99bbf6c434afa900a616149b07540d8991cd9d" => :mojave
     sha256 "a9903de125291e17da64a827370420c9b162bc0a2cbe6284a5c4c391ae87a5f2" => :high_sierra

--- a/Formula/exempi.rb
+++ b/Formula/exempi.rb
@@ -5,7 +5,6 @@ class Exempi < Formula
   sha256 "dc82fc24c0540a44a63fa4ad21775d24e00e63f1dedd3e2ae6f7aa27583b711b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "f276793d07a9d9509e3d9e9267a59a22bb95b1a021468e121700d64ec8e5176d" => :mojave
     sha256 "424eaeb7c609a08e98ba614d386d5b19deda7c808606698b398bac710637cfa4" => :high_sierra

--- a/Formula/exomizer.rb
+++ b/Formula/exomizer.rb
@@ -5,7 +5,6 @@ class Exomizer < Formula
   sha256 "cf94a2d9e66c104489846bb703c497aab8146ac4a54964def01692d418b16075"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "653ce86b30882fae1deae16bbf40b50f9b46b7f4f3f51e1952a988121e4fd5dc" => :mojave
     sha256 "46b2f9b190847344ab7a16c94eb4b2bad48009a8f08e5463427af75c9eb67409" => :high_sierra

--- a/Formula/fabio.rb
+++ b/Formula/fabio.rb
@@ -6,7 +6,6 @@ class Fabio < Formula
   head "https://github.com/fabiolb/fabio.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "67487a58775ce639924c4cdd51907b23d61d10c23667efca9b9d9e5752b3f363" => :mojave
     sha256 "aec5deb6a536a861abc132e787336c990a6a5635ab55454171877e2541e3543a" => :high_sierra

--- a/Formula/fades.rb
+++ b/Formula/fades.rb
@@ -6,7 +6,6 @@ class Fades < Formula
   head "https://github.com/PyAr/fades.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c21bbc27f3219e06672b379c38b065808bc9b32301d8d334e0556721aac2b654" => :mojave
     sha256 "6c4ee1dadfb942d489a91e6dd14f9b71fbab8962fed4a0e454456331cd2fc8c1" => :high_sierra

--- a/Formula/fftw.rb
+++ b/Formula/fftw.rb
@@ -6,7 +6,6 @@ class Fftw < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "35006ccac20707ac44c02bc93f29b37899af307ea18d2d52dcea86ac1f80730b" => :x86_64_linux
     sha256 "fafc0d1b43619cf3ac63946a4380782747903378dfb4f7b21387c40131ad2d59" => :mojave

--- a/Formula/file-formula.rb
+++ b/Formula/file-formula.rb
@@ -7,7 +7,6 @@ class FileFormula < Formula
   head "https://github.com/file/file.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "63271d014690b6ac45ca3ad13d23d6756ef196bd60870f7fbcf08853b60576c5" => :mojave
     sha256 "add66c41a0a6d051f263b9082ae931c0eb0f177bd04d4b2c08b79f89c3e6730b" => :high_sierra

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -5,7 +5,6 @@ class Fish < Formula
   sha256 "14728ccc6b8e053d01526ebbd0822ca4eb0235e6487e832ec1d0d22f1395430e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "0dda76c64b0e2b4f1bfe48b816346f54a3fd9531550439caadadc6a1641c6d6b" => :mojave
     sha256 "aaa15fbea68f8414084124da4347aec31484a3ab6320daf5f1cd54e208bf32c1" => :high_sierra

--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -6,7 +6,6 @@ class Flann < Formula
   revision 7
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "d7a3870b59388e523bb964b92f0030e75823c84072a55dfdcbe676bd2b1b046f" => :mojave
     sha256 "0dbf4ddcdab675609aa59e953052fde8e557212127ee0befad52fc5d92a561f0" => :high_sierra

--- a/Formula/flatbuffers.rb
+++ b/Formula/flatbuffers.rb
@@ -6,7 +6,6 @@ class Flatbuffers < Formula
   head "https://github.com/google/flatbuffers.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "7d796ffd01ee8b81de0ffba7ef8dd6c5a85111d2007f2bf06096e461cb2f2210" => :mojave
     sha256 "96246b405f3804a2e0bec7ff4b214fcb009e086a65941018a602f24dfe098c37" => :high_sierra

--- a/Formula/flatcc.rb
+++ b/Formula/flatcc.rb
@@ -6,7 +6,6 @@ class Flatcc < Formula
   head "https://github.com/dvidelabs/flatcc.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "4ca5ad18001cd6511efd9e6eca6b7c4be094c276c6febda4961ef9eaaface955" => :mojave
     sha256 "b792b08126ca76b61e6b0957b11e22118138cc698b8512169bae6d1a6a1f3213" => :high_sierra

--- a/Formula/fltk.rb
+++ b/Formula/fltk.rb
@@ -6,7 +6,6 @@ class Fltk < Formula
   sha256 "8729b2a055f38c1636ba20f749de0853384c1d3e9d1a6b8d4d1305143e115702"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "3ea6ccc2fec9151f3ed0f20761794b9fe0477d168dbc4e83ba88b3f3d16c530b" => :mojave
     sha256 "6edac0b91f19783376ec95c84819405a6f029d7d2bf8ac636d421682fc064e34" => :high_sierra
     sha256 "e2bd28a348c8fbf948f2400d3df29ba786a2ca9cc3f87b3727477fb49ebf57f0" => :sierra

--- a/Formula/fn.rb
+++ b/Formula/fn.rb
@@ -5,7 +5,6 @@ class Fn < Formula
   sha256 "143d836ffea499f0e98fc0c5c7da4b3a81e89545ba0be31ddbb03462b591e9d9"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "ee39d6e3fafe7dee15e53355eea0675483ed5273299d98ca52d0946a2ce3d69c" => :mojave
     sha256 "12efcbda739f6012e603b304d898dc92c36adfc66abb5f000fb4a7f244c8217c" => :high_sierra

--- a/Formula/fortio.rb
+++ b/Formula/fortio.rb
@@ -6,7 +6,6 @@ class Fortio < Formula
       :revision => "fd8f4a7177e9ea509f27105ae4e55e6c68ece6f7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "467956dd9643ecb9b349ce87c854e847d3880afe1e71deb2eb50bf57a8af6e98" => :mojave
     sha256 "638e50aa75d32f0a9aae6243061df73ed7660fb055a3fcc30b9ee0afc3b19f5b" => :high_sierra
     sha256 "663aa97525d032d3de935b487183ee478e2d18f92a4c82737a72ac5ed6c648a9" => :sierra

--- a/Formula/fstrm.rb
+++ b/Formula/fstrm.rb
@@ -5,7 +5,6 @@ class Fstrm < Formula
   sha256 "10ee7792a86face1d2271dc591652ab8c7af6976883887c69fdb11f10da135fc"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "3dd80be760c39df81e083f3e7b1a8fd00d65aada1d3bb43bb2af66fc1ab47bcf" => :mojave
     sha256 "b6e66ea781aba5fc3b2aafb0b895d5e8ac24f57de5fbc99d32c0947b36fd4e6d" => :high_sierra

--- a/Formula/fwup.rb
+++ b/Formula/fwup.rb
@@ -5,7 +5,6 @@ class Fwup < Formula
   sha256 "67afd3c21ea2e2dc806ea66ecb5def42d72fc194c74da40438c5a1edc4df3931"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "46f784f18ff96014fc8b259275495acb34161e0c703d430a9537cd52f60a0006" => :mojave
     sha256 "408355b57d37c6811d3d263c62294072dbffa479a1e884a3db882a79a9d9622b" => :high_sierra

--- a/Formula/fx.rb
+++ b/Formula/fx.rb
@@ -7,7 +7,6 @@ class Fx < Formula
   sha256 "d1bd4bdf821a0053a5972febd06ca8c9652d2cc0a62844e2b3bb521a73032b4b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "1b7b95e489a1e63f52412bbd0fb053e0debe8c52ffbb3f8cf039510f32361b3c" => :mojave
     sha256 "bb119118bdee2f95492a21515064644fa9954ab72d4174798b21ef8fbeaf4729" => :high_sierra

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -6,7 +6,6 @@ class Fzf < Formula
   head "https://github.com/junegunn/fzf.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "0f77b9b22f32f76493cdac585106b01502c6583908e0b7b6ea70ab023b5c1c2e" => :mojave
     sha256 "6f457b819868a5515d2154eae02eb8fdbc154a1815e96729ed62f68395672f38" => :high_sierra

--- a/Formula/gambit-scheme.rb
+++ b/Formula/gambit-scheme.rb
@@ -5,7 +5,6 @@ class GambitScheme < Formula
   sha256 "a5e4e5c66a99b6039fa7ee3741ac80f3f6c4cff47dc9e0ff1692ae73e13751ca"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     rebuild 1
     sha256 "a8b9f1adce4260059b05505e13fd9036a9bdb689aa8e7a56ef8d0804199988b0" => :mojave
     sha256 "8626389fe8f07074733a80f85d6da64b5961258f7f5a6c8258427a5378842f01" => :high_sierra

--- a/Formula/gandi.cli.rb
+++ b/Formula/gandi.cli.rb
@@ -7,7 +7,6 @@ class GandiCli < Formula
   sha256 "a575be04fd373d4798ae16f6cbe03e8ed16255043788fb3de13bebfe7e621c84"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "fd37e0329ef88f7b334ddb4d31128c7167f11c7f33334aca4cd8b954766b9bb9" => :mojave
     sha256 "9ab5c20d1af6e6083ebb211f1bc07dbeafa53a5ff5670452ef00fc26f68a843c" => :high_sierra

--- a/Formula/gauge.rb
+++ b/Formula/gauge.rb
@@ -6,7 +6,6 @@ class Gauge < Formula
   head "https://github.com/getgauge/gauge.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "be3ce930d0b5da738def3f33a45dc08e56087a703b5d88cc30cae46a3851be66" => :mojave
     sha256 "c0e163247633803520521ff4766026fa453972cd16ff418076afd59e8b79d27d" => :high_sierra

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -11,7 +11,6 @@ class GccAT7 < Formula
   # gcc is designed to be portable.
   bottle do
     cellar :any
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "cd0ab374ef92a1688ccf2e6cf6c275c64e99b05ef1e7b145e3ef56569cc2f2e6" => :mojave
     sha256 "5a47d91428176dfb4b77bcddc24844a0ae31dd0cd8347913e10eb753e0b7df61" => :high_sierra
     sha256 "804157359c20bdb3ddf6b8b2bd86a6ead241d217d00e82b1365539ef9675ce1b" => :sierra

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -7,7 +7,6 @@ class Gdb < Formula
   head "https://sourceware.org/git/binutils-gdb.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "16da5f61ca304740defde7f8a772d5fb5f5c48ac658984ef186d1c77f53b5d6a" => :mojave
     sha256 "2721c3a733fba77d623f84c33cce6a1cca46c6a020649269f4431de402704fa1" => :high_sierra
     sha256 "b2343fca9963d198248c98ee069211c28e04135effcc2e7ed0900fec7c7d95a3" => :sierra

--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -6,7 +6,6 @@ class Gdbm < Formula
   sha256 "86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     rebuild 1
     sha256 "80fc4bdfef26e3df4c1f7390e1169d32935faa69f00888318bf0ed8321798aad" => :x86_64_linux
   end

--- a/Formula/geocode-glib.rb
+++ b/Formula/geocode-glib.rb
@@ -5,7 +5,6 @@ class GeocodeGlib < Formula
   sha256 "5baa6ab76a76c9fc567e4c32c3af2cd1d1784934c255bc5a62c512e6af6bde1c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "089531370e651e0420bc0c475c458c717c4b7f60f5c25295e03c7ac979e2ff62" => :mojave
     sha256 "d4feecf40ea213121cec19cc80bccf17af7ac12139d4a9c6f64cf8ee48b1b79a" => :high_sierra
     sha256 "635e4c949e7159977e828ef5e3e36c556c8d32eb548fbbbbc8dce69556cf7229" => :sierra

--- a/Formula/geos.rb
+++ b/Formula/geos.rb
@@ -5,7 +5,6 @@ class Geos < Formula
   sha256 "2166e65be6d612317115bfec07827c11b403c3f303e0a7420a2106bc999d7707"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "8347358e36c773c315f742972786ac7a6e13f5998f799dd8fad3afec22ba5fcf" => :mojave
     sha256 "3f074801c641178e222dfa871463e1891419545e07c36bcedff0c00de8dc8c2a" => :high_sierra

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -5,7 +5,6 @@ class Getdns < Formula
   sha256 "1826a6a221ea9e9301f2c1f5d25f6f5588e841f08b967645bf50c53b970694c0"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "c293ffbb7cf95d03a0aaefe3192528e1ac48a45b178dbe7221c36cba3eef3193" => :mojave
     sha256 "a1e16166536523e0a38364c3a3734c3283ecfd45836f30bf2f3f134f75987306" => :high_sierra

--- a/Formula/getmail.rb
+++ b/Formula/getmail.rb
@@ -5,7 +5,6 @@ class Getmail < Formula
   sha256 "04d52f6475f09e9f99b4e3d2f1d2eb967a68b67f09af2a6a5151857f060b0a9d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "bbdb94c93d8c1371b5b711d0ad5e7d93291bf258c9369db8cf86df21b93730d9" => :mojave
     sha256 "bbdb94c93d8c1371b5b711d0ad5e7d93291bf258c9369db8cf86df21b93730d9" => :high_sierra

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -9,7 +9,6 @@ class Ghc < Formula
   sha256 "4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "ab7cfe45159057538fcde888c14ccf19b0154ac6e0e2d9bd92727c5a0b7734d5" => :mojave
     sha256 "6736c0d1bbff9d7c775c70979b4df8e54d2183ded84965bc44fa6b0c16a0996c" => :high_sierra

--- a/Formula/ghc@8.2.rb
+++ b/Formula/ghc@8.2.rb
@@ -9,7 +9,6 @@ class GhcAT82 < Formula
   sha256 "bb8ec3634aa132d09faa270bbd604b82dfa61f04855655af6f9d14a9eedc05fc"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     rebuild 1
     sha256 "4e0fb4e1672332d2efc68e76bdf23daaf1047c78908c99407616219fef56f961" => :x86_64_linux
   end

--- a/Formula/gifsicle.rb
+++ b/Formula/gifsicle.rb
@@ -5,7 +5,6 @@ class Gifsicle < Formula
   sha256 "5ab556c01d65fddf980749e3ccf50b7fd40de738b6df679999294cc5fabfce65"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "52be1cd49246909777199147dcbbeb6f490580558615138ae063b6149cfbe53c" => :mojave
     sha256 "a7cfb607906023c5bdb56a49f8a75ce0b3e2c76a971266bb530d04ed29be74f9" => :high_sierra

--- a/Formula/gifski.rb
+++ b/Formula/gifski.rb
@@ -5,7 +5,6 @@ class Gifski < Formula
   sha256 "e8d8d2fdb816953315989b3ecf39ac88f33b8c49aa7c79a0df8f53b4032755ab"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "41b0c73f3364637a793137b5ff167847f04104a29ef1db89fce744839786f20b" => :mojave
     sha256 "33268907c1359250acb2993847a179ae6dfd9c0173b9c62def3dfdb41168072b" => :high_sierra

--- a/Formula/git-fixup.rb
+++ b/Formula/git-fixup.rb
@@ -6,7 +6,6 @@ class GitFixup < Formula
   head "https://github.com/keis/git-fixup.git", :branch => "master"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "0fc85e047798c8602c8ad69796c6b6ac4d9759852bdba1b189aa0e999dfb53a2" => :mojave
     sha256 "0fc85e047798c8602c8ad69796c6b6ac4d9759852bdba1b189aa0e999dfb53a2" => :high_sierra

--- a/Formula/glm.rb
+++ b/Formula/glm.rb
@@ -6,7 +6,6 @@ class Glm < Formula
   head "https://github.com/g-truc/glm.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "12ad0bff26df5739227bb1f2865c064b46a1e21faa07e77f19c2be4e2abd8182" => :mojave
     sha256 "534081b8d1624708d52a12d75a31b47372c1711c56057b658c0dbf5fa67306c0" => :high_sierra

--- a/Formula/glog.rb
+++ b/Formula/glog.rb
@@ -6,7 +6,6 @@ class Glog < Formula
   head "https://github.com/google/glog.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "034a4d2272b48fd7655b467b92c78eebfb11efb33cc6cd31f7b13ee085b7169b" => :mojave
     sha256 "bbe6c4138b5fe8cd58d269a39644176f640fa62e694ffac36337f87661cacc69" => :high_sierra

--- a/Formula/gloox.rb
+++ b/Formula/gloox.rb
@@ -5,7 +5,6 @@ class Gloox < Formula
   sha256 "4ade1b14848ccfcd89a505a4fff05116c24f13cef8d02fab0ade2717117ec964"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "b443d6fa0056204e7f7584c0e945eb231f1f1e2f19dea9d959f6ccf31cb190da" => :mojave
     sha256 "12c47414e056dbec998397a7b362d289aaa0966323fb90cf6cddc1ccb04d0b57" => :high_sierra

--- a/Formula/glui.rb
+++ b/Formula/glui.rb
@@ -5,7 +5,6 @@ class Glui < Formula
   sha256 "f7f6983f7410fe8dfaa032b2b7b1aac2232ec6a400a142b73f680683dad795f8"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "24c323dbaa5f6f1b01fbf8f837c379ef503d323a448d2bb3d673c31ced622f0d" => :mojave
     sha256 "7cd9b9d6bffa3b6b6ff806c4041f495d5a7ef40296cb50097db25d17eb616265" => :high_sierra

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -7,7 +7,6 @@ class Gmp < Formula
   revision OS.mac? ? 2 : 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     rebuild 1
     sha256 "84f74594086bccc53bdb141f4d06d7847680374e255ebe016654da1e47db2dfc" => :mojave

--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -6,7 +6,6 @@ class GnuTar < Formula
   sha256 "b59549594d91d84ee00c99cf2541a3330fed3a42c440503326dab767f2fbb96c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "62ef2c92bf090b1ada1b8434034be21ac4534e9ab81388516191b7cecd6c095a" => :mojave
     sha256 "440e9a400c184e76bff84b0b634b1a103231409735c4f7885404d9619ca96c43" => :high_sierra
     sha256 "d245b143eae5179554fca39cdaf37e928e85df8956087d43c5ec0ac968f6c0e8" => :sierra

--- a/Formula/go-statik.rb
+++ b/Formula/go-statik.rb
@@ -5,7 +5,6 @@ class GoStatik < Formula
   sha256 "f157a1ada813eb643ddd9a60a0efe3158f1da25b1d11bc1ef6c7fa219d4b23bf"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "4e347596a83f169bdb0b72cd81d69ea275966fead97f7decb67c873380c179b8" => :mojave
     sha256 "4ec52d9626abcbb07f25640c9ecec4e620faa9ee619f6f289f172aa7bc509590" => :high_sierra

--- a/Formula/gocr.rb
+++ b/Formula/gocr.rb
@@ -5,7 +5,6 @@ class Gocr < Formula
   sha256 "df906463105f5f4273becc2404570f187d4ea52bd5769d33a7a8661a747b8686"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "f0af1bb6614e72f70b54eeacb2063aff9eea014965611828f2e13eb8677d636b" => :mojave
     sha256 "8bcc15b6bef035a94d27a242f7cd40f6c71d4585a2b0c964f3e26aa800258f8a" => :high_sierra

--- a/Formula/gollum.rb
+++ b/Formula/gollum.rb
@@ -6,7 +6,6 @@ class Gollum < Formula
   head "https://github.com/trivago/gollum.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "d2d022b779e4290e98d0783232b00c79bf46fc08d9ad3bea0dd352071e2995f3" => :mojave
     sha256 "afaf112d706150eeb5f8e5152a7b88ef18fc944fdd01dc8a46357a3c8ce13f8b" => :high_sierra

--- a/Formula/google-java-format.rb
+++ b/Formula/google-java-format.rb
@@ -5,7 +5,6 @@ class GoogleJavaFormat < Formula
   sha256 "199c70851146bc15c8e828f5ca78d6c2d7b338def9cc70786ac3ef5967796399"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "bb1fcc168016355d6f847b858018f6c5b188f41e9461aa956a1541e609406d93" => :mojave
     sha256 "c8f23d50f6512d56d4402cb0b2325d7e01563625104579f4ea52a1f47e7f2802" => :high_sierra

--- a/Formula/gopass.rb
+++ b/Formula/gopass.rb
@@ -6,7 +6,6 @@ class Gopass < Formula
   head "https://github.com/gopasspw/gopass.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "b52d40f659774f56428959c273fd9118f0387d7859fe15067233687dfcd9d421" => :mojave
     sha256 "288b95912064115d781f45500c99ca3c4ef9de5cc207e10ef3e9ceeda5a144c7" => :high_sierra

--- a/Formula/gox.rb
+++ b/Formula/gox.rb
@@ -6,7 +6,6 @@ class Gox < Formula
   head "https://github.com/mitchellh/gox.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "008ec56acef96c3ad3117bcde87f1998fcf4ef9c93f82ae363ed6ac39914a95d" => :mojave
     sha256 "c2d77e6fadb6c7585a5df89eb91aaf1f41f6b88829e1a647efb4ebbc70277b3b" => :high_sierra

--- a/Formula/graphene.rb
+++ b/Formula/graphene.rb
@@ -5,7 +5,6 @@ class Graphene < Formula
   sha256 "82a07f188d34eb69df4b087b5e1d66e918475f59f7e62fb0308e2c91432a712f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "14955a68031fdc7e48a9f0b6438a59fec32495bf5a4afa21173977027146a376" => :mojave
     sha256 "ce298f614ae9c0bacb0a0d7856db30ad25ff27bfc2f8bb18193a08d8ad83fd2f" => :high_sierra
     sha256 "2647d2925ca5a6f5da5375e7b8b4fc6080248ea2c576cc8914376a8c05076fb0" => :sierra

--- a/Formula/grib-api.rb
+++ b/Formula/grib-api.rb
@@ -5,7 +5,6 @@ class GribApi < Formula
   sha256 "6afd09feede94faf353b71caa2567b985ab214331d58e8c3f303ea01f387777d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "c47b2b6a977a73b010707e6190d0dde94499615913f88ef7eb4aedc4804768d0" => :mojave
     sha256 "1a0749fb9fa2f5b66ab7230920806f3dddcfb1a7b0cd3cd090e506c3f7e0e9af" => :high_sierra
     sha256 "e556a07e1d8a1ef6bd7f4c5f0c3770ffab42c897b3213d05d65e3ec9b386912b" => :sierra

--- a/Formula/gsettings-desktop-schemas.rb
+++ b/Formula/gsettings-desktop-schemas.rb
@@ -5,7 +5,6 @@ class GsettingsDesktopSchemas < Formula
   sha256 "2d59b4b3a548859dfae46314ee4666787a00d5c82db382e97df7aa9d0e310a35"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "b2873d19eca42edb79cbf3055f0814eb66314edd60df6400ce91a3119661a3a9" => :mojave
     sha256 "b2873d19eca42edb79cbf3055f0814eb66314edd60df6400ce91a3119661a3a9" => :high_sierra

--- a/Formula/gssdp.rb
+++ b/Formula/gssdp.rb
@@ -5,7 +5,6 @@ class Gssdp < Formula
   sha256 "6b57b79a96e229367981b6f00474e4bbc795909a2d3160c748cba3395b3556d3"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "2290af08181d27e7aa38ee9a005872b0c4c00b36b6d07bc35eb42ca475dfe73e" => :mojave
     sha256 "02e1fa177854c341451732648d6fe1d3872521efdcbaab7d6fc9427ae9b4fa6d" => :high_sierra
     sha256 "1c06bb7d867ca5f542e83340649e757ee07faf45540fdb37eb7685e600ef83ca" => :sierra

--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -6,7 +6,6 @@ class GtkDoc < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "b4c6a1d8576e0a796c9522b461e2485ffb98a3af35844401e8c5d3b862c20a69" => :mojave
     sha256 "b4c6a1d8576e0a796c9522b461e2485ffb98a3af35844401e8c5d3b862c20a69" => :high_sierra

--- a/Formula/gupnp.rb
+++ b/Formula/gupnp.rb
@@ -5,7 +5,6 @@ class Gupnp < Formula
   sha256 "a9aa557eff415598e05999d0ab122f202a978ff827688d3f951023117a315f5e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "df77e6d6914f4cac9d2fde9f6e798bbcf8e3df351c324c84385355c2f586b28f" => :mojave
     sha256 "11e816ca31530275242672eeb2fb03309775006f1ba18be7da20e36acfcbfd35" => :high_sierra
     sha256 "baeda23a353b10fa5f3ed22a9c17b6a72e44f75dc5622871fba62454f489167a" => :sierra

--- a/Formula/gx-go.rb
+++ b/Formula/gx-go.rb
@@ -8,7 +8,6 @@ class GxGo < Formula
   head "https://github.com/whyrusleeping/gx-go.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "8c86c8465cde5c6189e67f2d3b758604ef579d064f398cd48eff6ab6ce092bdb" => :mojave
     sha256 "57eb4c948ce99ebca79f938539c1b5e096aef6c16554c30f5744b4e1fc93016d" => :high_sierra

--- a/Formula/gx.rb
+++ b/Formula/gx.rb
@@ -8,7 +8,6 @@ class Gx < Formula
   head "https://github.com/whyrusleeping/gx.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "684f06520e421a1bff37db9419bec73924826428953b4dc5227546f1c94819aa" => :mojave
     sha256 "c60a535b2e9de4688ba699f4012527d25912b74ef9be40ff59fe5d3e6222000f" => :high_sierra

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -6,7 +6,6 @@ class Hdf5 < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "28ee1944f9b17a50bddbfbc1730d06373efaf2f188930fa1624370bb895626df" => :mojave
     sha256 "38fd7f6b101842d2fb103d45f3cbd927b7698795ec622495a9fc6052454eb011" => :high_sierra

--- a/Formula/hdf5@1.8.rb
+++ b/Formula/hdf5@1.8.rb
@@ -6,7 +6,6 @@ class Hdf5AT18 < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "1485cae9d86cf8858cbad57558e7fe5c87092df6558cf89781daf10abad1af5f" => :mojave
     sha256 "ec5ff75dd845f8718f816e2729ede6cb163866e86c16a9a206eea7a243846f94" => :high_sierra

--- a/Formula/help2man.rb
+++ b/Formula/help2man.rb
@@ -6,7 +6,6 @@ class Help2man < Formula
   sha256 "f371cbfd63f879065422b58fa6b81e21870cd791ef6e11d4528608204aa4dcfb"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "fe3ddffa91085d678ab198ffe981edf55b6347faf55bcc04f93fc4eb457d036e" => :mojave
     sha256 "fe3ddffa91085d678ab198ffe981edf55b6347faf55bcc04f93fc4eb457d036e" => :high_sierra

--- a/Formula/hivemind.rb
+++ b/Formula/hivemind.rb
@@ -6,7 +6,6 @@ class Hivemind < Formula
   head "https://github.com/DarthSim/hivemind.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "8e6f70ca5e0c8eb1e42d47bee207ec5333b453660d808103a36d53c51a7fb59a" => :mojave
     sha256 "7a89018774693681975cea22dcdebe35df043507476d1318f195e6d194978693" => :high_sierra

--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -9,7 +9,6 @@ class Hledger < Formula
   sha256 "849a6e0683192ec504da9a631ddfc82e04973583f4a028fd39b8cdac2efe29ea"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "f8f717413411bf98616d3df20f31583928b8b93e937080632e08677512cd9d5b" => :mojave
     sha256 "5150a38fc8378410ca9b7b9d2fca755ccc7fe0eef6805fc07650fd836460a0bb" => :high_sierra

--- a/Formula/http-parser.rb
+++ b/Formula/http-parser.rb
@@ -5,7 +5,6 @@ class HttpParser < Formula
   sha256 "5199500e352584852c95c13423edc5f0cb329297c81dd69c3c8f52a75496da08"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "1c6633009d218a0a991e42aa79ae824831a796b27ebe107166f718b169fb51d4" => :mojave
     sha256 "557d24ba21e7be4cc6dbc2e7c2da15338f45bf8b61dcc3791e6b2054b3498512" => :high_sierra

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -5,7 +5,6 @@ class Httpd < Formula
   sha256 "b4ca9d05773aa59b54d66cd8f4744b945289f084d3be17d7981d1783a5decfa2"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "2e182ce40202f92a9666d92df65308cc2fccfc3e6a1d0c484dbba3b2cfdf3f15" => :mojave
     sha256 "4d3819edd023dd903adb6eaad54eba89b5986869dd04e334ee84f0784e9cf6da" => :high_sierra
     sha256 "de26e4d8409b24499366e6ed40d6085146d9aceeffbee91350c13a12e790f58d" => :sierra

--- a/Formula/iamy.rb
+++ b/Formula/iamy.rb
@@ -6,7 +6,6 @@ class Iamy < Formula
   head "https://github.com/99designs/iamy.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "d24e802f1fc572c7d49620531e57a5e143956b2ce1e1d05b2320167b09fbf875" => :mojave
     sha256 "aac8b68119dad48d8aca16a2355cc5c8605e8b1fe44b18e5eb8326216873d657" => :high_sierra

--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -7,7 +7,6 @@ class Icu4c < Formula
   sha256 "627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "e858556120acc0c2d52b8fb572b677856724cc28d24a7e1b2762d458a2977c8e" => :mojave
     sha256 "02afdd6a472c31351e46a3b2a38c1c77354f0cc9199c3dbd7e06bc171b3638a2" => :high_sierra

--- a/Formula/ilmbase.rb
+++ b/Formula/ilmbase.rb
@@ -5,7 +5,6 @@ class Ilmbase < Formula
   sha256 "456978d1a978a5f823c7c675f3f36b0ae14dba36638aeaa3c4b0e784f12a3862"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "436dbe30d0bc520c5c056dac23a3558dd2595e5f5b68c6c17e18566716c71e56" => :mojave
     sha256 "4ef6417909dee0313b9d493b5689d04382907beb650abc669fc5a6346e4c4d5b" => :high_sierra

--- a/Formula/iniparser.rb
+++ b/Formula/iniparser.rb
@@ -6,7 +6,6 @@ class Iniparser < Formula
   head "https://github.com/ndevilla/iniparser.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "69dde8e886645f5b89f83f36835c18449afe7f6c4f119d466d7f204e994952c7" => :mojave
     sha256 "cec20d33114e7a5811acb41f9f9a36a411ffd2eebb7d537167b9b541b03fff8d" => :high_sierra

--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -5,7 +5,6 @@ class Iozone < Formula
   sha256 "2c488a7ccddd624fd557af16e71442c367b131d6178e1b4023bbd532bacdda59"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "ed77f59ddfb45e302b60e80d2f4a842e838af5973df7e6dc7d95a3d27c06d0e8" => :mojave
     sha256 "c0f0f7a10f585f40435d1d0a07322739925c9cae2afeb8c8714fe9e121a41572" => :high_sierra

--- a/Formula/ipbt.rb
+++ b/Formula/ipbt.rb
@@ -7,7 +7,6 @@ class Ipbt < Formula
   sha256 "8347b373252a4c7054d476a39933287a146bb0e0f9dbfe86cd23931cf9eabb5c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "bd283b7c7c23687fe8d2805171c1abf50924e53d4072fe5bb3ca96e6fa16c206" => :mojave
     sha256 "8a353ed14fde241fdc9894083f36298f5374c06c264129b4f1468188633e2467" => :high_sierra

--- a/Formula/ipv6calc.rb
+++ b/Formula/ipv6calc.rb
@@ -5,7 +5,6 @@ class Ipv6calc < Formula
   sha256 "a0ec4a1ff197210162f8a644381dd08b2c552cf50c68041748ea7e067df70080"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "e5816eae9ca8eed194d698a289d1f3d9dedcb93b983cd9761c6dca233d3a5ed7" => :mojave
     sha256 "8803971206dffa1bf5d040199f774e32f052d0d142b674ca41777e3736ab2bb3" => :high_sierra

--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -12,7 +12,6 @@ class Isl < Formula
   sha256 "777058852a3db9500954361e294881214f6ecd4b594c00da5eee974cd6a54960"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "f9188b5d486b2a835cd865f219be1a9848ce3926e27089a1538ee989db65447d" => :mojave
     sha256 "d997d49958218e521bc4f73369414ff9fad040d28601d94012e4c68cd090ea93" => :high_sierra

--- a/Formula/itstool.rb
+++ b/Formula/itstool.rb
@@ -6,7 +6,6 @@ class Itstool < Formula
   head "https://github.com/itstool/itstool.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "460851d054248b512c108b4f8b47731ee90fcb69b179a661f721efe8fa67bf60" => :mojave
     sha256 "460851d054248b512c108b4f8b47731ee90fcb69b179a661f721efe8fa67bf60" => :high_sierra

--- a/Formula/ivykis.rb
+++ b/Formula/ivykis.rb
@@ -6,7 +6,6 @@ class Ivykis < Formula
   sha256 "b724516d6734f4d5c5f86ad80bde8fc7213c5a70ce2d46b9a2d86e8d150402b5"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "4e33d0afd4c85a7dda64e0ceef937572c97beb5cbf3ddc54491eaa312f390e7b" => :mojave
     sha256 "fb7ee29809095d025bb9c34b73c5a9922a03ca631af52e790e14332be284c5ad" => :high_sierra

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -6,7 +6,6 @@ class Jasper < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "ed0856ff9b2429852401e658f4045c9e39cd05fa77b5ea7a6a3c2e21b4d8c460" => :mojave
     sha256 "630b86c544fda0a769815637e37b34e587a6d070b26d642b0d50401f609c744f" => :high_sierra

--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -5,7 +5,6 @@ class Jbig2dec < Formula
   sha256 "a4f6bf15d217e7816aa61b92971597c801e81f0a63f9fe1daee60fb88e0f0602"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "4f3bb46fc8727b6aa1b6def6b9d6893078cf929d0ed37e432ea864810ad6ddf7" => :mojave
     sha256 "1b2684d8ba1e74ed1f5d8eaaee419859056aa5cbc85a6979fd16241d658c08d7" => :high_sierra

--- a/Formula/jemalloc.rb
+++ b/Formula/jemalloc.rb
@@ -5,7 +5,6 @@ class Jemalloc < Formula
   sha256 "74be9f44a60d2a99398e706baa921e4efde82bf8fd16e5c0643c375c5851e3b4"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "65f360353caa81de08b1b1882de13e8423d0f72d92a67bb3a8cfd7ce71f39c71" => :mojave
     sha256 "9c0d0531d6da443ae28a585f23b6f959383c6c92e37c7db9287ba59c6b91bfc9" => :high_sierra

--- a/Formula/jid.rb
+++ b/Formula/jid.rb
@@ -5,7 +5,6 @@ class Jid < Formula
   sha256 "0912050b3be3760804afaf7ecd6b42bfe79e7160066587fbc0afa5324b03fb48"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "2552c0ab94b892750ecff994b5f3fa963d8ab69298fc27abff7ca92f1e371532" => :mojave
     sha256 "4cfdd2d04b54fdd4d63a1297205bc7867b8bd7049c727ab8ad306c12f0d270d6" => :high_sierra

--- a/Formula/jmeter.rb
+++ b/Formula/jmeter.rb
@@ -5,7 +5,6 @@ class Jmeter < Formula
   sha256 "844d510fe04aaf62269311f18117d75c959148bb9f0fc76b4047abc8a8edb4ae"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "75fe29e4b60b96e881c3b64475d4f7fc268cd405e300b31f1aa3ce6cb26c4211" => :mojave
     sha256 "75fe29e4b60b96e881c3b64475d4f7fc268cd405e300b31f1aa3ce6cb26c4211" => :high_sierra

--- a/Formula/john.rb
+++ b/Formula/john.rb
@@ -5,7 +5,6 @@ class John < Formula
   sha256 "0b266adcfef8c11eed690187e71494baea539efbd632fe221181063ba09508df"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "3a5ccc4400712b8b3ceeb47ac563cc1fa3fa7b4bb60937d3c1d3218cf51f2e4a" => :mojave
     sha256 "7e7f9960b5594da1e110c16613c9271e428d035ca468c3ae48ec4231b45aa2f1" => :high_sierra

--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -5,7 +5,6 @@ class Jp2a < Formula
   sha256 "e509d8bbf9434afde5c342568b21d11831a61d9942ca8cb1633d4295b7bc5059"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "97f05a0bb8f9ee5b075e21aff16503284592106cc87d384c1b85936128690345" => :mojave
     sha256 "36bd941b1b215c93b6934a085b9cf8fdaad2ba2ce47a8fbe096e53a144932201" => :high_sierra

--- a/Formula/jpeg-turbo.rb
+++ b/Formula/jpeg-turbo.rb
@@ -6,7 +6,6 @@ class JpegTurbo < Formula
   head "https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "8b1bebbe396aa8c87ffaf728e55206e6d87d431a1f26960e0043a4d314ecafaa" => :mojave
     sha256 "67e420053c229a4c33aaed0e6c585da8290b88c4fd6ca4e09d7c65c8d96656e8" => :high_sierra

--- a/Formula/jsonrpc-glib.rb
+++ b/Formula/jsonrpc-glib.rb
@@ -5,7 +5,6 @@ class JsonrpcGlib < Formula
   sha256 "bc60aa36c8bdc9c701ad490508445633a9f3973ae0bd5bdd0633d5f6ffeea6eb"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "04cca91e37582e34e6c67edc5c6582899a137ba5b36c5b9be1ac7878746bd748" => :mojave
     sha256 "12b38863599f606ac861abcdcb1f1042a0242ccb8a4f69e7f612924422381e18" => :high_sierra
     sha256 "25613b83e25e71ba162b96337bd394d01e48d57895ff0e8ec45e0a7b929bb2f1" => :sierra

--- a/Formula/jump.rb
+++ b/Formula/jump.rb
@@ -6,7 +6,6 @@ class Jump < Formula
   head "https://github.com/gsamokovarov/jump.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "125750ca3597f9d628b2fc988c492a5c77e3bbacb18580905d9169c24688049c" => :mojave
     sha256 "03cbd33d75d0928fb0ff6141b4460b76cd288864831147e0b323d0f767d26477" => :high_sierra

--- a/Formula/jupyter.rb
+++ b/Formula/jupyter.rb
@@ -6,7 +6,6 @@ class Jupyter < Formula
   revision 5
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     rebuild 3
     sha256 "b37596a5d6115045e04b687d6d90bb00c15ac544a3e5aa04ea66e60af099e622" => :mojave

--- a/Formula/kcov.rb
+++ b/Formula/kcov.rb
@@ -6,7 +6,6 @@ class Kcov < Formula
   head "https://github.com/SimonKagstrom/kcov.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "eb5bc53867f7dc0ebb53216daf6b1ec62ee45036fa36d60ccfa03722644176ed" => :mojave
     sha256 "e5c56807425593829fa59be83f58ba473cdde545216c06fdda54e7e59996f413" => :high_sierra

--- a/Formula/khard.rb
+++ b/Formula/khard.rb
@@ -7,7 +7,6 @@ class Khard < Formula
   sha256 "fc93d0b91f7e688a8f60896b4ff7b1968d6b4cb58d80fca9977232c3a68ed2d3"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "26563dd5d8fa44f38db40ca188b03559857bb833961a1ca09f91e5c28e9ddb25" => :mojave
     sha256 "f0bc10e7097d36e96ee44e60218000edaa4379fff88b5e7ca8023eb1c5c23793" => :high_sierra

--- a/Formula/kompose.rb
+++ b/Formula/kompose.rb
@@ -5,7 +5,6 @@ class Kompose < Formula
   sha256 "6da3ba8b66c7023f66b3ddc8f9ff1e5ce5f38e299da9ff93c4dd1c2a765b8dc5"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "f5aa21a04462d384e5eee491c064417868a987643e483d0abdf63b34ff1ef384" => :mojave
     sha256 "cca8ebca8fc06f5b756f8c507b69b4cf1e4dd43b8d77cd1aa42fb2a33e931e36" => :high_sierra

--- a/Formula/krakend.rb
+++ b/Formula/krakend.rb
@@ -5,7 +5,6 @@ class Krakend < Formula
   sha256 "8d6938af3483c909b0762ab44998f09812632081045bebc33b707c85b3985a00"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "7dd2278ffff7ddf5a88988a3ea5180df6da93c7189e673de995cace1948c7bd9" => :mojave
     sha256 "7cd76dbba92ea6011ef3ff439d51d19a7dddb9e1c64bf339cd78b2acb34e560c" => :high_sierra

--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -5,7 +5,6 @@ class Krb5 < Formula
   sha256 "5a6e2284a53de5702d3dc2be3b9339c963f9b5397d3fbbc53beb249380a781f5"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "a73183fac51592371795af726b991893db251dbacbcad5e9b0c2f1eb41dd1f62" => :mojave
     sha256 "beaa308f53f9586fa64a07cb62cc8b349365be3169ec08c9cf669ad3445dcfc7" => :high_sierra
     sha256 "375b6f6caf39eb186368e949b864d84d75f0af792ef31c3b8de59e3669ba645f" => :sierra

--- a/Formula/kyoto-cabinet.rb
+++ b/Formula/kyoto-cabinet.rb
@@ -5,7 +5,6 @@ class KyotoCabinet < Formula
   sha256 "56899329384cc6f0f1f8aa3f1b41001071ca99c1d79225086a7f3575c0209de6"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "ddd2f1b0f1985ad81b04b29dbd54f95c5f7c88f7427b559e9f298a6473a820b0" => :mojave
     sha256 "e4b99c22b5aebf85986e5c172ec61768833708acbb04318335f6641bea1f77ef" => :high_sierra
     sha256 "04ef198a6638dabdee27e881df9b16970eadc724f2f663a01edee7950b38b85a" => :sierra

--- a/Formula/kyoto-tycoon.rb
+++ b/Formula/kyoto-tycoon.rb
@@ -6,7 +6,6 @@ class KyotoTycoon < Formula
   revision 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "04d72b5c55be3c26c688eda6c0cc9f88c85855ba6fe81aa36e210fc29afe7572" => :mojave
     sha256 "ce7db5082c632bef982d5463f3a8507d786fd3bcae7f7cccf8663ab36c3571bd" => :high_sierra
     sha256 "e75c60a4417bc00d04e1f24241320329f01b0d3076de2585e92375b12c4ef31d" => :sierra

--- a/Formula/lapack.rb
+++ b/Formula/lapack.rb
@@ -7,7 +7,6 @@ class Lapack < Formula
   head "https://github.com/Reference-LAPACK/lapack.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "fa78953406938636ce45034e192d7611db5f72fbe46a934a2b4072ab2bb3a289" => :mojave
     sha256 "7de1e297afb68bcbcf867b5b996934e5f5d2278bbf28e95ea8c953cb3f74b0f7" => :high_sierra

--- a/Formula/laszip.rb
+++ b/Formula/laszip.rb
@@ -6,7 +6,6 @@ class Laszip < Formula
   head "https://github.com/LASzip/LASzip.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "bb1b85c70f7efee68cac94ed831941fe1420530f36166587a8715ec5507330eb" => :mojave
     sha256 "a9396e0e7d10b57df846c73fcfe807d354a1aab80f5b0c85fb6a68b420db00aa" => :high_sierra

--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -5,7 +5,6 @@ class Lbdb < Formula
   sha256 "b0cbc68abeb70be779b234f736dd7eb14bf3f7cd1a2ea41e636de1949da025bf"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "a02ea4967e809c9254dac7726c7ee9365e1ba99a8eef68fe6dfd4de34d2fa5af" => :mojave
     sha256 "0e5c126d7cb1c5ed3211ee1758a388597b00f32c3fb22c0420919e3667371ee2" => :high_sierra

--- a/Formula/lcdf-typetools.rb
+++ b/Formula/lcdf-typetools.rb
@@ -5,7 +5,6 @@ class LcdfTypetools < Formula
   sha256 "fb09bf45d98fa9ab104687e58d6e8a6727c53937e451603662338a490cbbcb26"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "0fd983396dbcf027e560753e6f25797500d085762edcf59a1a2034cd55c24cfd" => :mojave
     sha256 "cdff1c16d03fd920033f85dd2e2180f91791057729fbd26b6f193ac7cd0ce9f4" => :high_sierra
     sha256 "2bfe28f9e869eec676cada56bcf6efe97024e0e1f93b126a7b26ac2a292db2af" => :sierra

--- a/Formula/leptonica.rb
+++ b/Formula/leptonica.rb
@@ -5,7 +5,6 @@ class Leptonica < Formula
   sha256 "e2ed2e81e7a22ddf45d2c05f0bc8b9ae7450545d995bfe28517ba408d14a5a88"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "534b5e4c96c34aed7f2e3dd9ffc046fd49a9a015a1ed0c2f1859d2cc182ed66e" => :mojave
     sha256 "ca7ccc979d58c3586d74169c5dbd537976f2ec9a41bd16effaec418fb03ecfc0" => :high_sierra

--- a/Formula/leveldb.rb
+++ b/Formula/leveldb.rb
@@ -5,7 +5,6 @@ class Leveldb < Formula
   sha256 "55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "22e4a129bedd5030525f749a5b5ec978bf6da0a9b0625fe829da482a5ab85755" => :mojave
     sha256 "b1cf697cad28caac418d2e0ef49bc90863f389402185d3cc0f1f7079516d02c2" => :high_sierra

--- a/Formula/libatomic_ops.rb
+++ b/Formula/libatomic_ops.rb
@@ -5,7 +5,6 @@ class LibatomicOps < Formula
   sha256 "587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "b509d8669c5336775b0462c3e1464419d083bccc0bf43f8dab8fa3eb0ac44405" => :mojave
     sha256 "2e3053c22101fd8baf693ca404f258763b15e77372b5293e999f8bbc8b032522" => :high_sierra

--- a/Formula/libbluray.rb
+++ b/Formula/libbluray.rb
@@ -5,7 +5,6 @@ class Libbluray < Formula
   sha256 "a3dd452239b100dc9da0d01b30e1692693e2a332a7d29917bf84bb10ea7c0b42"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "25de56ece940908d1be482b234b5c6fc5ec2bc8d24aaf9c75d67718ea5770605" => :mojave
     sha256 "152dd759f3c3170eecf59f095c6b8dde3a9fc8dcf317846b50fbd85644bc3296" => :high_sierra

--- a/Formula/libcddb.rb
+++ b/Formula/libcddb.rb
@@ -6,7 +6,6 @@ class Libcddb < Formula
   revision 4
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "2eb96af074a3f8dc8babf689481d9be863c0e79445499a473f94c57773381983" => :mojave
     sha256 "f6f41c88a20822be86c07ce27b0f426d3c34d4d420c77d35ff457291c7ad3ada" => :high_sierra

--- a/Formula/libcdio.rb
+++ b/Formula/libcdio.rb
@@ -6,7 +6,6 @@ class Libcdio < Formula
   sha256 "8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "55014a60373e44384aa7f797c613ccd5289c55d759c3521b7e5d6819ff54b2ac" => :mojave
     sha256 "32604fb219cc4e59e5eb1e0937b320edfacf31d97f04b9a5fbfcd4354a6a56d0" => :high_sierra

--- a/Formula/libcdr.rb
+++ b/Formula/libcdr.rb
@@ -5,7 +5,6 @@ class Libcdr < Formula
   sha256 "6ace5c499a8be34ad871e825442ce388614ae2d8675c4381756a7319429e3a48"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "d5362604839f1948a8b594c53e2db0c1bd419ab63c59e158813d56e916d7201f" => :mojave
     sha256 "99fe39b40cf1977d09536fd15fa7557042c200e5848424b98b1b67fa8ed54198" => :high_sierra

--- a/Formula/libcoap.rb
+++ b/Formula/libcoap.rb
@@ -5,7 +5,6 @@ class Libcoap < Formula
   sha256 "9523e38da6ee8b2a8f5ce83ded64107dd1e514c7ad00cd74ccfe3454b679c271"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "e43618d83730577d3a647565e919d8b8db6ccd6d947995b001fc75a6e02655f0" => :mojave
     sha256 "c39515311e41413a6a569dd3b652cac35c15fe21a51140976e7f3294b14193b7" => :high_sierra

--- a/Formula/libdap.rb
+++ b/Formula/libdap.rb
@@ -5,7 +5,6 @@ class Libdap < Formula
   sha256 "29961922b53f62e9d4eb34d1d50ddc23a24100664f97b71f42561fa5588ccc58"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "d2f5c13913633acafe8c090b9ff94ad3f9eae5d7699be4707da57f15524fc530" => :mojave
     sha256 "15bf626100714d66c1691db44574295b5f257b1f0e3df025ac3f7c12c2526697" => :high_sierra
     sha256 "ccb2d18958ed0115c1e1294e1c13d1c4afed8090a88efd0a6c6ff023bb697093" => :sierra

--- a/Formula/libdill.rb
+++ b/Formula/libdill.rb
@@ -5,7 +5,6 @@ class Libdill < Formula
   sha256 "ebba0e5b433ec123b74a57d49b89dfa673aa258e03e6a452959e556b4c4529b9"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "7ebbbe85ab5989b48664688c9fdc833b4bbc7846ea94f3f73c34ef620026b878" => :mojave
     sha256 "062d2f9f6fdeb5588036d3e06752ecfd95b5f4e7b6008b727208fc0a2e7f50a6" => :high_sierra

--- a/Formula/libdvdread.rb
+++ b/Formula/libdvdread.rb
@@ -5,7 +5,6 @@ class Libdvdread < Formula
   sha256 "28ce4f0063883ca4d37dfd40a2f6685503d679bca7d88d58e04ee8112382d5bd"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "3919d408e59a7b7b50a22e088d347d78e0e5c1a2cf4c9d557210954a0aba9311" => :mojave
     sha256 "71d7adc722864315fcf72d6011b7932e5a038562585ec92ac1adcd7c22bfbcf2" => :high_sierra

--- a/Formula/libedit.rb
+++ b/Formula/libedit.rb
@@ -6,7 +6,6 @@ class Libedit < Formula
   sha256 "ac8f0f51c1cf65492e4d1e3ed2be360bda41e54633444666422fbf393bba1bae"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "c445caf1a4f1d47555f00505553b479c1638eb59e63ce7bcbd9cc03fd4b15e14" => :mojave
     sha256 "0b624516c27f8e3298eff0f2dbfd2e108bf6d428c6d7c057914665b26154b366" => :high_sierra

--- a/Formula/libestr.rb
+++ b/Formula/libestr.rb
@@ -5,7 +5,6 @@ class Libestr < Formula
   sha256 "46632b2785ff4a231dcf241eeb0dcb5fc0c7d4da8ee49cf5687722cdbe8b2024"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "543dcd541a69d52d5d1d21d51d0cf57c1617cc177f743c2dfea8ea3d548b93e8" => :mojave
     sha256 "7f17c5dbb6534afe6b37ae1d1f994d3387cd8527d6aaa768604837ac681eee59" => :high_sierra

--- a/Formula/libgeotiff.rb
+++ b/Formula/libgeotiff.rb
@@ -5,7 +5,6 @@ class Libgeotiff < Formula
   sha256 "f9e99733c170d11052f562bcd2c7cb4de53ed405f7acdde4f16195cd3ead612c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "5feecdec004c5bc749dbc16c4dda70382b001ad1e64ab7035086cfb425abf231" => :mojave
     sha256 "f34254f5d27c0b074d1b74dc4c73baeb8c042b4126a0e7283b7e11911e0e0e0c" => :high_sierra

--- a/Formula/libgit2-glib.rb
+++ b/Formula/libgit2-glib.rb
@@ -6,7 +6,6 @@ class Libgit2Glib < Formula
   head "https://github.com/GNOME/libgit2-glib.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "f82b96ed9c95745467ee9aff18b2d6ba0156d51f68801a781bee67d6b2b2923a" => :mojave
     sha256 "0b66cc16cda70882208b1f82be0a715fb3994054ea336c847e78189eb09dee97" => :high_sierra
     sha256 "e05260bd33fb4ff96ba9669ab65930bef977219bc455717ca6bdd97eb77e3bd6" => :sierra

--- a/Formula/libgpg-error.rb
+++ b/Formula/libgpg-error.rb
@@ -5,7 +5,6 @@ class LibgpgError < Formula
   sha256 "babd98437208c163175c29453f8681094bcaf92968a15cafb1a276076b33c97c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "a708445b7304f711ed41bbf95f5cc90e3c6c08339bb9e4d707b2a476971827d3" => :mojave
     sha256 "b17e8b8e93add16424efb34b5a9f6ab280b3127050c560db5829b4e16de7cabd" => :high_sierra
     sha256 "bba0dd545de4ce5469ba008009c04fcae21db32ae1cb755b7d57071741de3cfe" => :sierra

--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -6,7 +6,6 @@ class Libimobiledevice < Formula
   revision 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "08f492ac669856b6c8b24b47837e1ad771d028dd86017c1fa2fd22a64e681183" => :mojave
     sha256 "99f3f03c16a4a3818ade87ca533a54d411613b9f07e8c61bf49f157771bddc2f" => :high_sierra

--- a/Formula/liblwgeom.rb
+++ b/Formula/liblwgeom.rb
@@ -7,7 +7,6 @@ class Liblwgeom < Formula
   head "https://svn.osgeo.org/postgis/trunk/"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "ae9c29245251a22f8a93b751ae13ebb756e32f29f3fcfc18f1908db22fec534d" => :mojave
     sha256 "7fb25efd9d5c9066478b3bfa37eb20fe9067dde08a68d5d0ab71906f16c9b934" => :high_sierra

--- a/Formula/libmagic.rb
+++ b/Formula/libmagic.rb
@@ -5,7 +5,6 @@ class Libmagic < Formula
   sha256 "e9c13967f7dd339a3c241b7710ba093560b9a33013491318e88e6b8b57bae07f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "d4bef4ec5fd234cd4fdc0650d7a2dba51fa9e5d421669db9fa8d2d466e20c98c" => :mojave
     sha256 "14eb5417f36b7ae1813a290c6004c880bd2c50498bc470a48dd9fb8cb489aa4e" => :high_sierra
     sha256 "c5cacee5081c405d14caa39c8e3768c6112c8f154c9e1ebbeabd081fff88f44b" => :sierra

--- a/Formula/libmicrohttpd.rb
+++ b/Formula/libmicrohttpd.rb
@@ -6,7 +6,6 @@ class Libmicrohttpd < Formula
   sha256 "37c36f1be177f0e37ef181a645cd3baac1000bd322a01c2eff70f3cc8c91749c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "065c03c15e7cddac444a335ae9a4a581b9cb10f9ea4edbafab86cb9ec083ce49" => :mojave
     sha256 "2b022a903526ca0d939b8660fd1d9ca82877c29734b177bb865631a6fbf0e375" => :high_sierra

--- a/Formula/libmspub.rb
+++ b/Formula/libmspub.rb
@@ -6,7 +6,6 @@ class Libmspub < Formula
   revision 4
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "93f7e02d005fb22101eab93659f200ed8376130c9a4bad0c24b0cdde51b92f18" => :mojave
     sha256 "43347c63d9fb4a6746929b2127453241cdad9b13a9fd00ddf82af418d6a175b2" => :high_sierra

--- a/Formula/libmwaw.rb
+++ b/Formula/libmwaw.rb
@@ -5,7 +5,6 @@ class Libmwaw < Formula
   sha256 "0440bb09f05e3419423d8dfa36ee847056ebfd837f9cbc091fdb5b057daab0b1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "9b17fa0d1afca2803fed1412bcb20275552a73cf6a3ec6377d2070abc87310ee" => :mojave
     sha256 "a03479bf4c1becc688f76ce5c16519a6ccde95fc65da8d46c3e9cc6664b07fdb" => :high_sierra

--- a/Formula/libmxml.rb
+++ b/Formula/libmxml.rb
@@ -6,7 +6,6 @@ class Libmxml < Formula
   head "https://github.com/michaelrsweet/mxml.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     rebuild 1
     sha256 "a2b4ef33ab0e325d90dc981a1ec1dcc51cc7f655f9dbfdf4d1d22b77f2c485be" => :mojave

--- a/Formula/libomp.rb
+++ b/Formula/libomp.rb
@@ -5,7 +5,6 @@ class Libomp < Formula
   sha256 "f7b1705d2f16c4fc23d6531f67d2dd6fb78a077dd346b02fed64f4b8df65c9d5"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "6c8f66a6582efa00620593e16a41f3649018778a300cc772afbe79c711c2c396" => :mojave
     sha256 "4cc6fd69f1558f29165608c3e52aed88be6c56e3b0da10c9f6912ea3345daf3a" => :high_sierra

--- a/Formula/libosmium.rb
+++ b/Formula/libosmium.rb
@@ -5,7 +5,6 @@ class Libosmium < Formula
   sha256 "4c0fe0146aee20423d9526e88f205fe442257fdf26df19225e2bde6084bad0ef"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "622a61f6e3e28ddc14410739d8a3756c2c430a27390b02659f78f1a6124e9d7a" => :mojave
     sha256 "c3746f309883529af19021e3accc93b3c6a21976303c7812c41ea129cb11f408" => :high_sierra

--- a/Formula/libpng.rb
+++ b/Formula/libpng.rb
@@ -6,7 +6,6 @@ class Libpng < Formula
   sha256 "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "53bbd14cc27c86c16605e256e7646a1b5656c253abca084958c5d80a2961cb01" => :mojave
     sha256 "bbdd94bdd5954bc50c096391486e67265dce5631efb913dcffe4469806a242b6" => :high_sierra

--- a/Formula/libpqxx.rb
+++ b/Formula/libpqxx.rb
@@ -6,7 +6,6 @@ class Libpqxx < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "8f4cdde8aa2ddbe3e8bc52608ab31aca62f259b7271c723555a051871d7a96af" => :mojave
     sha256 "6d57ea59c5a3bb63c85de9211589f127346cb1dca8fc0c9faa6a3c2b802237a4" => :high_sierra

--- a/Formula/libspatialite.rb
+++ b/Formula/libspatialite.rb
@@ -16,7 +16,6 @@ class Libspatialite < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "443cb7ecfdc6b7df7a471e563935acde7c54109851ea0f28c37d76f4f3c84557" => :mojave
     sha256 "d5d2e556d73cd57ce5c9b57492c235cf78ee123f3e2e95259c3b5ba8148efc4b" => :high_sierra

--- a/Formula/libssh.rb
+++ b/Formula/libssh.rb
@@ -6,7 +6,6 @@ class Libssh < Formula
   head "https://git.libssh.org/projects/libssh.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "68027b65dae117340cbaa3b72f09850322b16a11609b4e334d0b2c9d6f4a64c3" => :mojave
     sha256 "c63546c5f5381f26d91e71ffb0c40f9b312534af3fc4548e1c170650be79c0e4" => :high_sierra

--- a/Formula/libtermkey.rb
+++ b/Formula/libtermkey.rb
@@ -5,7 +5,6 @@ class Libtermkey < Formula
   sha256 "6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "efa6360ccb50275ee143410e57b4ff47b2d6bafd97d6f4feeb3cb3ee02050a2c" => :mojave
     sha256 "e3b848de428f811c1879530c043145152bf4b0e599ed642aa2845904d13f7081" => :high_sierra

--- a/Formula/libtommath.rb
+++ b/Formula/libtommath.rb
@@ -6,7 +6,6 @@ class Libtommath < Formula
   head "https://github.com/libtom/libtommath.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "e69fa7fa3b1ff2e85209b6719ad17192942c9d2954321f30b7e039745e4e9ffb" => :mojave
     sha256 "291e7d5f7f5ecace41fc8d9a402f8bb630004700f264339ad013df713f9b33eb" => :high_sierra

--- a/Formula/libxc.rb
+++ b/Formula/libxc.rb
@@ -5,7 +5,6 @@ class Libxc < Formula
   sha256 "a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "f8b5f2dff116944721e2a0f3d9b8de233dd7ed5672a7a5e049be46d479be364f" => :mojave
     sha256 "c3e5f9d0fc66335ce0d246d2ed308b0d1ece555db9a2c877bcbb493813cff9ff" => :high_sierra

--- a/Formula/libxmp.rb
+++ b/Formula/libxmp.rb
@@ -5,7 +5,6 @@ class Libxmp < Formula
   sha256 "353535cc84c8cddae8decec4e65fa4c51fc64f22eb0891bc3dae6eaf25f9cccf"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "d86f0bd86f2cada740f5a87d9f18216b30e2383d9d572200c5a684fd73b8a9a4" => :mojave
     sha256 "642c904938aa1797b3512f3f820283d4104a8153d2b0144003110accdc48a877" => :high_sierra

--- a/Formula/libxo.rb
+++ b/Formula/libxo.rb
@@ -5,7 +5,6 @@ class Libxo < Formula
   sha256 "23885980313c42211610a65004f9f319804f2ff8e94b2e83b04f4920bf45f6cb"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "e9b18845d5b9fb0e5117beb87489d13f1ab387dabdfd71351e200d0283f6a3e4" => :mojave
     sha256 "aa3c710b7b134bcf40d09fe0b2b82c2115bddf2d86ab8c88e5a49e5e084b29cb" => :high_sierra
     sha256 "6de1f36c8ac26b26326393b5bf5be8d7485a72aafd1b8a6b68664c0f34025809" => :sierra

--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -6,7 +6,6 @@ class Libxslt < Formula
   revision OS.mac? ? 1 : 2
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c4881b3aa600bd7e96b799a852782dff5feca9a8c376a6d72038d1c38ea98d71" => :x86_64_linux
   end

--- a/Formula/libyaml.rb
+++ b/Formula/libyaml.rb
@@ -5,7 +5,6 @@ class Libyaml < Formula
   sha256 "46bca77dc8be954686cff21888d6ce10ca4016b360ae1f56962e6882a17aa1fe"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "aa23980d03fe5bd2e60d59424061b7ac91c24f315de84ec33856ab3bf44de0af" => :mojave
     sha256 "b763aa33bfdf6dca21b3bc16919217939ec28916266bb476ff8f44e777bde176" => :high_sierra

--- a/Formula/libzip.rb
+++ b/Formula/libzip.rb
@@ -5,7 +5,6 @@ class Libzip < Formula
   sha256 "be694a4abb2ffe5ec02074146757c8b56084dbcebf329123c84b205417435e15"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "0036272939932029e74982ae3757ddb3e2a671ea3328f80fbc6a61036396a8ec" => :mojave
     sha256 "adede5bd45b75dbbfb5df7ba638688afa3fa7ad71c84b5b238221fb982bed720" => :high_sierra

--- a/Formula/links.rb
+++ b/Formula/links.rb
@@ -5,7 +5,6 @@ class Links < Formula
   sha256 "70758c7dd9bb70f045407900e0a90f1114947fce832c2f9bdefd5c0158089a0a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "05eec8b900896aa68276828e3f03dc9d3877250e7a678ebde34a5cd9282027d4" => :mojave
     sha256 "09445c5dbb1365ea992ef378721bff650e3633fd00355893d68a5d6d26a4bb1b" => :high_sierra

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -66,7 +66,6 @@ class Llvm < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "14029e4108b81fc79afbf125b06075876586fb943af62e1a174ded1786b32192" => :mojave
     sha256 "efce74f9e72bc5f894e40daccd3b7cbeec6e7dc56bb1669d6ac3cbe1f3cfa7fb" => :high_sierra

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -7,7 +7,6 @@ class LlvmAT6 < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     rebuild 1
     sha256 "fa82b34b02759b52cf6d6eab0e41602a1c2b902b8eb94624d30ff0652697c16e" => :x86_64_linux

--- a/Formula/lz4.rb
+++ b/Formula/lz4.rb
@@ -6,7 +6,6 @@ class Lz4 < Formula
   head "https://github.com/lz4/lz4.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "a898c71e6e254a98310ed55d54962685c2c08c181dee12ad5f705083e18c168d" => :mojave
     sha256 "a3e6eac647b6a34547606523e97d004f29cdf3866334d04238bf088340e29a14" => :high_sierra

--- a/Formula/lzip.rb
+++ b/Formula/lzip.rb
@@ -5,7 +5,6 @@ class Lzip < Formula
   sha256 "e48b5039d3164d670791f9c5dbaa832bf2df080cb1fbb4f33aa7b3300b670d8b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "54716b72b43e41cb8d9912fe3f61aeef651f890bf42f8b92482adfd0f2c99798" => :mojave
     sha256 "bfe47a5379c4d793e15d1d71f5f6b12047a486e2531718f31f675683d54df595" => :high_sierra

--- a/Formula/lzlib.rb
+++ b/Formula/lzlib.rb
@@ -5,7 +5,6 @@ class Lzlib < Formula
   sha256 "6c5c5f8759d1ab7c4c3c53788ea2d9daad04aeddcf338226893f8ff134914d36"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "3c28dea3721b03227d660c7c453673d3cb40f00f41e2e4ba3f163a7171926da0" => :mojave
     sha256 "a49b8dfcf257d31c46841a733f1925020dd49493554d049a479467e602e3e796" => :high_sierra

--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -7,7 +7,6 @@ class Mage < Formula
   sha256 "e8fdfa30f68c8a90fcadd4e82f49c9136011accabff55e073ea26f5ee4280cf0"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "8833b1072a45cee90428727a5d12f535ea47c88fad1af229404b9e928eed885b" => :mojave
     sha256 "25e0320d8267416873745b7236ea3744a845e88e42a802039d4d43acc8d29a26" => :high_sierra

--- a/Formula/mariadb@10.0.rb
+++ b/Formula/mariadb@10.0.rb
@@ -5,7 +5,6 @@ class MariadbAT100 < Formula
   sha256 "022620ebeb4fb3744d101e72443ec55b4585e7d9a3d8c92aa846bc30e6808ac1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "a7f0c2b6a8331ec16fd99041ca36a21b2d549f8348bbf5741243f79b81c47891" => :mojave
     sha256 "a583dc308eda30c397b5254a7c2bb1d89607081daac6c272e515e74e1899d3d2" => :high_sierra
     sha256 "31510d6ab60ab73fafc8e079303e755d1a10a0860104236a7a4a84dce8062224" => :sierra

--- a/Formula/mdds.rb
+++ b/Formula/mdds.rb
@@ -5,7 +5,6 @@ class Mdds < Formula
   sha256 "25ce3d5af9f6609e1de05bb22b2316e57b74a72a5b686fbb2da199da72349c81"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "5707c206606cdb5020ae0a2a096396e1bec98e569c7b6316cc8031877a3af038" => :mojave
     sha256 "5707c206606cdb5020ae0a2a096396e1bec98e569c7b6316cc8031877a3af038" => :high_sierra

--- a/Formula/mecab-ipadic.rb
+++ b/Formula/mecab-ipadic.rb
@@ -7,7 +7,6 @@ class MecabIpadic < Formula
   sha256 "b62f527d881c504576baed9c6ef6561554658b175ce6ae0096a60307e49e3523"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "30967b4167d34f05c79f185d71a40198fff4067d0cce82aed59383548c898681" => :mojave
     sha256 "ef5cf167b05fd74457d5c31a46750450e8f80720ebc705766ee10df6ed41a861" => :high_sierra

--- a/Formula/memcached.rb
+++ b/Formula/memcached.rb
@@ -5,7 +5,6 @@ class Memcached < Formula
   sha256 "45a22c890dc1edb27db567fb4c9c25b91bfd578477c08c5fb10dca93cc62cc5a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "5deff247a1bbbdecd0e22ed534a4de8d57fc5a9d5c7dde08763a366c8783b54a" => :mojave
     sha256 "ef7043afc7f9af67793fb428e00ad392bbd5bc028821974dfc09349215a3aa2a" => :high_sierra

--- a/Formula/miller.rb
+++ b/Formula/miller.rb
@@ -5,7 +5,6 @@ class Miller < Formula
   sha256 "d9a7ed10a1a5e71082c33d489f77ab9caba6e6c4f9bf0f6c3958201b64974f7e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "a2a049c66f1a1f3d8bb14a316afa5624c290ddca8a5723417fe7bfb0b682d62e" => :mojave
     sha256 "dfe0d02b8fe42510d2637a6016ac7527b7e7fef981b6677f9171236780ffd05b" => :high_sierra

--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -6,7 +6,6 @@ class MingwW64 < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "3dc78c01bccb499a4c2ecc1a80f25bd2a59267c394fc377443efd4c9204d31a8" => :mojave
     sha256 "49039add961b0c0bd3b2efbfccd7cd5ba861c143fdf9d39a382f4c594caa3c1e" => :high_sierra
     sha256 "c339faff3c3f83b1f640c50633127edbb3f67fdaff02b702c2408727c4190d9a" => :sierra

--- a/Formula/minimal-python.rb
+++ b/Formula/minimal-python.rb
@@ -7,7 +7,6 @@ class MinimalPython < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "f0fb1887b88e5aa46ed6171a2501b0b9a5a16ac13a532b858b8f27c4e60114a8" => :x86_64_linux
   end
 

--- a/Formula/mmark.rb
+++ b/Formula/mmark.rb
@@ -5,7 +5,6 @@ class Mmark < Formula
   sha256 "fa64a7321ff8cc531a0caa36af2a72057c5bebd634b623407b9d6415e7184003"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "64668c943a366014740e8fb017fc7e6735454c1ba8d0314f8f618725d8d8a531" => :mojave
     sha256 "a77f99cc9523aeef1d1c0b55dccd094e5afa81e32444339a00432ef2c0029fce" => :high_sierra

--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -6,7 +6,6 @@ class Mmseqs2 < Formula
   sha256 "2890a748b38ed1a04d98c2197b11bac6b50c1329313b6218ba2f53aeb6c5e874"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "681f2f8d6ff749a72eff0f8d05a8bcf840941c8146ef26e976e78de65564a440" => :mojave
     sha256 "61c186285e1aeef7720fd770f870a452d1ec74fb8fefbf64ec043181fee0aa98" => :high_sierra

--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -6,7 +6,6 @@ class Mosh < Formula
   revision 5
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "70ca7ccdb7df9a452d9968cbf5b6da4f9fb3be7cb5c175ab5117b1e4cff7b985" => :mojave
     sha256 "9ea48721b704ca8a2d14c285c406a6d74e549f1b0e3ef46c39483ff4ac50f530" => :high_sierra

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -7,7 +7,6 @@ class Mpd < Formula
   head "https://github.com/MusicPlayerDaemon/MPD.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "e1814d5b120bd4ea5e1e8527822cb209597aca1fc6cf0664c68829e4ef2032a0" => :mojave
     sha256 "d3fad4a4ecfdf1737ffcaf939249f61d0dae9ad692cecc659b596f2a35f50d61" => :high_sierra
     sha256 "108282ab78e05ea808b14c9f3f6b6630d1b17cc99892ad8011c387724d2df709" => :sierra

--- a/Formula/mpfi.rb
+++ b/Formula/mpfi.rb
@@ -5,7 +5,6 @@ class Mpfi < Formula
   sha256 "2383d457b208c6cd3cf2e66b69c4ce47477b2a0db31fbec0cd4b1ebaa247192f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     rebuild 1
     sha256 "55d8819c0310e6b8bc66742f7ab5881b9b552a9c60eaf940595ed08e8a320a56" => :mojave

--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -6,7 +6,6 @@ class Mpfr < Formula
   sha256 "1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "cfce7ab866e98360c9364cd924da620ae7936d3a224d686aacc209c2107d19aa" => :mojave
     sha256 "bf5d21e7e8e549f7e8d07791a90f44a487f4c7151897b7c64d02928b5bd73520" => :high_sierra

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -7,7 +7,6 @@ class Mpv < Formula
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "a91d2f0d616a23d37308c5a0c1f4902b07eec44f2eb6619c285044d3e4bb0124" => :mojave
     sha256 "27b27bc1bfe887f696b5c625dc5ac5dab5806a02cfa6104be1214e1eb6d3ec53" => :high_sierra
     sha256 "61471c7206414f25b4c23da82b239197000d4d94104fdd51e0893e07d44b8737" => :sierra

--- a/Formula/mruby.rb
+++ b/Formula/mruby.rb
@@ -7,7 +7,6 @@ class Mruby < Formula
   revision 1 unless OS.mac?
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "3279a9fe511530c4fe0a56323efcbfd555d2fa981204a0d1595f0365f56cdd59" => :mojave
     sha256 "3e808c9c9a25a98a20a8af26a369bf688db7c9a635e3ae52836e2eda0e42b442" => :high_sierra

--- a/Formula/mvtools.rb
+++ b/Formula/mvtools.rb
@@ -6,7 +6,6 @@ class Mvtools < Formula
   head "https://github.com/dubhater/vapoursynth-mvtools.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "38a737a0f57228a8feafd128cf5124cb563a1579396943c5f3ae28716922ddc9" => :mojave
     sha256 "ddc7826a71b5c15138526db3857afbf16cda335c7037236bd2abe35035c9bcc9" => :high_sierra

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -5,7 +5,6 @@ class MysqlAT56 < Formula
   sha256 "1c95800bf0e1b7a19a37d37fbc5023af85c6bc0b41532433b3a886263a1673ef"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "a1eb58101bd7a6897da03abf98c3ce9eb6c964f25871da6fa363f0118b1fd5bf" => :mojave
     sha256 "690cd67c744f052a37b2a5a35131939a068b590f033ce32232c5bce862d7780a" => :high_sierra
     sha256 "0ee74b3db712bd7fcceb3f62e3538f3bb12d8e31a9eb5398e3be7a9fd4000320" => :sierra

--- a/Formula/ncompress.rb
+++ b/Formula/ncompress.rb
@@ -6,7 +6,6 @@ class Ncompress < Formula
   head "https://github.com/vapier/ncompress.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "ee109f0c632bb97ab6dd85f8f73c526b36becc9e30e003fcc67f32e09d4e9d5b" => :mojave
     sha256 "3f58c3e47a34c1720a0e082c242ca9f57c75a56121b8a79bcf6f2d4a1303c6e8" => :high_sierra

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -6,7 +6,6 @@ class Netcdf < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "d798cbc16c2e6c312d921abf4cef0d74f094c9f6496114c06219baabaa962974" => :mojave
     sha256 "0307831230fe41037beb09e9434d587497dc246ad4c0eb083e603efa4d5fbbec" => :high_sierra

--- a/Formula/ngspice.rb
+++ b/Formula/ngspice.rb
@@ -6,7 +6,6 @@ class Ngspice < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     rebuild 1
     sha256 "ad1218af03e9711b74cbf8919b8ef9c77ec216ee43d40648423c5043f4feb393" => :mojave
     sha256 "1241cc934814f62c3abcc148817b1eb10ec84db5a7ec65c7d0f5316e4bb7f831" => :high_sierra

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -7,7 +7,6 @@ class Ninja < Formula
   revision 2 unless OS.mac?
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "d3f825237b23175d46ed02f492df8297968f3ce45f328362f167caf962323c98" => :mojave
     sha256 "c6057431959eb3117f5eca1bb62d2403d189f3091f2cacaef89c9696b2ecec39" => :high_sierra

--- a/Formula/nkf.rb
+++ b/Formula/nkf.rb
@@ -6,7 +6,6 @@ class Nkf < Formula
   sha256 "d1a7df435847a79f2f33a92388bca1d90d1b837b1b56523dcafc4695165bad44"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "85183c457daaecd9a3ce59cea556189ad0131c6134d77e7890643a3fb75e3965" => :mojave
     sha256 "9af47f293d4531c8d7ec5a81bd041349773f982b9710edca03eb3eb59b02a8b5" => :high_sierra

--- a/Formula/node@8.rb
+++ b/Formula/node@8.rb
@@ -5,7 +5,6 @@ class NodeAT8 < Formula
   sha256 "3515e8e01568a5dc4dff3d91a76ebc6724f5fa2fbb58b4b0c5da7b178a2f7340"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "db34802888005a1fea191c94506db90a0f9e9cafa977b67646f1c7d1c8410cd5" => :mojave
     sha256 "2a2843b99c78bf29e693c71cec059683c524cfe6faca4cc1771610288d07c017" => :high_sierra

--- a/Formula/nspr.rb
+++ b/Formula/nspr.rb
@@ -5,7 +5,6 @@ class Nspr < Formula
   sha256 "15ea32c7b100217b6e3193bc03e77f485d9bf7504051443ba9ce86d1c17c6b5a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "df7f55099d7210f68306857a154677cfffe0bfc03a782674c8424a8f1dfe4e5e" => :mojave
     sha256 "4ebdabe6497e0f587aa034628469de65b57e7eec1450f7f580474f1a44c18078" => :high_sierra

--- a/Formula/ntl.rb
+++ b/Formula/ntl.rb
@@ -5,7 +5,6 @@ class Ntl < Formula
   sha256 "84ba3145abf8d5f3be6832a14c60b3368eb920719ee96e5774587e71ecd66e9d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "5a54ada102a07c107ff8b08f1995230cf977f6770552e16529dbb188f272ee11" => :mojave
     sha256 "0e55147c25186a9f5f5d22c47855570de07d7d5bd2eb1b9d4b0276b75dd31808" => :high_sierra

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -5,7 +5,6 @@ class OcamlFindlib < Formula
   sha256 "2b7b7d6d65bb0f3f8a2c51c63c02b0bcf1fea4c23513f866140dc7dc24fe27ad"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "6399780e078bca007730b218f4561ef4a513ba2296230aca2bcd9b6cfc75ea98" => :mojave
     sha256 "8c2e25008b18bde6fdbefacf85397ecd93a2b916d98c1e1954532509abbfd756" => :high_sierra
     sha256 "16682aa54745337c9aaae81fdd22000831c2b85b021250c6d4112fb94ab918a1" => :sierra

--- a/Formula/ocamlbuild.rb
+++ b/Formula/ocamlbuild.rb
@@ -6,7 +6,6 @@ class Ocamlbuild < Formula
   head "https://github.com/ocaml/ocamlbuild.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "5bc4b5c08dc6bb9b5ed2fedff2de70870ca2400ccaf1002ac8919ad26181a4ee" => :mojave
     sha256 "0b9fe3df0844b3c7f276e595b75b609611e55be4efa080dc2be10586630dea67" => :high_sierra
     sha256 "78f4e83ddb5c5727047f2ed027706c70a76ff16004e24a4c35efda6239175a99" => :sierra

--- a/Formula/oniguruma.rb
+++ b/Formula/oniguruma.rb
@@ -5,7 +5,6 @@ class Oniguruma < Formula
   sha256 "db7addb196ecb34e9f38d8f9c97b29a3e962c0e17ea9636127b3e3c42f24976a"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "c613befafe81da48913ebd1a7eb036a7d8a147516fae32e2fbf4278efdb34056" => :mojave
     sha256 "ea9b09c3567f1315153e44245ae033bb0d101b2c59cd6af304073c8b120e874c" => :high_sierra

--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -6,7 +6,6 @@ class OpenMpi < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "f7c495b7015a86f61cbc44c5788912d919e5bdd70b13160b0a94e4d07f892f69" => :mojave
     sha256 "6660708bc834553df9cda635ea590ad5e30112af7aa522e33c78b4655105901b" => :high_sierra
     sha256 "ecd525d18b89900646a4bbe161760830ad84ad2c9d4ca3afcb9f8855a692c5f1" => :sierra

--- a/Formula/openblas.rb
+++ b/Formula/openblas.rb
@@ -7,7 +7,6 @@ class Openblas < Formula
   head "https://github.com/xianyi/OpenBLAS.git", :branch => "develop"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "ce1788eedcf1776fcad04ae78cb81e7141e7db07762dafb44118c9cfb7748de0" => :mojave
     sha256 "50d5f9b0eae2a5b3c97c4a5adb23cd9d7a8e78c2dee9b7a8ea789185aed64b1e" => :high_sierra

--- a/Formula/opencolorio.rb
+++ b/Formula/opencolorio.rb
@@ -6,7 +6,6 @@ class Opencolorio < Formula
   head "https://github.com/imageworks/OpenColorIO.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "c672c422e3d7b9559acf9925c0c6529fee5caee63083d74c78e9ac70b64a1b31" => :mojave
     sha256 "ebc3541bd070af3a7c5ccee3b858fa37e20ef10ffec611130e24bb3676c180d4" => :high_sierra

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -6,7 +6,6 @@ class Opencv < Formula
   revision 2
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "3be6de71c28077e5279ffb0104729b0cef1267f81908e6ea0fb404fb81d913e6" => :mojave
     sha256 "ac383a5029e4ebec4a0695d8e27c95afc449609de3cc83840f9e11ec64f0b4d9" => :high_sierra
     sha256 "7f134df27e2f8a0ea59273bbb2cae3ce9e6070fa02cd5e125e650a3968f5af0d" => :sierra

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -6,7 +6,6 @@ class OpencvAT2 < Formula
   revision 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "58275354d07bd2721862f309460ba35dc40ae254398cbb547a9433d73f39c568" => :mojave
     sha256 "b3535abd6e68488da494dcfd012a0fafbd8efd11d6f7da079bc94cede0fe4780" => :high_sierra

--- a/Formula/openexr.rb
+++ b/Formula/openexr.rb
@@ -5,7 +5,6 @@ class Openexr < Formula
   sha256 "fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "111658d105dc894ea67e1fdc98597c73c1bf1fa64ac52f1287372ded53a1cdab" => :mojave
     sha256 "5673dfdc40bfc3f3495ec2fcff9ea5d5b65b244940f5bf686f79b838b97fdf3d" => :high_sierra

--- a/Formula/openjpeg.rb
+++ b/Formula/openjpeg.rb
@@ -6,7 +6,6 @@ class Openjpeg < Formula
   head "https://github.com/uclouvain/openjpeg.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "6de317bfef3ab808ff5f3eb9c1aa47f77e7236fba8ad0d606b29b38eb47c321e" => :mojave
     sha256 "1eb8b2f698ecf16196e06a2d9f7ba20eb7f0ba447d351e36eb3344d3ed6c5c58" => :high_sierra

--- a/Formula/opus.rb
+++ b/Formula/opus.rb
@@ -5,7 +5,6 @@ class Opus < Formula
   sha256 "65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "787bf9b6d56f63cc3d0cf0f7f17affeb85b6496b32bf9a200f57431c886ae4a5" => :mojave
     sha256 "187884409b33deb371002701b6ffb790c1832fecbe6b8e79e437039dae87aff8" => :high_sierra

--- a/Formula/osm2pgsql.rb
+++ b/Formula/osm2pgsql.rb
@@ -7,7 +7,6 @@ class Osm2pgsql < Formula
   head "https://github.com/openstreetmap/osm2pgsql.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "0ebba50375c8d63d13db3e8d1dc2b326d5099758f272c6fd5216be6497bba2ae" => :mojave
     sha256 "2ad65d522d094b6b9b742bca379d66f9999658050efbb19f1ad79fafbb1f823d" => :high_sierra
     sha256 "59fa881b0b8e0f1f0c542881814f21896d676bdcf6ab71c823f1676b0432be87" => :sierra

--- a/Formula/osmium-tool.rb
+++ b/Formula/osmium-tool.rb
@@ -5,7 +5,6 @@ class OsmiumTool < Formula
   sha256 "f0a75ce39ac92c43a01d978c1ecae05d864930bf7d518ea059d7ba320735dd66"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "7005a84bc3c481fa61a4279da2314e2a11f136c942f6d344206fcc3cd6544687" => :x86_64_linux
   end

--- a/Formula/pacapt.rb
+++ b/Formula/pacapt.rb
@@ -5,7 +5,6 @@ class Pacapt < Formula
   sha256 "ff59e9b1a5f049b7c5d8c309d99829a014d095153b453b03f6ab83dd96a538f1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "572ec7a9d8ff9a4401901f686e12a80755d41445096255874b638f6985805d6f" => :mojave
     sha256 "572ec7a9d8ff9a4401901f686e12a80755d41445096255874b638f6985805d6f" => :high_sierra

--- a/Formula/packmol.rb
+++ b/Formula/packmol.rb
@@ -7,7 +7,6 @@ class Packmol < Formula
   head "https://github.com/leandromartinez98/packmol.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "cf9e09622c5693667366b71ac09c0a1dcde7a66994ec5fecaae93c4187032667" => :mojave
     sha256 "7dbe01c4cf358d1183fcb8ca26e8289c20f8abd6ce04f078471eb34c65a0b204" => :high_sierra

--- a/Formula/pandoc-citeproc.rb
+++ b/Formula/pandoc-citeproc.rb
@@ -10,7 +10,6 @@ class PandocCiteproc < Formula
   head "https://github.com/jgm/pandoc-citeproc.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "021d2219b634ae4e613e11b5a459988c5b89916b494b8daf5189aa16612d12a4" => :mojave
     sha256 "414a220656a182ee9add047099021969f7a0c444dec715e827b8e5ec9710782e" => :high_sierra
     sha256 "c140d93c9252aecdff4fa65879badc085de47e1efbe728362a73ee9db471d48d" => :sierra

--- a/Formula/paperkey.rb
+++ b/Formula/paperkey.rb
@@ -5,7 +5,6 @@ class Paperkey < Formula
   sha256 "a245fd13271a8d2afa03dde979af3a29eb3d4ebb1fbcad4a9b52cf67a27d05f7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "894ef3339013be6574f736e316c61cbf54fbc3dcac358df14f1d54b1d7387854" => :mojave
     sha256 "82e49c6aa559a349ce73521a90881acb74a540de03d355ad7461c177d00bb8e8" => :high_sierra

--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -6,7 +6,6 @@ class Pcre < Formula
   sha256 "91e762520003013834ac1adb4a938d53b22a216341c061b0cf05603b290faf6b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "08e7414a7641d1e184c936537ff67f72f52649374d2308b896d4146ccc2c08fe" => :mojave
     sha256 "0389911a93a88efd4a69b52dea8ecb872fdb55bcfff45d2f7313be5f79730861" => :high_sierra

--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -6,7 +6,6 @@ class Pcre2 < Formula
   head "svn://vcs.exim.org/pcre2/code/trunk"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "fb30c3eebba4483a10378bc8df52f96761fed4a1ac5572ad1bf4afbf2f8638c5" => :mojave
     sha256 "26b34cf7a846d49cdbdefa853227d7d4b02d6bd97c59dacdb0fb9dcf155444b5" => :high_sierra

--- a/Formula/pgloader.rb
+++ b/Formula/pgloader.rb
@@ -6,7 +6,6 @@ class Pgloader < Formula
   head "https://github.com/dimitri/pgloader.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "38db7f6a7695e08463a32172d9b31a14766fbfe8c7aaa4c552c9336537be6d5d" => :mojave
     sha256 "3d569cdcdc3a27a6a0401582dd09b21aecf2032ec13e6df29d7f92c087857e84" => :high_sierra
     sha256 "d4f9b42c3ec8d2794b887d659e7da03390f799cbfcbca0defa6c5387a6dbe00a" => :sierra

--- a/Formula/pgweb.rb
+++ b/Formula/pgweb.rb
@@ -5,7 +5,6 @@ class Pgweb < Formula
   sha256 "e475973e7c1287905b3d2c26be9b9a11609cd05a088af77ef604823389a3d7ab"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "54d9b58164e36731378ca6bed6f5e78fc80a5484d598d5d6897927ccbb787fad" => :mojave
     sha256 "81b6f85babd2c22d092db1065e341c902834381d8e46583f1378c0d2974db062" => :high_sierra

--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -6,7 +6,6 @@ class Physfs < Formula
   head "https://hg.icculus.org/icculus/physfs/", :using => :hg
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "cb97a3a17728f3173d4c19fde495cffbddce965bbf6015e45882e3c27f267cf3" => :mojave
     sha256 "296927566472c976a578f89c4bd6bf0f518427a53d586499a8e202896d469ee3" => :high_sierra

--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -5,7 +5,6 @@ class Pilosa < Formula
   sha256 "5e0040b7605cae3ebf2b617d472e7c104ad026982ba52e83f8b0593b32b6fa05"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "36b8c8e39db4de4e18698e139d709166ef5ff09ef64c0e007f63b31bf11ce14f" => :mojave
     sha256 "45ed3cc1e4ce0d1d30b4492bf1f997eb21f31c074ef4d59ac46728d0563e23bc" => :high_sierra

--- a/Formula/pixman.rb
+++ b/Formula/pixman.rb
@@ -5,7 +5,6 @@ class Pixman < Formula
   sha256 "da66d6fd6e40aee70f7bd02e4f8f76fc3f006ec879d346bae6a723025cfbdde7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "3990b771ee29451c8a9bcb6cb077205ae08adc0d5af2faebf29197d13c36a51a" => :mojave
     sha256 "d383ddee57685391ea55033e6fccdca0352a898cbc4c75be40d7b5dc7c312916" => :high_sierra

--- a/Formula/plotutils.rb
+++ b/Formula/plotutils.rb
@@ -7,7 +7,6 @@ class Plotutils < Formula
   revision OS.mac? ? 1 : 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     rebuild 1
     sha256 "96a618ea8123f08d676b0db38c1c3b93dc8f707c742e97442b74650c2dd8e4c5" => :mojave

--- a/Formula/plzip.rb
+++ b/Formula/plzip.rb
@@ -5,7 +5,6 @@ class Plzip < Formula
   sha256 "edafae3c15142ac0ebd84c2231ff81da4f68db58359a737e750f2780686c3612"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "3e266c42c66babd4fbdfe82645ab876fc7224846e94b26a39183c57404e17c35" => :mojave
     sha256 "0a5df85c11e9afb266709a907980424cd60f1d1fd3adda71e8b0f9939ddf72a7" => :high_sierra

--- a/Formula/polyml.rb
+++ b/Formula/polyml.rb
@@ -6,7 +6,6 @@ class Polyml < Formula
   head "https://github.com/polyml/polyml.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "7d004ce1e0cd9920cc0d66a690be780e11365f8725bbfaa68222ddf324d1d0f8" => :mojave
     sha256 "11835db3f5848077c9b0e6af52bceffaf4c356892c9e3dc795976bcf9711a06b" => :high_sierra
     sha256 "b3dd5bae8d8cef36c6258c2620a4ae894a7a1c66fe56330c48e19a1f81aa66d9" => :sierra

--- a/Formula/primesieve.rb
+++ b/Formula/primesieve.rb
@@ -5,7 +5,6 @@ class Primesieve < Formula
   sha256 "ff9b9e8c6ca3b5c642f9a334cc399dd55830a8d9c25afd066528aa2040032399"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "c932276f2380adb0931435638641dcce166d2ab542ec7254a6fc4257b9b2f259" => :mojave
     sha256 "799b34ea32419dd37598adeaac9b6b779351cfd91a3dba99c122ba3b518e5a04" => :high_sierra

--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -6,7 +6,6 @@ class ProtobufSwift < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "bae411c98ef6433579d163c3768da147faa3f467dd9c194c1de0edc57fbc1863" => :mojave
     sha256 "ac056837e13336ab4a19148fcba9638b2598409ef81eb7fda97f8db3b4bca573" => :high_sierra

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -7,7 +7,6 @@ class Protobuf < Formula
   head "https://github.com/protocolbuffers/protobuf.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     rebuild 1
     sha256 "410f34fc3240dc94c16bf74e3317b56d987acddc361228c03e6b10e8373588fb" => :mojave
     sha256 "cb0e47a0eaa45e5237eab16fec5cc1efb00c531d51484aefceb9a19d6c686f61" => :high_sierra

--- a/Formula/pumba.rb
+++ b/Formula/pumba.rb
@@ -6,7 +6,6 @@ class Pumba < Formula
   head "https://github.com/alexei-led/pumba.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "247794d0ef37e5eb999c989e0e8c5fb3bf8f2b61ec35e93b94321cbff5c2b79a" => :mojave
     sha256 "72f425c3c11e1c08da7485cf6f7db1d771a2f914f342f4f61f0d273e12fc9b8e" => :high_sierra

--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -10,7 +10,6 @@ class Purescript < Formula
   head "https://github.com/purescript/purescript.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "ffe0e6ec4234b1c57ed36f6a5de31bb06e05b7c01a25a4667880a7295837cc7d" => :mojave
     sha256 "c68dc6a3d29335c469dd96649f490a3f8b8af267e86ba0740ceb5da3556a8122" => :high_sierra
     sha256 "587f83a8e1ba6acd493bb82b75413d155cd7e8afd22d355c539eafe7b7bc2958" => :sierra

--- a/Formula/py3cairo.rb
+++ b/Formula/py3cairo.rb
@@ -5,7 +5,6 @@ class Py3cairo < Formula
   sha256 "70172e58b6bad7572a3518c26729b074acdde15e6fee6cbab6d3528ad552b786"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "c3d966320ca66c24c01fa3dd2dd867329e9b6d817895fc5466b8280ea806d093" => :mojave
     sha256 "f285ea47d9693b403080decdc94c0ae60364ec554c44a61473480ca0f420ebc3" => :high_sierra

--- a/Formula/pygobject.rb
+++ b/Formula/pygobject.rb
@@ -6,7 +6,6 @@ class Pygobject < Formula
   revision OS.mac? ? 2 : 3
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "caf4b79e8454b58bb67e73a6f06853d7a410c1fa9b31478c6ac389424ca690bb" => :mojave
     sha256 "04550d558f335fd6431ee3c124ba19011ec4284e7584eff343ad6b78483472a5" => :high_sierra

--- a/Formula/qd.rb
+++ b/Formula/qd.rb
@@ -5,7 +5,6 @@ class Qd < Formula
   sha256 "30c1ffe46b95a0e9fa91085949ee5fca85f97ff7b41cd5fe79f79bab730206d3"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "219d016113bc23c78c0d41e5e8348bca0513a1c58aa3f3b3c589c60bb5543a5d" => :mojave
     sha256 "d5b003dd1d1fcfb17072ee7c7dcaea5509b9560c76fa9dd70a8777abf4c109db" => :high_sierra

--- a/Formula/qrupdate.rb
+++ b/Formula/qrupdate.rb
@@ -6,7 +6,6 @@ class Qrupdate < Formula
   revision 10
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "cbaca0a12ab0f6527739e37a9100b82e3aaa5b35760739e679395dbfd63dca44" => :mojave
     sha256 "fee484380157553a368f516ad9b8cbe01be53bca3bd20068a0d255c33d8ccf94" => :high_sierra

--- a/Formula/quilt.rb
+++ b/Formula/quilt.rb
@@ -6,7 +6,6 @@ class Quilt < Formula
   head "https://git.savannah.gnu.org/git/quilt.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "5d7f412108ec8831b8b6bfbc8e41d8b577523ffd66f9d095853a4680ec23b04f" => :mojave
     sha256 "691a01a091194910f0848aea529b331559fb98d44e9821c1ebafba51d2a2d62c" => :high_sierra

--- a/Formula/rakudo-star.rb
+++ b/Formula/rakudo-star.rb
@@ -5,7 +5,6 @@ class RakudoStar < Formula
   sha256 "640a69de3a2b4f6c49e75a01040e8770de3650ea1d5bb61057e3dfa3c79cc008"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "0254663db2347c6002b4402ddbb7ed64bf29068b15e196e6fe011e9b027081ee" => :mojave
     sha256 "dd67fdfc69505bae6b7e1a30f5c6908bba312e3673ca81c415d3a626387ed8be" => :high_sierra
     sha256 "773b28e24f2893e23307c818b49f8517a6fb4a3af3be4eee468e4c2e1ff70555" => :sierra

--- a/Formula/rancher-cli.rb
+++ b/Formula/rancher-cli.rb
@@ -5,7 +5,6 @@ class RancherCli < Formula
   sha256 "b41bf4637c9df174a6a9d813eeea5b60c9b407dfcea379a5112097393d416052"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "88afc29ccbe080da761bee57ee5b80c1a1f300cba13447b87c0cad577ad349bf" => :mojave
     sha256 "1cb11955d2e394ae1732c0444b2de52c5a1d91252761e0e0b26f55f972a52b81" => :high_sierra

--- a/Formula/rbenv.rb
+++ b/Formula/rbenv.rb
@@ -6,7 +6,6 @@ class Rbenv < Formula
   head "https://github.com/rbenv/rbenv.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "d1019098dee8d037587069398e5ad04e6d736f834dc44ae73943bec46b10b260" => :mojave
     sha256 "b5984102794a9d39388ca1f6ec77965aeea29b971cc00cb5af8ede8ee6c926d6" => :high_sierra

--- a/Formula/recoverjpeg.rb
+++ b/Formula/recoverjpeg.rb
@@ -5,7 +5,6 @@ class Recoverjpeg < Formula
   sha256 "db996231e3680bfaf8ed77b60e4027c665ec4b271648c71b00b76d8a627f3201"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "89bd9fe522bc64508a3c2925edda2a3ae3cfc32e7ff59f7e70eb1069352129b2" => :mojave
     sha256 "ce460e293cc4c4c5bf3650cf9860e7b06654017473c414dc88c1df9d82e8466e" => :high_sierra

--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -6,7 +6,6 @@ class Redis < Formula
   head "https://github.com/antirez/redis.git", :branch => "unstable"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "eb5538dadb10570c5a8aa9e8aafa5d21b7747e7597c92954916b9b6ca55ae407" => :mojave
     sha256 "e9de9e750d86c5f63ea3e60cd75fbdf9f8162494938ed14616a2dc4490577558" => :high_sierra

--- a/Formula/reprepro.rb
+++ b/Formula/reprepro.rb
@@ -6,7 +6,6 @@ class Reprepro < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "0fe440a480fa2c723af48142ca77b2cc5fb733ba5e20c011f90c11a0a1f221a0" => :mojave
     sha256 "dfeae3f34e3cf85ed2a5242f2b692a647935b78bae036398e02595448eb82e69" => :high_sierra

--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -6,7 +6,6 @@ class Ripgrep < Formula
   head "https://github.com/BurntSushi/ripgrep.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "db7aa040d1dace4cc4225493ca37802cf7c3769b26e3ed0d1cdd32780aeda252" => :mojave
     sha256 "d205bcd983c83ec1097523502d44598b844c3a13760e88449cd05b34e0ceba77" => :high_sierra

--- a/Formula/rst-lint.rb
+++ b/Formula/rst-lint.rb
@@ -7,7 +7,6 @@ class RstLint < Formula
   sha256 "4bf9d4724f59bc05ebe1cd5192c03d4597ee95c4bbf60bd5644422e1a2558da3"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "6141abff3561e93a197148e81d2c0634a3665f41beabb4a5bbf92bb0355ce270" => :mojave
     sha256 "377505a302c81418df15ab1a29723a0b4572d78e7a8bb984a33bd57daf352fbd" => :high_sierra

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -5,7 +5,6 @@ class Ruby < Formula
   sha256 "11a83f85c03d3f0fc9b8a9b6cad1b2674f26c5aaa43ba858d4b0fcc2b54171e1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "56630571e08b65c422073d54458db4f338be7a707a572173f51e964fcc611f3c" => :mojave
     sha256 "52face1cf238072f1964cb6ace624510008857c645dee162ad0b60a138b6c136" => :high_sierra
     sha256 "e43742f0a29eff33122a484ee06d58b9ac236a7013fd972b1e4c47dc3acb9e82" => :sierra

--- a/Formula/s-search.rb
+++ b/Formula/s-search.rb
@@ -8,7 +8,6 @@ class SSearch < Formula
   head "https://github.com/zquestz/s.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "04281fb66e28cf23c3ea1cd23ec6286432191fde31ac8c7b6c9c13bc6b365b0a" => :mojave
     sha256 "4a0c5595943e8b7b4892ff3caf4d03b29533405a411268a77e0a51272a3d7823" => :high_sierra

--- a/Formula/salt.rb
+++ b/Formula/salt.rb
@@ -9,7 +9,6 @@ class Salt < Formula
   head "https://github.com/saltstack/salt.git", :branch => "develop", :shallow => false
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "34e1a591055346fe0d3a34e7d857fde0cd8e4ea6abded8e13500282f0993c340" => :mojave
     sha256 "f7e521f883eca1584d91317e0afb0dd0f410fb0190cb3db05f13030d6732ba6d" => :high_sierra

--- a/Formula/scalapack.rb
+++ b/Formula/scalapack.rb
@@ -6,7 +6,6 @@ class Scalapack < Formula
   revision 15
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "5145405aea16d22bc8aa4672fbda2cf9b5ad98a89c4704c0ab2c7d4d94af154e" => :mojave
     sha256 "a18a1dce08bc8f7114143e35fea3aa9d3bbab7ff92c368664ae00083352ebc83" => :high_sierra

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -6,7 +6,6 @@ class Scipy < Formula
   head "https://github.com/scipy/scipy.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "6ba4af97b345fb1b95db42eafc9b5a89af45c2da60734b4d317daba2f93bd2f2" => :mojave
     sha256 "02c6c92cb694c7c1c493e4c309043f104538366dc2813c180d4def06d28892c6" => :high_sierra
     sha256 "9d3f6843a954b1b525af1deb5a0e66cd9b9e0ee377d4435ddd6bd602a68cb862" => :sierra

--- a/Formula/scw.rb
+++ b/Formula/scw.rb
@@ -6,7 +6,6 @@ class Scw < Formula
   head "https://github.com/scaleway/scaleway-cli.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "57a21449714df68f713fba876e8c2b4a62de751fd48cd51c15b5109d4a6fb74f" => :mojave
     sha256 "f292e2359a0f203d78598f08c36c333a7e418bdd2da019dcb12b4a662b1d2e36" => :high_sierra

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -6,7 +6,6 @@ class Sdl < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "28bfde74acbd1e68c0c2600d0bef4ebe7baf089f62f957779deb2c5dc0df2dd9" => :mojave
     sha256 "115af7ed86433a36baf4ca221bf19a7a61059fb6c2e55ae3d499fd7cdc2854bc" => :high_sierra

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -19,7 +19,6 @@ class Sdl2 < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "73dc083fe09bef54cdd08d6e1d86fba67172bc7bda4886e410d3e72fe5ab1c32" => :mojave
     sha256 "eb6b0eb77c69f111c67f48962699e5b237eab26c3a49f8f46bf59bfa241839ab" => :high_sierra

--- a/Formula/securefs.rb
+++ b/Formula/securefs.rb
@@ -6,7 +6,6 @@ class Securefs < Formula
   head "https://github.com/netheril96/securefs.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "07605d0d88a95902f1ee39d88c56dceadcacdf6e61a71431f68cdbf97003c848" => :mojave
     sha256 "e0a3b66b2dd99a8cd2a6f79b4fe537875c55aa240f7383bef450b008fff6dfff" => :high_sierra

--- a/Formula/serf.rb
+++ b/Formula/serf.rb
@@ -7,7 +7,6 @@ class Serf < Formula
   head "https://github.com/hashicorp/serf.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "692266b0fa6ba7a7772849938ba42dc9246d1f117a216bdcb8bd1a130181a814" => :mojave
     sha256 "979604efa2ecf8c34e88d7060c84ffb003fe9eeafd26871bbc3cc94a77e0eede" => :high_sierra

--- a/Formula/shapelib.rb
+++ b/Formula/shapelib.rb
@@ -5,7 +5,6 @@ class Shapelib < Formula
   sha256 "1fc0a480982caef9e7b9423070b47750ba34cd0ba82668f2e638fab1d07adae1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "90f9b9b0ccadf93be027e515be356d0b92f4dfb33979f11df9fc7570c3249d0e" => :mojave
     sha256 "f1242aaf566b272f69331d16441171b12d0b4cef8396b56e0a8246fe7618ca68" => :high_sierra

--- a/Formula/shfmt.rb
+++ b/Formula/shfmt.rb
@@ -6,7 +6,6 @@ class Shfmt < Formula
   head "https://github.com/mvdan/sh.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "15b43658df24bf448ab0d3373ee75ab6e6af1e101ae684019fd9830a169fc48c" => :mojave
     sha256 "c18cccddb9678d23261c99b8a9870bc8ac98c74a332f6263eff670561f620a7a" => :high_sierra

--- a/Formula/shmux.rb
+++ b/Formula/shmux.rb
@@ -5,7 +5,6 @@ class Shmux < Formula
   sha256 "c9f8863e2550e23e633cf5fc7a9c4c52d287059f424ef78aba6ecd98390fb9ab"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "e433bd14622d3f77a35042649d0d73e888b164ab4f04431864fb68c9ec64b62c" => :mojave
     sha256 "bc38ad3a6feddd116edd9d3ab00ac18bc6663d08b9d111414975bdd1543d1b79" => :high_sierra

--- a/Formula/shyaml.rb
+++ b/Formula/shyaml.rb
@@ -8,7 +8,6 @@ class Shyaml < Formula
   head "https://github.com/0k/shyaml.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "6aa2db7ebec7ea9a269c90e6c63491bad0f419570790b717ce4e6db3e382ea74" => :mojave
     sha256 "a985968768985ec82d27b9b2e4d409fe965a1b610e12f31086175417eafa8ffb" => :high_sierra

--- a/Formula/singular.rb
+++ b/Formula/singular.rb
@@ -6,7 +6,6 @@ class Singular < Formula
   sha256 "b520809ce061059081a973d4a3b102b05863d49c20565d03f638ba5146296d4f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "20523ce9de4f5b0785093b9feffcbc7f80b011aca893e83ea80d5896e2300892" => :mojave
     sha256 "c23b5d7053a5f1ff939b20bd43fa29e8a2381c884d58b1e03f3e0a089d5f352b" => :high_sierra
     sha256 "ae11ffa3c011fc42916658e246a2d1d1a3f54ea8c7a181327265ba0585ac4e0a" => :sierra

--- a/Formula/sipsak.rb
+++ b/Formula/sipsak.rb
@@ -5,7 +5,6 @@ class Sipsak < Formula
   sha256 "e07f32e692381d9db404d75868218b553e0aba414d35efc96d13024533a53f0f"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "20c81bc83de9456d6bef1a04e2782c8c0a4898151f063c716077f7159a5dff24" => :mojave
     sha256 "908c57962d3cc43847b4048db06a291437756fd8da691a7703f5285776fd2d78" => :high_sierra

--- a/Formula/slackcat.rb
+++ b/Formula/slackcat.rb
@@ -5,7 +5,6 @@ class Slackcat < Formula
   sha256 "e5c8f98f3048cccc3f8e49c0449435a839a18c7f12426643ac80731b63b829a9"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "b8fb7acbcb922af01da7e97b7c3ef303dcda92762996d2ad9a12ffec1bfea608" => :mojave
     sha256 "4a5566659aedb0453c68c468c65521b53d0602113a940b50afab759488b4997c" => :high_sierra

--- a/Formula/socat.rb
+++ b/Formula/socat.rb
@@ -5,7 +5,6 @@ class Socat < Formula
   sha256 "8cc0eaee73e646001c64adaab3e496ed20d4d729aaaf939df2a761e99c674372"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "8df52f1aac80cb54571c817acf3dc3a37dc7c6cc61efda3ff5d894b802e41488" => :mojave
     sha256 "146f0a748cf86284207e7a23f178eace6019d861add738fca74e74171a079fb6" => :high_sierra

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -7,7 +7,6 @@ class SourceToImage < Formula
   head "https://github.com/openshift/source-to-image.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "179ed06aa8cee8c8c7c6b8658eed696359170116c2ac366dadfaf086d533b033" => :mojave
     sha256 "a315100e844a70c78cf11eae24c70ff663f239fe79274da5b99223fbe6081a87" => :high_sierra

--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -7,7 +7,6 @@ class Spades < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "6eff79211afd0a5f2a3194db28a630bfa53cec5b968dc810e65bbaefce55fae4" => :mojave
     sha256 "ef7d029efa28d81c236a428f40c0780b074827b50e5618cc328b4cfffdc7e579" => :high_sierra

--- a/Formula/sparse.rb
+++ b/Formula/sparse.rb
@@ -6,7 +6,6 @@ class Sparse < Formula
   head "https://git.kernel.org/pub/scm/devel/sparse/sparse.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "a7bb9bba1767d4df2a5c07911fbe5a52e63a89ee61f59ac38b7abdf18f915050" => :mojave
     sha256 "a2e1769a7a40c5ed66ee727a6b07d7227a7cf5f8bfe1f0acf7af1b4549841ef5" => :high_sierra

--- a/Formula/spatialindex.rb
+++ b/Formula/spatialindex.rb
@@ -5,7 +5,6 @@ class Spatialindex < Formula
   sha256 "52d6875deea12f88e6918d192cbfd38d6e78d13f84e1fd10cca66132fa063941"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "bdda20e0607a6ac0a2bbf3ee37c0d507b7f9ede93f2210c3b33887b1682c173e" => :mojave
     sha256 "81cb9da70510a276cf06cc993f1b94aa27ce688b923aeac8170df372496bd371" => :high_sierra

--- a/Formula/spigot.rb
+++ b/Formula/spigot.rb
@@ -6,7 +6,6 @@ class Spigot < Formula
   sha256 "a2c29bf6aa627300444bb06b277edb7e841a83a31fbae7d33adf6f52b1019df7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "629d5dcb9ce0a58cb0983956ece08b26c5adefe4fb13eea562cda70f7f172b15" => :mojave
     sha256 "dd9f37d3a0104425cc70b7bb7c917d3e79879e9bc9abd2f012b4bff1ec76278e" => :high_sierra

--- a/Formula/srt.rb
+++ b/Formula/srt.rb
@@ -6,7 +6,6 @@ class Srt < Formula
   head "https://github.com/Haivision/srt.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "05c095fe08f26b93c8352c5b50f3af1a5b4d5c6922ec630af4da5b773f57f670" => :mojave
     sha256 "3fa85c4a24c41a81ec33987349b8b7280455229bbcbaf0be473aa39c4e54ecf5" => :high_sierra

--- a/Formula/step.rb
+++ b/Formula/step.rb
@@ -5,7 +5,6 @@ class Step < Formula
   sha256 "c212a6a016ce41eca5970b42bdbbe57dec43a9fe91bd758a82e4dac5f10af6e9"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "bd97baaa9c96be7ecf60e07cf4c8ca1dceb34339fde24f32d402464740ca6779" => :mojave
     sha256 "9231418888f8e1a42911d6ade6c2cd600f515c1e76719bfa0e580993c20a9e93" => :high_sierra

--- a/Formula/streamlink.rb
+++ b/Formula/streamlink.rb
@@ -5,7 +5,6 @@ class Streamlink < Formula
   sha256 "496c81804bbe534b47f6cf4d77aa6fae95347ebaab495277f9d2526543cbafa6"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "5037aada38d677b20836b833e27531f97de860d3fb3e9fb8ba2c4dc5542ae9ac" => :mojave
     sha256 "7c528315997d20e5429bb7c82947463912b7b3e1881d07863df3e3e8ea97e3c6" => :high_sierra

--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -6,7 +6,6 @@ class Stubby < Formula
   head "https://github.com/getdnsapi/stubby.git", :branch => "develop"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "aa05e8445978d4d7391addd20666f7ab141e9587e4585d7873052acb68aed123" => :mojave
     sha256 "e336da47ce50d92a0c3f445db4200dad8f99ba406ef454abfffb4085601e9e71" => :high_sierra
     sha256 "685cec7e37bf310b77da3680fa81d1bfc920928289c4905eb5c6899e40f6f801" => :sierra

--- a/Formula/suite-sparse.rb
+++ b/Formula/suite-sparse.rb
@@ -6,7 +6,6 @@ class SuiteSparse < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "cd8f66c3e7358c6bb81f9e7975663283c605d057838bf74edafa21d5a9f55401" => :mojave
     sha256 "f3c2906bb5685a2c1a1c2702ec902b21dcbb41867a0962a8b161201a999200d2" => :high_sierra

--- a/Formula/sundials.rb
+++ b/Formula/sundials.rb
@@ -6,7 +6,6 @@ class Sundials < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "f4c847a59ffa3fc65c5d4945bde6f645ac4779803b9956f44847a691cf3b728d" => :mojave
     sha256 "cf0ee67d67435830aa71cb4c00aafbd38d80c15bf9c8516855a8073cbcef3d39" => :high_sierra

--- a/Formula/superlu.rb
+++ b/Formula/superlu.rb
@@ -6,7 +6,6 @@ class Superlu < Formula
   revision 4
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "d47a98b1d94b041aa93835c10e024f2e3bb4f6535f1dd5c142343e5cf395e785" => :mojave
     sha256 "5e02b75c1053a83ae4d07e3450d1cff929b825e2296327cbae038ace4d077e3a" => :high_sierra

--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -5,7 +5,6 @@ class Swig < Formula
   sha256 "e8a39cd6437e342cdcbd5af27a9bf11b62dc9efec9248065debcb8276fcbb925"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "9eff7a235762c2727dfdb767217be4a48a55f29efcae5fedc450c3dfeb806904" => :mojave
     sha256 "aed79cb436b3a0ac5812c4085e3121ffd62866397b8c7eaa06815ed8ec1e22b7" => :high_sierra
     sha256 "af4c42215d5c7c042d83e98aecb70958acd73038dfc2b59d1854f2287fb50980" => :sierra

--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -5,7 +5,6 @@ class Sysbench < Formula
   sha256 "9bcad62eaf473510f5184f33cc41f1e07c2640c8810ae9eebe25ba27ba04df5d"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "064afff9de05baa1de8eea0fb9d4c94fb247c87364e7bdbe238e127b68922971" => :mojave
     sha256 "39aef6117641eebb5157d30a6523b9881e9049d5f5cfabb9710f34f37387cb1a" => :high_sierra

--- a/Formula/talloc.rb
+++ b/Formula/talloc.rb
@@ -5,7 +5,6 @@ class Talloc < Formula
   sha256 "5c6f6a45ef96b3fd0b28942673a68d0c6af5dcca9d676a2e4d57ce7e86c22ebc"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "ff869573e3b472a59a8ffb3fb2e7eed6f31434a162a8e6391ab89d07957c5fd3" => :mojave
     sha256 "2619d7231ca1c73abaedf250e0e9bc84b2192881e59a780e724a8c423e4b7b01" => :high_sierra

--- a/Formula/task.rb
+++ b/Formula/task.rb
@@ -6,7 +6,6 @@ class Task < Formula
   head "https://github.com/GothenburgBitFactory/taskwarrior.git", :branch => "2.6.0", :shallow => false
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "bba98b6bdfb3f79f1434229d8ade4b0622119320353da0eb8fec39809d66947d" => :mojave
     sha256 "6a651be957b736bef14633efedef011a81c49ee37178eae4d8ef863549d7c584" => :high_sierra
     sha256 "d1cb582ab9ee211ec154690634b5988f8058ead31000c74d5cdfa949d319d0ed" => :sierra

--- a/Formula/taskell.rb
+++ b/Formula/taskell.rb
@@ -9,7 +9,6 @@ class Taskell < Formula
   sha256 "3aec117a845542513f6f674f5841c6edc5e494ad313b1f0572c224971d359ff0"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "86c3605cf37d04617f6db0ff165d17817ad0379a1dbbd1addec3ab692910cbff" => :mojave
     sha256 "be0d352ef92c4908cc4044e91fc0f5baa86b1c0443dfb32653986445773228eb" => :high_sierra

--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -7,7 +7,6 @@ class Tasksh < Formula
   revision 1 unless OS.mac?
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c766ebd317962a04a3d78a4fbcc202085a27e0d15f63debf095f84a9a97d6306" => :mojave
     sha256 "17f99be8d0aea4c43877fbfb121b7989047f04650ccffa85e948859e8ee51e0b" => :high_sierra

--- a/Formula/tcsh.rb
+++ b/Formula/tcsh.rb
@@ -6,7 +6,6 @@ class Tcsh < Formula
   sha256 "c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "b5b22fe69189ad23daaba0da4997ee6ea17b21d63f2c7ef0a78f91f5a816ab16" => :mojave
     sha256 "a2497b4079f9ef60652e987b58e305627533491169a4ec348f7d967ab46787ca" => :high_sierra
     sha256 "88ee66c224517188212d05f1595c6ab3a0a16cefab8fce80f6b6a36488c274e1" => :sierra

--- a/Formula/terraform_landscape.rb
+++ b/Formula/terraform_landscape.rb
@@ -5,7 +5,6 @@ class TerraformLandscape < Formula
   sha256 "2fef358c16fe58f87e74a7d777ce669b5c2b368b4fcdba98d114948484156532"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "514ab58c4634a439faeac56e08511346b582e0094b2ffb981b837758ee0d2684" => :mojave
     sha256 "b271788171df1bc43fe3dff81806bbff64ab13796ea561e611e70817f4b74924" => :high_sierra

--- a/Formula/tesseract-lang.rb
+++ b/Formula/tesseract-lang.rb
@@ -5,7 +5,6 @@ class TesseractLang < Formula
   sha256 "f1b71e97f27bafffb6a730ee66fd9dc021afc38f318fdc80a464a84a519227fe"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "631211ef37fcafa9a3fac6a7cd6ca94aaeca83ae28543716a7aaa9cf1072d414" => :mojave
     sha256 "631211ef37fcafa9a3fac6a7cd6ca94aaeca83ae28543716a7aaa9cf1072d414" => :high_sierra

--- a/Formula/texinfo.rb
+++ b/Formula/texinfo.rb
@@ -6,7 +6,6 @@ class Texinfo < Formula
   sha256 "9bb9ca00da53f26a7e5725eee49689cd4a1e18d25d5b061ac8b2053018d93d66"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "2ea78114fc2f1bedb52a8cc4148c7ab48cbfe15bb2347783fb7f84998247ccc3" => :mojave
     sha256 "0181ad9121222a096857230faa80ed6b706a03eec49a5b9359694c0b8587db73" => :high_sierra
     sha256 "00f00f4d5ab3a6ba46d90264df0c8e0117cb14e30398ca574b0b53b95226e687" => :sierra

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -7,7 +7,6 @@ class Texlive < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "4e24715e406a78243cc4391aabc6dc7776390b43fd57d21315a002776ea8994a" => :x86_64_linux
   end

--- a/Formula/texmath.rb
+++ b/Formula/texmath.rb
@@ -9,7 +9,6 @@ class Texmath < Formula
   sha256 "fe4e24af001104ed3c95ee44076e6819ffad67684efdabee5ae07cf8ceb81087"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "ef810c923e8a459cc4d18ab596c348e4e8610b177c642242b4bf07915eab7e16" => :mojave
     sha256 "1782096bfc10752b5916f16aa188a37e57609f101f334be92b1abf23bf8ed59d" => :high_sierra
     sha256 "45e18931b08c56b33ec7610ebeae791d5acf496d1e3cfe949dca28162e10c15e" => :sierra

--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -5,7 +5,6 @@ class Thrift < Formula
   sha256 "c336099532b765a6815173f62df0ed897528a9d551837d627c1f87fadad90428"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "84321af08a88b55fb203083d5653cf2daf7815dbaa3093deb38af952c65e749b" => :mojave
     sha256 "51a0d9888ed9ca351ad0668632f0ec920c7509bfb9fa7bca5e0f446fbf3358a2" => :high_sierra

--- a/Formula/tippecanoe.rb
+++ b/Formula/tippecanoe.rb
@@ -5,7 +5,6 @@ class Tippecanoe < Formula
   sha256 "7a2dd2376a93d66a82c8253a46dbfcab3eaaaaca7bf503388167b9ee251bee54"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "201ef6af440f2dcfaf9a554512e77f004fe83028f001bcb399d58d7cf68a90c8" => :mojave
     sha256 "056ce50e3b65cb5f56051869291e0e52e2d244c8282b2103a2c7718fb92d294d" => :high_sierra

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -5,7 +5,6 @@ class Tmux < Formula
   sha256 "839d167a4517a6bffa6b6074e89a9a8630547b2dea2086f1fad15af12ab23b25"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "39e422362b56750f805e9725c498fd5653987a26e1b892d5f0d40820616be69d" => :mojave
     sha256 "5c7148b6beb43995a0f53504f9a3f0500420e5ad11e17f34ce60401f42b833df" => :high_sierra

--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -6,7 +6,6 @@ class Tor < Formula
   sha256 "b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     sha256 "b48b0db02211c743921d73017107ec254d2a2814f35a413462f1f97c7d89f6a0" => :mojave
     sha256 "84abc429dd05a6957c4d1a3937762fce8c0b4a464462569b4f796cc2540b3cc2" => :high_sierra
     sha256 "c4693bce8195e5c2fef75777010bf872bb8bd93cfac8dd00b5218d4612aa82c2" => :sierra

--- a/Formula/translate-shell.rb
+++ b/Formula/translate-shell.rb
@@ -6,7 +6,6 @@ class TranslateShell < Formula
   head "https://github.com/soimort/translate-shell.git", :branch => "develop"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "36a689f6c97099a7143160efa40f2de05856f701a78ea7e0c92dc8da764c85d6" => :mojave
     sha256 "36a689f6c97099a7143160efa40f2de05856f701a78ea7e0c92dc8da764c85d6" => :high_sierra

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -5,7 +5,6 @@ class Travis < Formula
   sha256 "77f43de7c1e686e2b8eca3f467047de9687c4021c4a12f46dcf1e0f3e63a96c3"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "42d8323b7ebb3687b3ea96b1051fd9e02c22732ebd2964d6bea064fb443f99ba" => :mojave
     sha256 "d66aa769ff2b66c634ead1d76966015f852d39c3b6baf5ef01e80f2da5c66c45" => :high_sierra

--- a/Formula/ttfautohint.rb
+++ b/Formula/ttfautohint.rb
@@ -5,7 +5,6 @@ class Ttfautohint < Formula
   sha256 "87bb4932571ad57536a7cc20b31fd15bc68cb5429977eb43d903fa61617cf87e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "04ca530843887602e80fde17d24f4ed8e19d1248bd71c81c925c161770dbdf56" => :mojave
     sha256 "a6573ae816a7555d62308759c2d64f9fb955ba056d856d904a522996ba0a0c83" => :high_sierra

--- a/Formula/unp64.rb
+++ b/Formula/unp64.rb
@@ -6,7 +6,6 @@ class Unp64 < Formula
   sha256 "55126d9cd6d3bb0d77aeba3c9bd5d9e16805b098c66de92b33f44814425c39e1"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "966cbf5ee30ed72e472df6fa40c80adc623a18c3ab9764e22185cb0b48da4e46" => :mojave
     sha256 "d84f3af986ace7e131687c719d399212ca7c8e5bb4fc5f7bc9d0910db4116132" => :high_sierra

--- a/Formula/unrar.rb
+++ b/Formula/unrar.rb
@@ -5,7 +5,6 @@ class Unrar < Formula
   sha256 "e1c2fddaa87a88b1535bfc10ca484f3c5af4e5a55fbb933f8819e26203bbe2ee"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "8d30a945be9a3b5a668d3c558f40dd22d3ba1e4b44e3f3d3a1b004b594d66fbf" => :mojave
     sha256 "3d5b170619917ee01c311696c457eb1b75310cc13cbe5cc7fc57c37e17c31a44" => :high_sierra

--- a/Formula/usbmuxd.rb
+++ b/Formula/usbmuxd.rb
@@ -15,7 +15,6 @@ class Usbmuxd < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "2305d6794314c64d0fb8c3339c2d75a8e01d218715bc871560e4fe9fcad486a8" => :mojave
     sha256 "253be465f391159e278a0a9625775075503f75b0a404aa64b9f557486de3b82c" => :high_sierra

--- a/Formula/utf8proc.rb
+++ b/Formula/utf8proc.rb
@@ -5,7 +5,6 @@ class Utf8proc < Formula
   sha256 "b2e5d547c1d94762a6d03a7e05cea46092aab68636460ff8648f1295e2cdfbd7"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "5cbd1c95723915eda5c5bb0437f49c3aeb50d768cfec87e9ff09507912244589" => :mojave
     sha256 "b1bbbd93be674c8304888ff5843a63433a5e3b7ccd7d8c8d9ceb450ce71a9c88" => :high_sierra

--- a/Formula/vcdimager.rb
+++ b/Formula/vcdimager.rb
@@ -7,7 +7,6 @@ class Vcdimager < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "cb45bd1a48e551a60e8b344668a79e24414012ebc76a141ee6c0677ec21ad594" => :mojave
     sha256 "993b40efcd1af1844ed14064de2551cecbdacc3a1c4d39f9fe1d8b289b3b6eb9" => :high_sierra

--- a/Formula/wabt.rb
+++ b/Formula/wabt.rb
@@ -5,7 +5,6 @@ class Wabt < Formula
   sha256 "90e7f4a4e924e38af4edb6ca298ade662869c5b61a12399e71ee53d598d52cbe"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "c1339d52cf0c351231d7e3dda70ac733746a186a4478641c9be00a790acc2d1f" => :mojave
     sha256 "2923d126a13d7075629d6180bbf4a79ca081f979a85e3386f88b4ed2e5efb5ff" => :high_sierra

--- a/Formula/wsk.rb
+++ b/Formula/wsk.rb
@@ -6,7 +6,6 @@ class Wsk < Formula
   sha256 "0f0052ea85b10aea8902d4ccb9393fd523b96d5b2477b1c38d486366edc9535c"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "850399f50dccd74a0b26b06110bcc2c350684113d43c4befc589cc184eb10254" => :mojave
     sha256 "f15b8866018349165cf08465902fc6de24b7ffa4207baa8aab4f1e4851933cbf" => :high_sierra

--- a/Formula/xtensor.rb
+++ b/Formula/xtensor.rb
@@ -5,7 +5,6 @@ class Xtensor < Formula
   sha256 "ea0ed42ac27888f4e4acaf99367fbef714373fa586f204e8bc22b8e5335ecf06"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "cd91f1e093dd83c47e6857e3762f374b35a8f210aacdc7b9134ca5c4f7fb81b3" => :mojave
     sha256 "cd91f1e093dd83c47e6857e3762f374b35a8f210aacdc7b9134ca5c4f7fb81b3" => :high_sierra

--- a/Formula/xxhash.rb
+++ b/Formula/xxhash.rb
@@ -5,7 +5,6 @@ class Xxhash < Formula
   sha256 "b34792646d5e19964bb7bba24f06cb13aecaac623ab91a54da08aa19d3686d7e"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "ba896fa36c62ca5100bfe8a0e224a8c8af7d780da0f9859f6f3eabcff11f66a6" => :mojave
     sha256 "3e2f2e6993a2655c6bbbc5f8ab269729285dfc176afce79152119c2442e7fbb4" => :high_sierra

--- a/Formula/yara.rb
+++ b/Formula/yara.rb
@@ -6,7 +6,6 @@ class Yara < Formula
   head "https://github.com/VirusTotal/yara.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "96e4ce1d68bf111eb31a83380383176e3fc2d79221751e2d301e01cf5a043fe0" => :mojave
     sha256 "da1fb89ba681a95d0841a5be0b07621cd88223d1af66564a2217c144739b2b5f" => :high_sierra

--- a/Formula/you-get.rb
+++ b/Formula/you-get.rb
@@ -8,7 +8,6 @@ class YouGet < Formula
   head "https://github.com/soimort/you-get.git", :branch => "develop"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "7a16d5cb1e0159d4750f1453cbe0814c3eeba309bc6906df426a9dc995e8a82a" => :mojave
     sha256 "36211043db5029d7c4ed660c2d3f4bb28c35e2820af18c186039411b35594c6e" => :high_sierra

--- a/Formula/yq.rb
+++ b/Formula/yq.rb
@@ -5,7 +5,6 @@ class Yq < Formula
   sha256 "5277293b3bcd7c891d8c20c029637ca5064409696b77937a1cba1bfc07164163"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any_skip_relocation
     sha256 "04f9e504ff627ee5c24a2051122c68bbb2cabf66d6ea2be4c6d161613e38d2c0" => :mojave
     sha256 "691172310ea3a78373640dcb21d2d9f8615d337f7314e78627fbda47dd59f47c" => :high_sierra

--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -6,7 +6,6 @@ class Zbackup < Formula
   revision 9
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles"
     cellar :any
     sha256 "6f90dd99ebcf108479b5c8b8277905096fa9f13b533b466e07ea6f3eb4ebc839" => :mojave
     sha256 "6a4bc9f7dfda15391161d00ab8add5e955d48d01c4e9fd6cf64bf2dd53f2b90f" => :high_sierra


### PR DESCRIPTION
Having a root_url prevents HOMEBREW_BOTTLE_DOMAIN from taking effect.
For a while, the Linuxbrew test bot was mistakenly adding the default
bottle domain into formulae.

Closes #14598.

Signed-off-by: Mike Seplowitz <mseplowitz@bloomberg.net>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.