### PR TITLE
lsof: Fix build

### DIFF
--- a/Formula/lsof.rb
+++ b/Formula/lsof.rb
@@ -32,7 +32,7 @@ class Lsof < Formula
 
     system "make"
     bin.install "lsof"
-    man8.install "lsof.8"
+    man8.install "Lsof.8"
     prefix.install_metafiles
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Fixes #14662.
- Running `brew install --interactive lsof` revealed that the man page
  name is now capitalized?!
- Should probably push this upstream to Homebrew/homebrew-core, but
  that's _several more merges_ away and this is currently blocking our
  Linux users.