### PR TITLE
Remove Circle CI build-time memory usage constraints for formulae

### DIFF
--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -28,9 +28,6 @@ class Assimp < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     args = std_cmake_args
     args << "-DASSIMP_BUILD_TESTS=OFF"
     system "cmake", *args

--- a/Formula/atkmm.rb
+++ b/Formula/atkmm.rb
@@ -18,9 +18,6 @@ class Atkmm < Formula
   depends_on "glibmm"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j6" if ENV["CIRCLECI"]
-
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -31,9 +31,6 @@ class Bitcoin < Formula
   depends_on "zeromq"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1 -l1.0" if ENV["CIRCLECI"]
-
     if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       ENV.delete("SDKROOT")
     end

--- a/Formula/bloaty.rb
+++ b/Formula/bloaty.rb
@@ -16,9 +16,6 @@ class Bloaty < Formula
   depends_on "cmake" => :build
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     system "cmake", ".", *std_cmake_args
     system "make"
     bin.install buildpath/"bloaty"

--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -17,9 +17,6 @@ class BoostPython < Formula
   depends_on "python@2" => :recommended unless OS.mac?
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",
             "--libdir=#{lib}",

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -23,9 +23,6 @@ class BoostPython3 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",
             "--libdir=#{lib}",

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -21,9 +21,6 @@ class Boost < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
       if OS.mac?

--- a/Formula/boost@1.60.rb
+++ b/Formula/boost@1.60.rb
@@ -36,9 +36,6 @@ class BoostAT160 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
       if OS.mac?

--- a/Formula/capnp.rb
+++ b/Formula/capnp.rb
@@ -17,9 +17,6 @@ class Capnp < Formula
   depends_on "cmake" => :build
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -51,9 +51,6 @@ class ClangFormat < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2 -l2.0" if ENV["CIRCLECI"]
-
     (buildpath/"projects/libcxx").install resource("libcxx") if OS.mac?
     (buildpath/"tools/clang").install resource("clang")
 

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -26,9 +26,6 @@ class Cmake < Formula
   # For the GUI application please instead use `brew cask install cmake`.
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV.deparallelize if ENV["CIRCLECI"]
-
     ENV.cxx11 unless OS.mac?
 
     args = %W[

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -23,9 +23,6 @@ class Coq < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     system "./configure", "-prefix", prefix,
                           "-mandir", man,
                           "-coqdocdir", "#{pkgshare}/latex",

--- a/Formula/davix.rb
+++ b/Formula/davix.rb
@@ -25,9 +25,6 @@ class Davix < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     ENV.libcxx
 
     system "cmake", ".", *std_cmake_args

--- a/Formula/draco.rb
+++ b/Formula/draco.rb
@@ -15,9 +15,6 @@ class Draco < Formula
   depends_on "cmake" => :build
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     mkdir "build" do
       system "cmake", "..", * std_cmake_args
       system "make", "install"

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -43,9 +43,6 @@ class Emscripten < Formula
   depends_on "yuicompressor"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     ENV.cxx11
     # rewrite hardcoded paths from system python to homebrew python
     python2_shebangs = `grep --recursive --files-with-matches ^#!/usr/bin/python #{buildpath}`

--- a/Formula/fibjs.rb
+++ b/Formula/fibjs.rb
@@ -16,9 +16,6 @@ class Fibjs < Formula
   depends_on :macos => :sierra # fibjs requires >= Xcode 8.3 (or equivalent CLT)
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["HOMEBREW_MAKE_JOBS"] = "16" if ENV["CIRCLECI"]
-
     # the build script breaks when CI is set by Homebrew
     begin
       env_ci = ENV.delete "CI"

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -31,9 +31,6 @@ class Folly < Formula
   uses_from_macos "python"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     mkdir "_build" do
       args = std_cmake_args + %w[
         -DFOLLY_USE_JEMALLOC=OFF

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -64,9 +64,6 @@ class Gcc < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8 -l2.5" if ENV["CIRCLECI"]
-
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -51,9 +51,6 @@ class GccAT6 < Formula
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     # C, C++, ObjC, Fortran compilers are always built
     languages = %w[c c++ objc obj-c++ fortran]
 

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -49,9 +49,6 @@ class GccAT7 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8 -l2.5" if ENV["CIRCLECI"]
-
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -36,9 +36,6 @@ class GccAT8 < Formula
   cxxstdlib_check :skip
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8 -l2.5" if ENV["CIRCLECI"]
-
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -43,9 +43,6 @@ class GccAT9 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8 -l2.5" if ENV["CIRCLECI"]
-
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -55,9 +55,6 @@ class Gdal < Formula
   conflicts_with "cpl", :because => "both install cpl_error.h"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     # Fixes: error: inlining failed in call to always_inline __m128i _mm_shuffle_epi8
     ENV.append_to_cflags "-msse4.1" if ENV["CIRCLECI"]
 

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -60,9 +60,6 @@ class Ghc < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     ENV["CC"] = ENV.cc
     ENV["LD"] = "ld"
 

--- a/Formula/ghc@8.0.rb
+++ b/Formula/ghc@8.0.rb
@@ -71,9 +71,6 @@ class GhcAT80 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j6" if ENV["CIRCLECI"]
-
     # Setting -march=native, which is what --build-from-source does, fails
     # on Skylake (and possibly other architectures as well) with the error
     # "Segmentation fault: 11" for at least the following files:

--- a/Formula/ghc@8.2.rb
+++ b/Formula/ghc@8.2.rb
@@ -49,9 +49,6 @@ class GhcAT82 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     ENV["CC"] = ENV.cc
     ENV["LD"] = "ld"
 

--- a/Formula/glibmm.rb
+++ b/Formula/glibmm.rb
@@ -18,9 +18,6 @@ class Glibmm < Formula
   depends_on "libsigc++"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j6" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     # see https://bugzilla.gnome.org/show_bug.cgi?id=781947

--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -22,9 +22,6 @@ class Grafana < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     ENV["GOPATH"] = buildpath
     grafana_path = buildpath/"src/github.com/grafana/grafana"
     grafana_path.install buildpath.children

--- a/Formula/gtkmm.rb
+++ b/Formula/gtkmm.rb
@@ -22,9 +22,6 @@ class Gtkmm < Formula
   depends_on "pangomm"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/highlight.rb
+++ b/Formula/highlight.rb
@@ -16,9 +16,6 @@ class Highlight < Formula
   depends_on "lua"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     conf_dir = etc/"highlight/" # highlight needs a final / for conf_dir
     system "make", "PREFIX=#{prefix}", "conf_dir=#{conf_dir}"
     system "make", "PREFIX=#{prefix}", "conf_dir=#{conf_dir}", "install"

--- a/Formula/ibex.rb
+++ b/Formula/ibex.rb
@@ -21,9 +21,6 @@ class Ibex < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     # Reported 9 Oct 2017 https://github.com/ibex-team/ibex-lib/issues/286

--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -30,9 +30,6 @@ class Kibana < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     resource("node").stage do
       system "./configure", "--prefix=#{libexec}/node"
       system "make", "install"

--- a/Formula/kibana@4.4.rb
+++ b/Formula/kibana@4.4.rb
@@ -32,9 +32,6 @@ class KibanaAT44 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     resource("node").stage do
       system "./configure", "--prefix=#{libexec}/node"
       system "make", "install"

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -23,9 +23,6 @@ class Ledger < Formula
   uses_from_macos "groff"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     args = %W[

--- a/Formula/libglademm.rb
+++ b/Formula/libglademm.rb
@@ -17,9 +17,6 @@ class Libglademm < Formula
   depends_on "libglade"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/libmwaw.rb
+++ b/Formula/libmwaw.rb
@@ -21,9 +21,6 @@ class Libmwaw < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/libosmium.rb
+++ b/Formula/libosmium.rb
@@ -22,9 +22,6 @@ class Libosmium < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     resource("protozero").stage { libexec.install "include" }
     system "cmake", ".", "-DINSTALL_GDALCPP=ON",
                          "-DINSTALL_UTFCPP=ON",

--- a/Formula/libsass.rb
+++ b/Formula/libsass.rb
@@ -19,9 +19,6 @@ class Libsass < Formula
   depends_on "libtool" => :build
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV.deparallelize if ENV["CIRCLECI"]
-
     ENV.cxx11
     system "autoreconf", "-fvi"
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",

--- a/Formula/libwps.rb
+++ b/Formula/libwps.rb
@@ -19,9 +19,6 @@ class Libwps < Formula
   depends_on "libwpd"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           # Installing Doxygen docs trips up make install
                           "--prefix=#{prefix}", "--without-docs"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -151,9 +151,6 @@ class Llvm < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2 -l2.0" if ENV["CIRCLECI"]
-
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -82,9 +82,6 @@ class LlvmAT4 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j5" if ENV["CIRCLECI"]
-
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 

--- a/Formula/llvm@5.rb
+++ b/Formula/llvm@5.rb
@@ -135,9 +135,6 @@ class LlvmAT5 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2 -l2.0" if ENV["CIRCLECI"]
-
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -98,9 +98,6 @@ class LlvmAT6 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2 -l2.0" if ENV["CIRCLECI"]
-
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 

--- a/Formula/llvm@7.rb
+++ b/Formula/llvm@7.rb
@@ -85,9 +85,6 @@ class LlvmAT7 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2 -l2.0" if ENV["CIRCLECI"]
-
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 

--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -26,9 +26,6 @@ class Lnav < Formula
   depends_on "sqlite"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     # Fix errors such as "use of undeclared identifier 'sqlite3_value_subtype'"
     ENV.delete("SDKROOT")
 

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -13,9 +13,6 @@ class Log4cplus < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j12" if ENV["CIRCLECI"]
-
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -28,9 +28,6 @@ class Mariadb < Formula
     :because => "both install plugins"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     # Set basedir and ldata so that mysql_install_db can find the server
     # without needing an explicit path to be set. This can still
     # be overridden by calling --basedir= when calling.

--- a/Formula/mednafen.rb
+++ b/Formula/mednafen.rb
@@ -24,9 +24,6 @@ class Mednafen < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
   end

--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -37,9 +37,6 @@ class MingwW64 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     target_archs.each do |arch|
       arch_dir = "#{prefix}/toolchain-#{arch}"
       target = "#{arch}-w64-mingw32"

--- a/Formula/mitmproxy.rb
+++ b/Formula/mitmproxy.rb
@@ -156,9 +156,6 @@ class Mitmproxy < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4 -l2.5" if ENV["CIRCLECI"]
-
     venv = virtualenv_create(libexec, "python3")
     venv.pip_install resource("cffi")
     venv.pip_install resources

--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -34,9 +34,6 @@ class Mkvtoolnix < Formula
   depends_on "ruby" => :build unless OS.mac?
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" unless OS.mac?
 
     ENV.cxx11

--- a/Formula/mongo-cxx-driver.rb
+++ b/Formula/mongo-cxx-driver.rb
@@ -17,9 +17,6 @@ class MongoCxxDriver < Formula
   depends_on "mongo-c-driver"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     mongo_c_prefix = Formula["mongo-c-driver"].opt_prefix
     system "cmake", ".", *std_cmake_args,
       "-DLIBBSON_DIR=#{mongo_c_prefix}", "-DLIBMONGOC_DIR=#{mongo_c_prefix}"

--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -43,9 +43,6 @@ class Mongodb < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["HOMEBREW_MAKE_JOBS"] = "6" if ENV["CIRCLECI"]
-
     ENV.libcxx
 
     ["Cheetah", "PyYAML", "typing"].each do |r|

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -34,9 +34,6 @@ class MysqlCluster < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     # Make sure the var/mysql-cluster directory exists
     (var/"mysql-cluster").mkpath
 

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -44,8 +44,6 @@ class Mysql < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j3" if ENV["CIRCLECI"]
     # Fix libmysqlgcs.a(gcs_logging.cc.o): relocation R_X86_64_32
     # against `_ZN17Gcs_debug_options12m_debug_noneB5cxx11E' can not be used when making
     # a shared object; recompile with -fPIC

--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -29,9 +29,6 @@ class Ncmpcpp < Formula
   depends_on "taglib"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j6" if ENV["CIRCLECI"]
-
     ENV.cxx11
     ENV.append "LDFLAGS", "-liconv" if OS.mac?
     ENV.append "BOOST_LIB_SUFFIX", "-mt"

--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -32,9 +32,6 @@ class Neko < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     args = std_cmake_args
     unless OS.mac?
       args << "-DAPR_LIBRARY=#{Formula["apr"].libexec}/lib"

--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -39,9 +39,6 @@ class Nghttp2 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     args = %W[

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -25,9 +25,6 @@ class Node < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     # Never install the bundled "npm", always prefer our
     # installation from tarball for better packaging control.
     args = %W[--prefix=#{prefix} --without-npm --with-intl=system-icu]

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -67,9 +67,6 @@ class Octave < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -39,9 +39,6 @@ class Opencv < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
     dylib = OS.mac? ? "dylib" : "so"
 

--- a/Formula/opensaml.rb
+++ b/Formula/opensaml.rb
@@ -19,9 +19,6 @@ class Opensaml < Formula
   depends_on "xml-tooling-c"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"

--- a/Formula/osmium-tool.rb
+++ b/Formula/osmium-tool.rb
@@ -15,9 +15,6 @@ class OsmiumTool < Formula
   uses_from_macos "expat"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     protozero = Formula["libosmium"].opt_libexec/"include"
     system "cmake", ".", "-DPROTOZERO_INCLUDE_DIR=#{protozero}", *std_cmake_args
     system "make", "install"

--- a/Formula/pandoc-citeproc.rb
+++ b/Formula/pandoc-citeproc.rb
@@ -22,9 +22,6 @@ class PandocCiteproc < Formula
   depends_on "unzip" => :build unless OS.mac?
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     install_cabal_package
   end
 

--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -24,9 +24,6 @@ class Pandoc < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     cabal_sandbox do
       install_cabal_package
     end

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -27,9 +27,6 @@ class Pdns < Formula
   depends_on "sqlite"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     # Fix "configure: error: cannot find boost/program_options.hpp"
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
 

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -23,9 +23,6 @@ class Pdnsrec < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     args = %W[

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -54,9 +54,6 @@ class PerconaServer < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     args = %W[
       -DCOMPILATION_COMMENT=Homebrew
       -DDEFAULT_CHARSET=utf8

--- a/Formula/postgrest.rb
+++ b/Formula/postgrest.rb
@@ -22,9 +22,6 @@ class Postgrest < Formula
   depends_on "postgresql"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4 -l2.5" if ENV["CIRCLECI"]
-
     install_cabal_package :using => ["happy"]
   end
 

--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -23,9 +23,6 @@ class Povray < Formula
   depends_on "openexr"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     args = %W[

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -32,9 +32,6 @@ class Protobuf < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
     # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61

--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -15,9 +15,6 @@ class Re2 < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     system "make", "install", "prefix=#{prefix}"

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -19,9 +19,6 @@ class Rtags < Formula
   depends_on "openssl"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
     ENV.append("LDFLAGS", "-lc++abi") if OS.mac?
 

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -65,9 +65,6 @@ class Rust < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1 -l2.0" if ENV["CIRCLECI"]
-
     # Fix build failure for compiler_builtins "error: invalid deployment target
     # for -stdlib=libc++ (requires OS X 10.7 or later)"
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version if OS.mac?

--- a/Formula/simgrid.rb
+++ b/Formula/simgrid.rb
@@ -21,9 +21,6 @@ class Simgrid < Formula
   depends_on "python"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     system "cmake", ".",
                     "-Denable_debug=on",
                     "-Denable_compile_optimizations=off",

--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -24,9 +24,6 @@ class Spades < Formula
   fails_with :clang # no OpenMP support
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     mkdir "src/build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"

--- a/Formula/stella.rb
+++ b/Formula/stella.rb
@@ -21,9 +21,6 @@ class Stella < Formula
   fails_with :gcc => "4.8" unless OS.mac?
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     sdl2 = Formula["sdl2"]
     libpng = Formula["libpng"]
     if OS.mac?

--- a/Formula/uhd.rb
+++ b/Formula/uhd.rb
@@ -25,9 +25,6 @@ class Uhd < Formula
   end
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
-
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
 

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -31,9 +31,6 @@ class Watchman < Formula
   depends_on "python"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -31,9 +31,6 @@ class Wxmac < Formula
   patch :DATA if OS.mac?
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     args = [
       "--prefix=#{prefix}",
       "--enable-clipboard",

--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -18,9 +18,6 @@ class Wxmaxima < Formula
   depends_on "wxmac"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
-
     system "cmake", ".", *std_cmake_args
     system "make", "install"
     prefix.install "wxMaxima.app" if OS.mac?

--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -16,9 +16,6 @@ class Z3 < Formula
   depends_on "python"
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
-
     xy = Language::Python.major_minor_version "python3"
     system "python3", "scripts/mk_make.py",
                       "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- No new branches made from the latest master will have PRs that build on Circle CI, so this is safe.
