### PR TITLE
azure-pipelines: git fetch --unshallow

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
       sudo /home/linuxbrew/.linuxbrew/bin/brew tap homebrew/homebrew-test-bot
       cd /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
       git checkout -b test
+      if [ -e .git/shallow ]; then git fetch --unshallow; fi
       git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
       git checkout pr
     displayName: Setup taps and checkout


### PR DESCRIPTION
- We're seeing some `shallow update not allowed` errors in CI when
  pushing bottle commits.

Co-authored-by: Shaun Jackman <sjackman@gmail.com>