### PR TITLE
Revert "azure-pipelines: git fetch --unshallow"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,6 @@ jobs:
       sudo /home/linuxbrew/.linuxbrew/bin/brew tap homebrew/homebrew-test-bot
       cd /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
       git checkout -b test
-      if [ -e .git/shallow ]; then git fetch --unshallow; fi
       git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
       git checkout pr
     displayName: Setup taps and checkout


### PR DESCRIPTION
Reverts Homebrew/linuxbrew-core#14729

The _builds_, which run from this pipeline, are fine. It's the _bottles_, run from a step in the CI UI, that aren't working.