### PR TITLE
Revert "git rm circleci/config.yml"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: linuxbrew/brew
+    environment:
+      CIRCLE_REPOSITORY_URL: https://github.com/homebrew/linuxbrew-core
+      HOMEBREW_DEVELOPER: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_VERBOSE: 1
+      HOMEBREW_VERBOSE_USING_DOTS: 1
+      HOMEBREW_FAIL_LOG_LINES: 300
+      HOMEBREW_MAKE_JOBS: 8
+    steps:
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends netbase
+      - run: |
+          cd /home/linuxbrew/.linuxbrew/Homebrew
+          git fetch origin --tags
+          git reset --hard origin/master
+      - checkout
+      - run: git remote set-url origin $CIRCLE_REPOSITORY_URL
+      - run: if [ -e .git/shallow ]; then echo git fetch --unshallow; fi
+      - run: git fetch origin
+      - run: git config --global user.name LinuxbrewTestBot
+      - run: git config --global user.email testbot@linuxbrew.sh
+      - run: chmod 0644 Formula/*.rb
+      - run: mkdir -p /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew
+      - run: cp -a . /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
+      - run:
+         no_output_timeout: 60m
+         command: |
+          mkdir /tmp/bottles
+          cd /tmp/bottles
+          umask 022
+          PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"
+          brew install patchelf
+          brew tap linuxbrew/extra
+          brew tap linuxbrew/xorg
+          brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
+      - store_artifacts:
+          path: /tmp/bottles
+          destination: bottles
+      - store_test_results:
+          path: /tmp/bottles
+notify:
+  webhooks:
+    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/ci-upload?keep-old=1


### PR DESCRIPTION
Reverts Homebrew/linuxbrew-core#14639

We need to build bottles with Circle CI at least temporarily.