### PR TITLE
Remove "# Build a bottle for Linuxbrew' comments in formulae

### DIFF
--- a/Formula/cgdb.rb
+++ b/Formula/cgdb.rb
@@ -1,4 +1,3 @@
-# cgdb: Build a bottle for Linuxbrew
 class Cgdb < Formula
   desc "Curses-based interface to the GNU Debugger"
   homepage "https://cgdb.github.io/"

--- a/Formula/cxxtest.rb
+++ b/Formula/cxxtest.rb
@@ -1,4 +1,3 @@
-# cxxtest: Build a bottle for Linuxbrew
 class Cxxtest < Formula
   desc "xUnit-style unit testing framework for C++"
   homepage "https://cxxtest.com/"

--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -1,4 +1,3 @@
-# hugo: Build a bottle for Linuxbrew
 class Hugo < Formula
   desc "Configurable static site generator"
   homepage "https://gohugo.io/"

--- a/Formula/libjwt.rb
+++ b/Formula/libjwt.rb
@@ -1,4 +1,3 @@
-# libjwt: Build a bottle for Linuxbrew
 class Libjwt < Formula
   desc "JSON Web Token C library"
   homepage "https://github.com/benmcollins/libjwt"

--- a/Formula/libxlsxwriter.rb
+++ b/Formula/libxlsxwriter.rb
@@ -1,4 +1,3 @@
-# libxlsxwriter: Build a bottle for Linuxbrew
 class Libxlsxwriter < Formula
   desc "C library for creating Excel XLSX files"
   homepage "https://libxlsxwriter.github.io/"

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -1,4 +1,3 @@
-# llvm@6: Build a bottle for Linuxbrew
 class LlvmAT6 < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"

--- a/Formula/treefrog.rb
+++ b/Formula/treefrog.rb
@@ -1,4 +1,3 @@
-# treefrog: Build a bottle for Linuxbrew
 class Treefrog < Formula
   desc "High-speed C++ MVC Framework for Web Application"
   homepage "http://www.treefrogframework.org/"

--- a/Formula/ungit.rb
+++ b/Formula/ungit.rb
@@ -1,4 +1,3 @@
-# ungit: Build a bottle for Linuxbrew
 require "language/node"
 
 class Ungit < Formula

--- a/Formula/xmount.rb
+++ b/Formula/xmount.rb
@@ -1,4 +1,3 @@
-# xmount: Build a bottle for Linuxbrew
 class Xmount < Formula
   desc "Convert between multiple input & output disk image types"
   homepage "https://www.pinguin.lu/xmount/"


### PR DESCRIPTION
- These were left over from bad `brew squash-bottle-pr`s, or when we
  fixed builds for formulae when they failed the bottling step.