### PR TITLE
[Actions] Run `brew build-bottle-pr` on merges to master

### DIFF
--- a/.github/workflows/raise_bottle_prs.yml
+++ b/.github/workflows/raise_bottle_prs.yml
@@ -1,0 +1,81 @@
+name: brew build-bottle-pr on merges
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  bottle_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@master
+
+      - name: Set up Homebrew
+        run: |
+          HOMEBREW_REPOSITORY="$HOME/Homebrew"
+          export PATH="$HOMEBREW_REPOSITORY/bin:$PATH"
+          rm -rf $HOMEBREW_REPOSITORY
+          git clone --depth=1 https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"
+          HOMEBREW_CORE_TAP_DIR="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core"
+          mkdir -p "$HOMEBREW_CORE_TAP_DIR"
+          rm -rf "$HOMEBREW_CORE_TAP_DIR"
+          git clone https://github.com/Homebrew/linuxbrew-core "$HOMEBREW_CORE_TAP_DIR"
+          export HOMEBREW_GITHUB_USER=linuxbrewtestbot
+          export HOMEBREW_DEVELOPER=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_ANALYTICS=1
+          brew help # trigger vendored ruby installation
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "LinuxbrewTestBot"
+          git config --global user.email "testbot@linuxbrew.sh"
+
+      - name: Set up SSH key
+        env:
+          ISSYL0_BOT_SSH_KEY: {{ secrets.ISSYL0_BOT_SSH_KEY }}
+        run: |
+          mkdir ~/.ssh
+          chmod 700 ~/.ssh
+          echo "$LINUXBREWTESTBOT_SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          git config --global core.sshCommand "ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+
+      - name: Set up credentials for `hub`
+        env:
+          LINUXBREWTESTBOT_GITHUB_TOKEN: {{ secrets.LINUXBREWTESTBOT_GITHUB_TOKEN }}
+        run: |
+          cat <<EOF > ~/.config/hub
+          github.com:
+          - user: linuxbrewtestbot
+            oath_token: $LINUXBREWTESTBOT_GITHUB_TOKEN
+            protocol: https
+          EOF
+
+      - name: brew install hub
+        run: |
+          brew update
+          brew install hub
+
+      - name: Set up linuxbrew/developer tap
+        run: |
+          brew tap linuxbrew/developer
+
+      - name: Add issyl0 remote
+        run: |
+          cd $(brew --repo homebrew/core)
+          git remote add linuxbrewtestbot git@github.com:linuxbrewtestbot/linuxbrew-core.git
+          git fetch -p linuxbrewtestbot
+
+      - name: Run build-bottle-pr
+        run: |
+          if brew find-formulae-to-bottle > /dev/null; then
+            for i in $(brew find-formulae-to-bottle); do
+              brew build-bottle-pr $i
+            done
+          else
+            echo "Either there were no conflicts, HEAD is not a merge commit, or something else went wrong. Aborting."
+            exit 1
+          fi

--- a/.github/workflows/raise_bottle_prs.yml
+++ b/.github/workflows/raise_bottle_prs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up SSH key
         env:
-          ISSYL0_BOT_SSH_KEY: {{ secrets.ISSYL0_BOT_SSH_KEY }}
+          LINUXBREWTESTBOT_SSH_KEY: {{ secrets.LINUXBREWTESTBOT_SSH_KEY }}
         run: |
           mkdir ~/.ssh
           chmod 700 ~/.ssh

--- a/.github/workflows/raise_bottle_prs.yml
+++ b/.github/workflows/raise_bottle_prs.yml
@@ -63,14 +63,10 @@ jobs:
         run: |
           brew tap linuxbrew/developer
 
-      - name: Add issyl0 remote
-        run: |
-          cd $(brew --repo homebrew/core)
-          git remote add linuxbrewtestbot git@github.com:linuxbrewtestbot/linuxbrew-core.git
-          git fetch -p linuxbrewtestbot
-
       - name: Run build-bottle-pr
         run: |
+          cd $(brew --repo homebrew/core)
+
           if brew find-formulae-to-bottle > /dev/null; then
             for i in $(brew find-formulae-to-bottle); do
               brew build-bottle-pr $i


### PR DESCRIPTION
- Currently, after merges between Homebrew/homebrew-core and Homebrew/linuxbrew-core, maintainers must build bottles for formulae that had merge conflicts that were in the bottle blocks.
- Thankfully, there's a command for this: [`brew build-bottle-pr`](https://github.com/Linuxbrew/homebrew-developer/blob/master/cmd/brew-build-bottle-pr.rb), but it still takes time to get the list of changed formulae and run the command to raise each PR.
- GitHub Actions, on merges to master, can run [`brew find-formulae-to-bottle`](https://github.com/Linuxbrew/homebrew-developer/blob/master/cmd/brew-find-formulae-to-bottle.rb) to detect if it's a merge commit, and if it is, it will run `brew build-bottle-pr` on each of the changed formulae and raise PRs as the `LinuxbrewTestBot` GitHub user.

TODO:
- [ ] Generate GITHUB_TOKEN and SSH_KEY credentials for the LinuxbrewTestBot user and add them to its account. This requires a GITHUB_TOKEN because of `hub`. I am not sure if the default Actions-provided one will work. It might, because it'll be raising PRs against the same repo the Action is running from (unlike in my testing repo).
- [ ] Add the credentials to the secrets repo settings pane so that Actions can retrieve them. This requires a repo admin, please.

Things to note:
- This Action does not handle deleting of branches. This will become a problem _if_ we choose to stick with the default I chose here of the bot pushing branches to its fork:
  - Someone will have to log in as that user and delete the closed PRs branches.
  - Or, we set this up to push to branches directly on this repo (`origin`), which means that maintainers can delete them, or we can use [GitHub's new "delete branches" feature](https://help.github.com/en/articles/managing-the-automatic-deletion-of-branches) (though that might work better if we _merged_ PRs rather than _closed_ them?).
  - A future Action may be to make something that deletes branches automatically. :pray:
- THIS IS AS YET ENTIRELY UNTESTED WITH THE NEW ACTIONS YAML SYNTAX AND THE LINUXBREWTESTBOT USER!