### PR TITLE
depend on libcap

### DIFF
--- a/Formula/gor.rb
+++ b/Formula/gor.rb
@@ -14,6 +14,7 @@ class Gor < Formula
   end
 
   depends_on "go" => :build
+  depends_on "libpcap" unless OS.mac?
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
libcap headers required in order to build `gor`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. --- see original issue

-----
Original Issue: https://github.com/Homebrew/linuxbrew-core/issues/14837

revision 1
