### PR TITLE
Switch `uses_from_macos linuxbrew/xorg` to `depends_on`

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -20,7 +20,7 @@ class DiffPdf < Formula
   depends_on "poppler"
   depends_on "wxmac"
   depends_on :x11 if OS.mac?
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -42,7 +42,7 @@ class Freerdp < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on :x11 if OS.mac?
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gifsicle.rb
+++ b/Formula/gifsicle.rb
@@ -19,7 +19,7 @@ class Gifsicle < Formula
     depends_on "automake" => :build
   end
 
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   conflicts_with "giflossy",
     :because => "both install an `gifsicle` binary"

--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -15,7 +15,7 @@ class Gromacs < Formula
   depends_on "fftw"
   depends_on "gsl"
   depends_on "gcc" # for OpenMP
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     # Non-executable GMXRC files should be installed in DATADIR

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -33,7 +33,7 @@ class Imagemagick < Formula
   uses_from_macos "libxml2"
 
   uses_from_macos "bzip2"
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
   uses_from_macos "libxml2"
 
   skip_clean :la

--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -19,7 +19,7 @@ class Imlib2 < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on :x11 if OS.mac?
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     args = %W[

--- a/Formula/links.rb
+++ b/Formula/links.rb
@@ -17,7 +17,7 @@ class Links < Formula
   depends_on "librsvg"
   depends_on "libtiff"
   depends_on "openssl"
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     args = %W[

--- a/Formula/ncview.rb
+++ b/Formula/ncview.rb
@@ -17,7 +17,7 @@ class Ncview < Formula
   depends_on "netcdf"
   depends_on "udunits"
   depends_on :x11 if OS.mac?
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     # Bypass compiler check (which fails due to netcdf's nc-config being

--- a/Formula/plotutils.rb
+++ b/Formula/plotutils.rb
@@ -19,7 +19,7 @@ class Plotutils < Formula
   end
 
   depends_on "libpng"
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     # Fix usage of libpng to be 1.5 compatible

--- a/Formula/xclip.rb
+++ b/Formula/xclip.rb
@@ -17,7 +17,7 @@ class Xclip < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on :x11 if OS.mac?
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/xdotool.rb
+++ b/Formula/xdotool.rb
@@ -18,7 +18,7 @@ class Xdotool < Formula
   depends_on "libxkbcommon"
 
   depends_on :x11 if OS.mac?
-  uses_from_macos "linuxbrew/xorg/xorg"
+  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
 
   def install
     # Work around an issue with Xcode 8 on El Capitan, which


### PR DESCRIPTION
- Saying that the `linuxbrew/xorg/xorg` formula comes from macOS disturbs
  my comprehension of the `uses_from_macos` construct, and is untrue.
  This appeared in
  https://github.com/Homebrew/linuxbrew-core/pull/13947.