### PR TITLE
meson: do not modify RPATH when installing if install_rpath is not set

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -4,17 +4,22 @@ class Meson < Formula
   url "https://github.com/mesonbuild/meson/releases/download/0.51.1/meson-0.51.1.tar.gz"
   sha256 "f27b7a60f339ba66fe4b8f81f0d1072e090a08eabbd6aa287683b2c2b9dd2d82"
   head "https://github.com/mesonbuild/meson.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
     sha256 "9e738539de75c599ffda9eb9abc13634daa470fd3ee84e6f2d58c75c209cf585" => :mojave
     sha256 "9e738539de75c599ffda9eb9abc13634daa470fd3ee84e6f2d58c75c209cf585" => :high_sierra
     sha256 "fe1e6d70ef40f9239304d9ae3412ce19f8150ffbdcb112cd8c8c45422a1ca0b7" => :sierra
-    sha256 "a6d343c3b07705fb3ebf2a9158098617b05625642e5370e8c356e16f1ddd7728" => :x86_64_linux
   end
 
   depends_on "ninja"
   depends_on "python"
+
+  patch do
+    url "https://raw.githubusercontent.com/MontaVista-OpenSourceTechnology/poky/f705787a07f1043d9143516cb3b9775fd758107d/meta/recipes-devtools/meson/meson/disable-rpath-handling.patch"
+    sha256 "73eeaba28dd4de2e5fad39338c39b1fb66d6d92bf6e2a8c714b1a8d319c66748"
+  end
 
   def install
     version = Language::Python.major_minor_version("python3")


### PR DESCRIPTION


- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
By default meson will remove all RPATH data when installing software
The patch the formula is fetching has been provided for fixing
https://github.com/mesonbuild/meson/issues/4027 which is similar to
the problem linuxbrew is having as it doesn't install software in
the normal path.
The patch is adding a test before modifying RPATH:
- if install_rpath is set, modify RPATH to install_rpath
- otherwise, keep existing RPATH