### PR TITLE
minikube: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -1,0 +1,26 @@
+class Minikube < Formula
+  desc "Run a Kubernetes cluster locally"
+  homepage "https://github.com/kubernetes/minikube"
+  url "https://github.com/kubernetes/minikube/archive/v1.3.1.tar.gz"
+  sha256 "7aa57e5896852c499f1687fbc424abf93645e1801fc9f8c2833e0affbb76eb41"
+  # tag "linuxbrew"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ENV.deparallelize
+    ENV["GOOS"] = "linux"
+    ENV["GOARCH"] = "amd64"
+
+    system "make"
+    bin.install "out/minikube"
+  end
+
+  test do
+    assert_match("config modifies minikube config files using subcommands like \"minikube config set vm-driver kvm\"", shell_output("#{bin}/minikube config"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Follow up from #14947. As requested I'm splitting each one into its
  own PR and updating them if necessary.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires enother `brew tap` command,
  and we're gradually deprecating the Linuxbrew organisation.
- This is tagged with `linuxbrew` so that it's visibly Linux-only. On
  macOS, `minikube` is a Cask.