### PR TITLE
aws-vault: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -1,0 +1,30 @@
+class AwsVault < Formula
+  desc "Securely store and access AWS credentials in development environments"
+  homepage "https://github.com/99designs/aws-vault"
+  url "https://github.com/99designs/aws-vault/archive/v4.6.3.tar.gz"
+  sha256 "89428b99568d67335c5a9a4f74bdc7f4511864aa1dd11a07e7912588bcaa2716"
+  # tag "linuxbrew"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOOS"] = "linux"
+    ENV["GOARCH"] = "amd64"
+
+    flags = "-X main.Version=#{version} -s -w"
+
+    system "go", "build", "-ldflags=#{flags}"
+    bin.install "aws-vault"
+
+    zsh_completion.install "completions/zsh/_aws-vault"
+    bash_completion.install "completions/bash/aws-vault"
+  end
+
+  test do
+    assert_match("aws-vault: error: required argument 'profile' not provided, try --help", shell_output("#{bin}/aws-vault login 2>&1", 1))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Follow up from #14947. As requested I'm splitting each one into its
  own PR and updating them if necessary.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires another `brew tap` command, and
  we're gradually deprecating the Linuxbrew organisation.
- This is tagged with `linuxbrew` so that it's visibly Linux-only. On
  macOS, `aws-vault` is a Cask.