### PR TITLE
singularity: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/singularity.rb
+++ b/Formula/singularity.rb
@@ -1,0 +1,29 @@
+class Singularity < Formula
+  desc "Application containers for Linux"
+  homepage "https://www.sylabs.io/singularity/"
+  url "https://github.com/sylabs/singularity/releases/download/v3.3.0/singularity-3.3.0.tar.gz"
+  sha256 "070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f"
+  # tag "linuxbrew"
+
+  bottle do
+  end
+
+  depends_on "go" => :build
+  depends_on "openssl" => :build
+  depends_on "libarchive"
+  depends_on "pkg-config"
+  depends_on "squashfs"
+  depends_on "util-linux" # for libuuid
+
+  def install
+    system "./mconfig", "--prefix=#{prefix}"
+    cd "./builddir" do
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/singularity --help")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----
- Follow up from #14947. As requested I'm splitting each one into its own PR and updating them if necessary.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires enother `brew tap` command,
  and we're gradually deprecating the Linuxbrew organisation.
- This commit also upgrades `singularity` from 2.6.0 to the latest:
  3.3.0. The entire build system has changed to be Go-based.
- This is tagged with linuxbrew so that it's visibly Linux-only.