### PR TITLE
linux-pam: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/linux-pam.rb
+++ b/Formula/linux-pam.rb
@@ -1,0 +1,46 @@
+class LinuxPam < Formula
+  desc "Pluggable Authentication Modules for Linux"
+  homepage "http://www.linux-pam.org"
+  url "https://github.com/linux-pam/linux-pam/releases/download/v1.3.1/Linux-PAM-1.3.1.tar.xz"
+  sha256 "eff47a4ecd833fbf18de9686632a70ee8d0794b79aecb217ebd0ce11db4cd0db"
+  head "https://github.com/linux-pam/linux-pam.git"
+  # tag "linuxbrew"
+
+  bottle do
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "berkeley-db"
+  depends_on "libprelude"
+
+  skip_clean :la, "etc"
+
+  def install
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --includedir=#{include}/security
+      --oldincludedir=#{include}
+      --enable-securedir=#{lib}/security
+      --sysconfdir=#{etc}
+      --with-xml-catalog=#{etc}/xml/catalog
+      --with-libprelude-prefix=#{Formula["libprelude"].opt_prefix}
+    ]
+
+    system "./configure", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  def post_install
+    chmod "u=rwxs,g=rx,o=rx", "#{sbin}/unix_chkpwd"
+  end
+
+  test do
+    File.exist? "#{sbin}/unix_chkpwd"
+    assert_match "Usage", shell_output("#{sbin}/mkhomedir_helper 2>&1", 14)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Follow up from #14947. As requested I'm splitting each one into its
  own PR and updating them if necessary.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires enother brew tap command,
  and we're gradually deprecating the Linuxbrew organisation.
- This is tagged with `linuxbrew` so that it's visibly Linux-only.