### PR TITLE
lm-sensors: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/lm-sensors.rb
+++ b/Formula/lm-sensors.rb
@@ -1,0 +1,29 @@
+class LmSensors < Formula
+  desc "Tools for monitoring the temperatures, voltages, and fans"
+  homepage "https://github.com/groeck/lm-sensors"
+  url "https://github.com/lm-sensors/lm-sensors/archive/V3-5-0.tar.gz"
+  version "3.5.0"
+  sha256 "f671c1d63a4cd8581b3a4a775fd7864a740b15ad046fe92038bcff5c5134d7e0"
+  # tag "linuxbrew"
+
+  bottle do
+  end
+
+  depends_on "bison" => :build
+  depends_on "flex" => :build
+
+  def install
+    args = %W[
+      PREFIX=#{prefix}
+      BUILD_STATIC_LIB=0
+      MANDIR=#{man}
+      ETCDIR=#{prefix}/etc
+    ]
+    system "make", *args
+    system "make", *args, "install"
+  end
+
+  test do
+    assert_match("Usage", shell_output("#{bin}/sensors --help"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Follow up from #14947. As requested I'm splitting each one into its
  own PR and updating them if necessary.
- I've added a `--help` text check as a test to appease `brew audit
  --strict` - we can revisit this later. I would have done an actual
  test, but I didn't know what CI would output as against my local
  machine.
- I also renamed this formula `lm-sensors` from `lm_sensors` as
  the source repo is hyphenated.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires enother `brew tap` command,
  and we're gradually deprecating the Linuxbrew organisation.
- This is tagged with `linuxbrew` so that it's visibly Linux-only.