### PR TITLE
strace: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/strace.rb
+++ b/Formula/strace.rb
@@ -1,0 +1,35 @@
+class Strace < Formula
+  desc "Diagnostic, instructional, and debugging tool for the Linux kernel"
+  homepage "https://strace.io/"
+  url "https://github.com/strace/strace/releases/download/v5.2/strace-5.2.tar.xz"
+  sha256 "d513bc085609a9afd64faf2ce71deb95b96faf46cd7bc86048bc655e4e4c24d2"
+  # tag "linuxbrew"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  head do
+    url "https://github.com/strace/strace.git"
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
+  depends_on "linux-headers"
+
+  def install
+    system "./bootstrap" if build.head?
+    system "./configure",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+      "--enable-mpers=no" # FIX: configure: error: Cannot enable m32 personality support
+    system "make", "install"
+  end
+
+  test do
+    out = `"strace" "true" 2>&1` # strace the true command, redirect stderr to output
+    assert_match "execve(", out
+    assert_match "+++ exited with 0 +++", out
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,4 +1,3 @@
 {
-  "iotop": "linuxbrew/extra",
-  "strace": "linuxbrew/extra"
+  "iotop": "linuxbrew/extra"
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----
- Follow up from #14947. As requested I'm splitting each one into its
own PR and updating them if necessary.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires enother brew tap command,
  and we're gradually deprecating the Linuxbrew organisation.
- This is tagged with `linuxbrew` so that it's visibly Linux-only.
- There's no point this formula being in `tap_migrations.json` any more.