### PR TITLE
tap_migrations: Remove non-existent formulae

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,6 +1,4 @@
 {
   "iotop": "linuxbrew/extra",
-  "libpipeline": "linuxbrew/extra",
-  "man-db": "linuxbrew/extra",
   "strace": "linuxbrew/extra"
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- `man-db` was moved from Linuxbrew/homebrew-extra to -core in February:
  https://github.com/Homebrew/homebrew-core/pull/36629
- `libpipeline` was folded into the `man-db` formula as a resource, and
  is no longer in Linuxbrew/homebrew-extra either.