### PR TITLE
iotop: Migrate from Linuxbrew/homebrew-extra tap

### DIFF
--- a/Formula/iotop.rb
+++ b/Formula/iotop.rb
@@ -1,0 +1,26 @@
+class Iotop < Formula
+  desc "Top-like UI used to show which process is using the I/O"
+  homepage "http://guichaz.free.fr/iotop/"
+  url "http://guichaz.free.fr/iotop/files/iotop-0.6.tar.bz2"
+  sha256 "3adea2a24eda49bbbaeb4e6ed2042355b441dbd7161e883067a02bfc8dcef75b"
+  revision 1
+  head "git://repo.or.cz/iotop.git"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  depends_on "python@2"
+
+  def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
+
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    assert_match "DISK READ and DISK WRITE", shell_output("#{bin}/iotop --help")
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,0 @@
-{
-  "iotop": "linuxbrew/extra"
-}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Follow up from #14947. As requested I'm splitting each one into its
  own PR and updating them if necessary.
- This was added to Linuxbrew/homebrew-extra, but that repo is less
  discoverable than this one, requires enother brew tap command,
  and we're gradually deprecating the Linuxbrew organisation.
- This is tagged with linuxbrew so that it's visibly Linux-only.
- There's no point this formula being in tap_migrations.json any more.