### PR TITLE
duo_unix: The linux-pam dependency comes from -core now, not linuxbrew/extra

### DIFF
--- a/Formula/duo_unix.rb
+++ b/Formula/duo_unix.rb
@@ -3,19 +3,19 @@ class DuoUnix < Formula
   homepage "https://www.duosecurity.com/docs/duounix"
   url "https://github.com/duosecurity/duo_unix/archive/duo_unix-1.11.2.tar.gz"
   sha256 "e1ec2f43036ba639743d631f308419c9a88618a93d4038bf40a9cdeef89ca6db"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "006db27f7e6d2370e6a5e318c5c5eb0105c1dd5092c0fe397b0c9196d7298432" => :mojave
     sha256 "c77151aad876b68e731ac2f63ea6ca661f95e0e1e603a0c081f0d7a6d5c110c2" => :high_sierra
     sha256 "dcd51390cdf902d90e1c9f21b67f4a38a4b470d4bd8b7e1190c40d0df6641377" => :sierra
-    sha256 "96dc74d6eaa6246abdff20855d456698ecd9b7b017f64f2309508ba118ab4aa1" => :x86_64_linux
   end
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "openssl"
-  uses_from_macos "linuxbrew/extra/linux-pam"
+  depends_on "linux-pam" unless OS.mac?
 
   def install
     system "./bootstrap"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Follow up from #15026.