### PR TITLE
Fix building Terraform 0.11 on Linux.

### DIFF
--- a/Formula/terraform@0.11.rb
+++ b/Formula/terraform@0.11.rb
@@ -18,6 +18,7 @@ class TerraformAT011 < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "on" unless OS.mac?
     ENV.prepend_create_path "PATH", buildpath/"bin"
 
     dir = buildpath/"src/github.com/hashicorp/terraform"
@@ -28,11 +29,14 @@ class TerraformAT011 < Formula
       ENV.delete "AWS_ACCESS_KEY"
       ENV.delete "AWS_SECRET_KEY"
 
-      ENV["XC_OS"] = "darwin"
+      os = OS.mac? ? "darwin" : "linux"
+      ENV["XC_OS"] = os
       ENV["XC_ARCH"] = "amd64"
-      system "make", "tools", "test", "bin"
+      # Tests fail to build on linux: FAIL: TestFmt_check
+      # See https://github.com/Homebrew/linuxbrew-core/pull/13309
+      system "make", "tools", *("test" if OS.mac?), "bin"
 
-      bin.install "pkg/darwin_amd64/terraform"
+      bin.install "pkg/#{os}_amd64/terraform"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

```
➜ brew install terraform@0.11
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
git-crypt ✔        doctl              ejabberd           epic5              fossil             gerbil-scheme      gocryptfs          h2o                http_load          ike-scan           libdvbpsi          minio              siege
afflib             dovecot            ekg2               erlang@21          fq                 getxbook           gsoap              haproxy            httping            ircd-hybrid        libfaketime        minio-mc           stunnel
dcmtk              duo_unix           encfs              exim               freeradius-server  gloox              gtmess             heimdal            httrack            juju               libpulsar          rdesktop           u-boot-tools
==> Deleted Formulae
frag_find                                                                                                                       ftimes

==> Downloading https://github.com/hashicorp/terraform/archive/v0.11.14.tar.gz
Already downloaded: /home/nirvdrum/.cache/Homebrew/downloads/13115c72dcc5da1d8b60b54e1022cba5cd86dce72969027ae9d62f8a24a948db--terraform-0.11.14.tar.gz
==> make tools test bin
Last 15 lines from /home/nirvdrum/.cache/Homebrew/Logs/terraform@0.11/01.make:
GO111MODULE=off go get -u github.com/golang/mock/mockgen
==> Checking that code complies with gofmt requirements...
GOFLAGS=-mod=vendor go generate ./...
2019/08/29 16:13:16 Generated command/internal_plugin_list.go
# go fmt doesn't support -mod=vendor but it still wants to populate the
# module cache with everything in go.mod even though formatting requires
# no dependencies, and so we're disabling modules mode for this right
# now until the "go fmt" behavior is rationalized to either support the
# -mod= argument or _not_ try to install things.
GO111MODULE=off go fmt command/internal_plugin_list.go > /dev/null
go list -mod=vendor ./... | xargs -t -n4 go test  -mod=vendor -timeout=2m -parallel=4
build flag -mod=vendor only valid when using modules
go test -mod=vendor -timeout=2m -parallel=4 
build flag -mod=vendor only valid when using modules
make: *** [Makefile:35: test] Error 123

READ THIS: https://docs.brew.sh/Troubleshooting
```

-----

I mostly just ported the changes from terraform.rb that make it work with Linux. I have no idea why the Linux-compatible build changes aren't upstream. But it probably makes sense to get the Terraform Linux formulae all working with Linux and then push to have them merged upstream in one pass.