### PR TITLE
stdman: Get `man-db` dependency from core not linuxbrew/extra

### DIFF
--- a/Formula/stdman.rb
+++ b/Formula/stdman.rb
@@ -3,6 +3,7 @@ class Stdman < Formula
   homepage "https://github.com/jeaye/stdman"
   url "https://github.com/jeaye/stdman/archive/2018.03.11.tar.gz"
   sha256 "d29e6b34cb5ba9905360cee6adcdf8c49e7f11272521bf2e10b42917486840e8"
+  revision 1
   version_scheme 1
   head "https://github.com/jeaye/stdman.git"
 
@@ -12,10 +13,9 @@ class Stdman < Formula
     sha256 "0f795424e68e066cc1f6c567a5513001481cd610cded75dfab77aa8db42cf9ed" => :high_sierra
     sha256 "d3e640c191d2cf471b37b2121d20ebab97ff353f2d69616cfa7f7227db069beb" => :sierra
     sha256 "d4b15103ae4011c1f2c9a4e3dcb0b205bfa45595d7ad25d6cb87ec1dc4f395ab" => :el_capitan
-    sha256 "b6b0ef820da71198038598ff37437525a2079bb58701ebaf71de5fe3c182c294" => :x86_64_linux
   end
 
-  depends_on "linuxbrew/extra/man-db" => :test unless OS.mac?
+  depends_on "man-db" => :test unless OS.mac?
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- `man-db` was removed from linuxbrew/extra in February, and now that tap is deprecated.