### PR TITLE
pixz: depend on libxslt

### DIFF
--- a/Formula/pixz.rb
+++ b/Formula/pixz.rb
@@ -16,6 +16,7 @@ class Pixz < Formula
   depends_on "asciidoc" => :build
   depends_on "docbook" => :build
   depends_on "pkg-config" => :build
+  depends_on "libxslt" unless OS.mac?
   depends_on "libarchive"
   depends_on "xz"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Build fails without this dependency:
```sh
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/pixz/1.0.6_1
==> make
==> make install
==> a2x --doctype manpage --format manpage src/pixz.1.asciidoc
Last 15 lines from /home/dawidd6/.cache/Homebrew/Logs/pixz/04.a2x:
2019-09-10 17:26:17 +0200

a2x
--doctype
manpage
--format
manpage
src/pixz.1.asciidoc

a2x: ERROR: "xsltproc"  --stringparam callout.graphics 0 --stringparam navig.graphics 0 --stringparam admon.textlabel 1 --stringparam admon.graphics 0  "/home/linuxbrew/.linuxbrew/Cellar/asciidoc/8.6.10_4/etc/asciidoc/docbook-xsl/manpage.xsl" "/tmp/pixz-20190910-6610-163tq2n/pixz-1.0.6/src/pixz.1.xml" returned non-zero exit status 127
==> Kept temporary files
Temporary files retained at /tmp/pixz-20190910-6610-163tq2n

READ THIS: https://docs.brew.sh/Troubleshooting
```