### PR TITLE
pyenv: drop python2 dependency

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -15,11 +15,11 @@ class Pyenv < Formula
     sha256 "58dfa3676f53f08c1dc5da03af42e120335cae4c5ea2541fce7a203d83322034" => :x86_64_linux
   end
 
+  depends_on "python@2" => :test
   depends_on "autoconf"
   depends_on "openssl@1.1"
   depends_on "pkg-config"
   depends_on "readline"
-  depends_on "python@2" => :test
 
   def install
     inreplace "libexec/pyenv", "/usr/local", HOMEBREW_PREFIX

--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -3,7 +3,7 @@ class Pyenv < Formula
   homepage "https://github.com/pyenv/pyenv"
   url "https://github.com/pyenv/pyenv/archive/v1.2.13.tar.gz"
   sha256 "ebf9899f70cb04a6a6bf9835c37d9d7e4ed7dadb22dd8123b19d6d790a13fffe"
-  revision 1
+  revision 2
   version_scheme 1
   head "https://github.com/pyenv/pyenv.git"
 
@@ -19,7 +19,7 @@ class Pyenv < Formula
   depends_on "openssl@1.1"
   depends_on "pkg-config"
   depends_on "readline"
-  depends_on "python@2" => :test unless OS.mac?
+  depends_on "python@2" => :test
 
   def install
     inreplace "libexec/pyenv", "/usr/local", HOMEBREW_PREFIX


### PR DESCRIPTION
Hi!

The crux of this PR is [this](https://github.com/pyenv/pyenv#in-contrast-with-pythonbrew-and-pythonz-pyenv-does-not), that `pyenv` doesn't require python to build and install, and never did.

That the formula here mentions python2, I think, is a bug.

It looks like it's causing a CI failure here: ycm-core/ycmd#1301

OSX's homebrew doesn't install python2 for `pyenv` either; so I'm sending the PR to this repo, per CONTRIBUTING.md.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
