### PR TITLE
vim: bump revision for python 3.7.4_1

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -5,12 +5,12 @@ class Vim < Formula
   url "https://github.com/vim/vim/archive/v8.1.2000.tar.gz"
   sha256 "11f19bb169391e9eefb775baf9b8db0c8382ecb222c3bd0fa321f6b945fa4a65"
   head "https://github.com/vim/vim.git"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "1864054669ee13ce21a34fc9306be860b5584c5c77423e0359d7327cf1bbdf77" => :mojave
     sha256 "cc641ce613cdbee9182ed2fb269f62e7050e6c8965d7e4df7b8bcbb08137ae89" => :high_sierra
     sha256 "0b44d535bfcf3273bab46ccf183575a018ec15f7b9665f03d1951d82d803c809" => :sierra
-    sha256 "b0dfed063fe441d5ab845da0e105c735a373dce48dcc80f9f6307d8708bd6005" => :x86_64_linux
   end
 
   depends_on "gettext"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The version of the current bottled vim:
```
VIM - Vi IMproved 8.1 (2018 May 18, compiled Sep 10 2019 18:48:11)
Included patches: 1-1999
Compiled by Homebrew
Huge version without GUI.  Features included (+) or not (-):
+acl               -farsi             -mouse_sysmouse    -tag_any_white
+arabic            +file_in_path      +mouse_urxvt       -tcl
+autocmd           +find_in_path      +mouse_xterm       +termguicolors
+autochdir         +float             +multi_byte        +terminal
-autoservername    +folding           +multi_lang        +terminfo
-balloon_eval      -footer            -mzscheme          +termresponse
+balloon_eval_term +fork()            +netbeans_intg     +textobjects
-browse            +gettext           +num64             +textprop
++builtin_terms    -hangul_input      +packages          +timers
+byte_offset       +iconv             +path_extra        +title
+channel           +insert_expand     +perl              -toolbar
+cindent           +job               +persistent_undo   +user_commands
-clientserver      +jumplist          +postscript        +vartabs
-clipboard         +keymap            +printer           +vertsplit
+cmdline_compl     +lambda            +profile           +virtualedit
+cmdline_hist      +langmap           -python            +visual
+cmdline_info      +libcall           +python3           +visualextra
+comments          +linebreak         +quickfix          +viminfo
+conceal           +lispindent        +reltime           +vreplace
+cryptv            +listcmds          +rightleft         +wildignore
+cscope            +localmap          +ruby              +wildmenu
+cursorbind        -lua               +scrollbind        +windows
+cursorshape       +menu              +signs             +writebackup
+dialog_con        +mksession         +smartindent       -X11
+diff              +modify_fname      -sound             -xfontset
+digraphs          +mouse             +spell             -xim
-dnd               -mouseshape        +startuptime       -xpm
-ebcdic            +mouse_dec         +statusline        -xsmp
+emacs_tags        -mouse_gpm         -sun_workshop      -xterm_clipboard
+eval              -mouse_jsbterm     +syntax            -xterm_save
+ex_extra          +mouse_netterm     +tag_binary
+extra_search      +mouse_sgr         -tag_old_static
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
       defaults file: "$VIMRUNTIME/defaults.vim"
  fall-back for $VIM: "/home/linuxbrew/.linuxbrew/share/vim"
Compilation: gcc-5 -c -I. -Iproto -DHAVE_CONFIG_H     -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
Linking: gcc-5   -L. -fstack-protector-strong -rdynamic -Wl,-export-dynamic -L/home/linuxbrew/.linuxbrew/opt/libyaml/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib -L/home/linuxbrew/.linuxbrew/opt/readline/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/readline/lib -Wl,-E -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/perl/5.30.0/lib/perl5/5.30.0/x86_64-linux-thread-multi/CORE   -L/usr/local/lib -Wl,--as-needed -o vim        -lm -lnsl   -lncurses -ldl   -Wl,-E -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/perl/5.30.0/lib/perl5/5.30.0/x86_64-linux-thread-multi/CORE  -fstack-protector-strong -L/usr/local/lib  -L/home/linuxbrew/.linuxbrew/Cellar/perl/5.30.0/lib/perl5/5.30.0/x86_64-linux-thread-multi/CORE -lperl -lpthread -lnsl -ldl -lm -lcrypt -lutil -lc  -L/home/linuxbrew/.linuxbrew/Cellar/python/3.7.4/lib/python3.7/config-3.7m-x86_64-linux-gnu -lpython3.7m -lcrypt -lpthread -ldl -lutil -lm  -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/ruby/2.6.4_2/lib -L/home/linuxbrew/.linuxbrew/Cellar/ruby/2.6.4_2/lib -lruby -lm
```

Note that it refers `-L/home/linuxbrew/.linuxbrew/Cellar/python/3.7.4/lib/python3.7/config-3.7m-x86_64-linux-gnu`, but the current version of python is `3.7.4_1`.