### PR TITLE
go@1.12: fix build

### DIFF
--- a/Formula/go@1.12.rb
+++ b/Formula/go@1.12.rb
@@ -22,18 +22,24 @@ class GoAT112 < Formula
 
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
-    url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
+    if OS.mac?
+      url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
+      sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+    elsif OS.linux?
+      url "https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz"
+      sha256 "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
+    end
     version "1.7"
-    sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
   end
 
   def install
+    ENV["CGO_ENABLED"] = "1" unless OS.mac?
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
+      ENV["GOOS"]         = OS.mac? ? "darwin" : "linux"
       system "./make.bash", "--no-clean"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This PR should also fix: https://github.com/Homebrew/linuxbrew-core/pull/15726

Build error taken from CI:
```sh
Building Go cmd/dist using /tmp/go@1.12-20190920-5895-kpx3ha/go/gobootstrap.
./make.bash: line 167: /tmp/go@1.12-20190920-5895-kpx3ha/go/gobootstrap/bin/go: cannot execute binary file: Exec format error
```

Looks like this formula somehow slipped through the merge process.