### PR TITLE
python: replace Cellar paths with opt in config

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -3,11 +3,10 @@ class Python < Formula
   homepage "https://www.python.org/"
   url "https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz"
   sha256 "fb799134b868199930b75f26678f18932214042639cd52b16da7fd134cd9b13f"
-  revision 1
+  revision OS.mac? ? 1 : 2
   head "https://github.com/python/cpython.git"
 
   bottle do
-    sha256 "826f498701eaced3c4c365526c0bf48da9a64242024868133e6ded9746ed4d4b" => :x86_64_linux
   end
 
   # setuptools remembers the build flags python is built with and uses them to
@@ -182,6 +181,12 @@ class Python < Formula
       # https://github.com/Homebrew/homebrew/issues/15943
       ["Headers", "Python", "Resources"].each { |f| rm(prefix/"Frameworks/Python.framework/#{f}") }
       rm prefix/"Frameworks/Python.framework/Versions/Current"
+    else
+      # Prevent third-party packages from building against fragile Cellar paths
+      inreplace Dir[lib_cellar/"**/_sysconfigdata_m_linux_x86_64-*.py",
+                    lib_cellar/"config*/Makefile",
+                    lib/"pkgconfig/python-3.?.pc"],
+                prefix, opt_prefix
     end
 
     # Symlink the pkgconfig files into HOMEBREW_PREFIX so they're accessible.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This fixes <https://github.com/Homebrew/linuxbrew-core/pull/15701#issuecomment-533898665>.

But about `_sysconfigdata_m_linux_x86_64-linux-gnu.py`, do you want it to be `_sysconfigdata_m_linux_x86_64-*.py`, or `_sysconfigdata_m_linux_*.py`?