### PR TITLE
libnetfilter-queue: new formula

### DIFF
--- a/Formula/libnetfilter-queue.rb
+++ b/Formula/libnetfilter-queue.rb
@@ -1,0 +1,56 @@
+class LibnetfilterQueue < Formula
+  desc "Userspace API to packets queued by the kernel packet filter"
+  homepage "https://www.netfilter.org/projects/libnetfilter_queue"
+  url "git://git.netfilter.org/libnetfilter_queue",
+    :tag      => "libnetfilter_queue-1.0.3",
+    :revision => "601abd1c71ccdf90753cf294c120ad43fb25dc54"
+  # tag "linuxbrew"
+
+  bottle do
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libmnl"
+  depends_on "libnfnetlink"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <errno.h>
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <unistd.h>
+      #include <string.h>
+      #include <time.h>
+      #include <arpa/inet.h>
+
+      #include <libmnl/libmnl.h>
+      #include <linux/netfilter.h>
+      #include <linux/netfilter/nfnetlink.h>
+
+      #include <linux/types.h>
+      #include <linux/netfilter/nfnetlink_queue.h>
+
+      #include <libnetfilter_queue/libnetfilter_queue.h>
+
+      int main(int argc, char *argv[])
+      {
+        struct mnl_socket *nl;
+        char buf[NFQA_CFG_F_MAX];
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmnl", "-o", "test"
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Dependency of: https://github.com/Homebrew/linuxbrew-core/pull/15835