### PR TITLE
Remove remaining CIRCLECI checks for Linuxbrew

### DIFF
--- a/Formula/asio.rb
+++ b/Formula/asio.rb
@@ -19,9 +19,6 @@ class Asio < Formula
   depends_on "openssl@1.1"
 
   def install
-    # Reduce memory usage for CircleCI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     if build.head?

--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -23,9 +23,6 @@ class Blast < Formula
   conflicts_with "proj", :because => "both install a `libproj.a` library"
 
   def install
-    # Reduce memory usage for CircleCI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     cd "c++" do
       # Use ./configure --without-boost to fix
       # error: allocating an object of abstract class type 'ncbi::CNcbiBoostLogger'

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -93,6 +93,6 @@ class BoostMpi < Formula
     EOS
     boost = Formula["boost"]
     system "mpic++", "test.cpp", "-L#{lib}", "-L#{boost.lib}", "-lboost_mpi-mt", "-lboost_serialization", "-o", "test"
-    system "mpirun", *("--allow-run-as-root" if ENV["CIRCLECI"]), "-np", "2", "./test"
+    system "mpirun", *("--allow-run-as-root" if ENV["CI"]), "-np", "2", "./test"
   end
 end

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -61,7 +61,7 @@ class ClangFormat < Formula
       args << "-DLLVM_ENABLE_LIBCXX=OFF" unless OS.mac?
       args << ".."
       system "cmake", "-G", "Ninja", *args
-      system "ninja", *("-j2" if ENV["CIRCLECI"]), "clang-format"
+      system "ninja", "clang-format"
       bin.install "bin/clang-format"
     end
     bin.install "tools/clang/tools/clang-format/git-clang-format"

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -78,7 +78,7 @@ class Consul < Formula
 
   test do
     # Workaround for Error creating agent: Failed to get advertise address: Multiple private IPs found. Please configure one.
-    return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+    return if ENV["CI"]
 
     fork do
       exec "#{bin}/consul", "agent", *("-bind" unless OS.mac?), *("127.0.0.1" unless OS.mac?), "-data-dir", "."

--- a/Formula/corebird.rb
+++ b/Formula/corebird.rb
@@ -39,7 +39,7 @@ class Corebird < Formula
 
   test do
     # Fails without an X11 display: Gtk-WARNING **: cannot open display
-    return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+    return if ENV["CI"]
 
     system "#{bin}/corebird", "--help"
   end

--- a/Formula/dbxml.rb
+++ b/Formula/dbxml.rb
@@ -24,9 +24,6 @@ class Dbxml < Formula
   end
 
   def install
-    # Reduce memory usage for CircleCI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     ENV.cxx11
 
     inreplace "dbxml/configure" do |s|

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -1,10 +1,3 @@
-class CIRequirement < Requirement
-  # freeswitch installs more thant 500 Mb of sound files
-  # which makes the formula too big to be uploaded to bintray
-  fatal true
-  satisfy { ENV["CIRCLECI"].nil? && ENV["TRAVIS"].nil? }
-end
-
 class Freeswitch < Formula
   desc "Telephony platform to route various communication protocols"
   homepage "https://freeswitch.org"
@@ -40,7 +33,6 @@ class Freeswitch < Formula
     depends_on "libedit"
     depends_on "util-linux" # for libuuid
     depends_on "zlib"
-    depends_on CIRequirement
   end
 
   # https://github.com/Homebrew/homebrew/issues/42865

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -56,7 +56,7 @@ class Gdal < Formula
 
   def install
     # Fixes: error: inlining failed in call to always_inline __m128i _mm_shuffle_epi8
-    ENV.append_to_cflags "-msse4.1" if ENV["CIRCLECI"]
+    ENV.append_to_cflags "-msse4.1" if ENV["CI"]
 
     unless OS.mac?
       # The python build needs libgdal.so, which is located in .libs

--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -18,9 +18,6 @@ class Ginac < Formula
   uses_from_macos "python@2"
 
   def install
-    # Reduce memory usage for CircleCI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/gl2ps.rb
+++ b/Formula/gl2ps.rb
@@ -67,7 +67,7 @@ class Gl2ps < Formula
     else
       system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lgl2ps", "-lglut", "-lGL"
       # Fails without an X11 display: freeglut (./test): failed to open display ''
-      return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+      return if ENV["CI"]
     end
     system "./test"
     assert_predicate testpath/"test.eps", :exist?

--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -31,7 +31,7 @@ class GnuTar < Formula
     ENV["gl_cv_func_getcwd_abort_bug"] = "no" if MacOS.version == :el_capitan
 
     # Fix configure: error: you should not run configure as root
-    ENV["FORCE_UNSAFE_CONFIGURE"] = "1" unless ENV["CIRCLECI"]
+    ENV["FORCE_UNSAFE_CONFIGURE"] = "1" unless ENV["CI"]
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/inspectrum.rb
+++ b/Formula/inspectrum.rb
@@ -26,9 +26,8 @@ class Inspectrum < Formula
   end
 
   test do
-    unless ENV["CIRCLECI"]
-      # This test requires X11.
-      assert_match "-r, --rate <Hz>  Set sample rate.", shell_output("#{bin}/inspectrum -h").strip
-    end
+    return if ENV["CI"]
+    # This test requires X11.
+    assert_match "-r, --rate <Hz>  Set sample rate.", shell_output("#{bin}/inspectrum -h").strip
   end
 end

--- a/Formula/kibana@4.4.rb
+++ b/Formula/kibana@4.4.rb
@@ -1,6 +1,6 @@
 class CIRequirement < Requirement
   fatal true
-  satisfy { ENV["CIRCLECI"].nil? && ENV["TRAVIS"].nil? }
+  satisfy { ENV["CI"].nil? }
 end
 
 require "language/node"

--- a/Formula/makefile2graph.rb
+++ b/Formula/makefile2graph.rb
@@ -20,9 +20,9 @@ class Makefile2graph < Formula
 
   def install
     system "make"
-    # make test fails on CircleCI. Error: fontconfig: Couldn't find font.
+    # make test fails on CI. Error: fontconfig: Couldn't find font.
     # It can be fixed with apt-get install fonts-dejavu-core
-    system "make", "test" unless ENV["CIRCLECI"]
+    system "make", "test" unless ENV["CI"]
     bin.install "make2graph", "makefile2graph"
     man1.install "make2graph.1", "makefile2graph.1"
     doc.install "LICENSE", "README.md", "screenshot.png"

--- a/Formula/mednafen.rb
+++ b/Formula/mednafen.rb
@@ -30,7 +30,7 @@ class Mednafen < Formula
 
   test do
     # Test fails on headless CI: Could not initialize SDL: No available video device
-    return if ENV["CIRCLECI"] || ENV["TRAVIS"]
+    return if ENV["CI"]
 
     cmd = "#{bin}/mednafen | head -n1 | grep -o '[0-9].*'"
     assert_equal version.to_s, shell_output(cmd).chomp

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -25,7 +25,6 @@ class MysqlAT57 < Formula
   end
 
   def install
-    ENV["MAKEFLAGS"] = "-j3" if ENV["CIRCLECI"]
     # Fix libmysqlgcs.a(gcs_logging.cc.o): relocation R_X86_64_32
     # against `_ZN17Gcs_debug_options12m_debug_noneB5cxx11E' can not be used when making
     # a shared object; recompile with -fPIC

--- a/Formula/nnn.rb
+++ b/Formula/nnn.rb
@@ -27,7 +27,7 @@ class Nnn < Formula
   test do
     # Test fails on CI: Input/output error @ io_fread - /dev/pts/0
     # Fixing it involves pty/ruby voodoo, which is not worth spending time on
-    return if ENV["CIRCLECI"] || ENV["TRAVIS"] || ENV["CI"]
+    return if ENV["CI"]
 
     # Testing this curses app requires a pty
     require "pty"

--- a/Formula/p11-kit.rb
+++ b/Formula/p11-kit.rb
@@ -40,7 +40,7 @@ class P11Kit < Formula
                           "--with-module-config=#{etc}/pkcs11/modules",
                           "--without-libtasn1"
     system "make"
-    system "make", "check" if OS.mac? # Takes more than 30 min on circle.ci
+    system "make", "check"
     system "make", "install"
   end
 

--- a/Formula/ppsspp.rb
+++ b/Formula/ppsspp.rb
@@ -1,8 +1,3 @@
-class CIRequirement < Requirement
-  fatal true
-  satisfy { ENV["CIRCLECI"].nil? && ENV["TRAVIS"].nil? }
-end
-
 class Ppsspp < Formula
   desc "PlayStation Portable emulator"
   homepage "https://ppsspp.org/"
@@ -20,7 +15,6 @@ class Ppsspp < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on CIRequirement
   depends_on "ffmpeg"
   depends_on "glew"
   depends_on "libzip"

--- a/Formula/protobuf@3.1.rb
+++ b/Formula/protobuf@3.1.rb
@@ -74,9 +74,6 @@ class ProtobufAT31 < Formula
   end
 
   def install
-    # Reduce memory usage for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
     # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61

--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -1,8 +1,3 @@
-class CIRequirement < Requirement
-  fatal true
-  satisfy { ENV["CIRCLECI"].nil? && ENV["TRAVIS"].nil? }
-end
-
 class Rocksdb < Formula
   desc "Embeddable, persistent key-value store for fast storage"
   homepage "https://rocksdb.org/"
@@ -17,7 +12,6 @@ class Rocksdb < Formula
     sha256 "86792cf15a7d20c03f15d1e2dfb40e3abe8407ace76a9436ec47db7f349b52ef" => :sierra
   end
 
-  depends_on CIRequirement
   depends_on "gflags"
   depends_on "lz4"
   depends_on "snappy"

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -88,7 +88,7 @@ class Rust < Formula
       args << "--release-channel=stable"
     end
     system "./configure", *args
-    system "make", *("-j1" if ENV["CIRCLECI"])
+    system "make"
     system "make", "install"
 
     resource("cargobootstrap").stage do

--- a/Formula/wabt.rb
+++ b/Formula/wabt.rb
@@ -16,9 +16,6 @@ class Wabt < Formula
   depends_on "python@2" => :build unless OS.mac?
 
   def install
-    # Reduce memory usage for CircleCI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
-
     mkdir "build" do
       system "cmake", "..", "-DBUILD_TESTS=OFF", *std_cmake_args
       system "make", "install"


### PR DESCRIPTION
We removed CIRCLE_CI env variables as we are not building on circle
anymore, but we forgot to remove the CIRCLECI env variables,
which are probably just typos we made over the years.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
