### PR TITLE
Add a GitHub Action to generate Linux formulae and analytics data

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -41,3 +41,50 @@ jobs:
           fi
         env:
           ANALYTICS_JSON_KEY: ${{ secrets.ANALYTICS_JSON_KEY }}
+
+  generate-linux:
+    if: github.repository == 'Homebrew/linuxbrew-core'
+    runs-on: ubuntu-latest
+    container: homebrew/brew:latest
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: Homebrew/actions/git-ssh@master
+        with:
+          git_user: BrewTestBot
+          git_email: homebrew-test-bot@lists.sfconservancy.org
+          key: ${{ secrets.FORMULAE_DEPLOY_KEY }}
+      - run: |
+          brew update-reset "$(brew --repository)"
+          brew tap "$GITHUB_REPOSITORY"
+          brew update-reset "$(brew --repository "$GITHUB_REPOSITORY")"
+
+
+          export PATH="$(brew --repo)/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH"
+
+          # create stubs so build dependencies aren't incorrectly flagged as missing
+          for i in python svn unzip xz
+          do
+            touch /usr/bin/$i
+            chmod +x /usr/bin/$i
+          done
+
+          git clone git@github.com:Homebrew/formulae.brew.sh
+          cd formulae.brew.sh
+
+          # setup analytics
+          brew install jq
+          echo "$ANALYTICS_JSON_KEY_B64" | base64 --decode | jq . > ~/.homebrew_analytics.json
+
+          # run rake (without a rake binary)
+          ruby -e "load Gem.bin_path('rake', 'rake')" linux_formula_and_analytics
+
+          # commit and push generated files
+          git add _data/analytics-linux _data/formula-linux api/formula-linux formula-linux
+
+          if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux _data/formula-linux api/formula-linux formula-linux; then
+            git commit -m "formula: update from ${GITHUB_REPOSITORY} push" _data/analytics-linux _data/formula-linux api/formula-linux formula-linux
+            git push
+          fi
+        env:
+          ANALYTICS_JSON_KEY_B64: ${{ secrets.ANALYTICS_JSON_KEY_B64 }}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install
  --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

This adds a `generate-linux` job to the existing formulae.brew.sh
generation GitHub Action that generates formulae listings and
analytics data for `Homebrew/linuxbrew-core` formulae.

TODO:
- [x] Credentials entered into the Actions UI for these tasks (that is, an
   SSH key and Google Analytics keys).
- [x] Switch formulae.brew.sh to `Homebrew/formulae.brew.sh` and the master
   branch. When https://github.com/Homebrew/formulae.brew.sh/pull/150 is merged.