### PR TITLE
Make aria2 support most features.

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -3,18 +3,19 @@ class Aria2 < Formula
   homepage "https://aria2.github.io/"
   url "https://github.com/aria2/aria2/releases/download/release-1.35.0/aria2-1.35.0.tar.xz"
   sha256 "1e2b7fd08d6af228856e51c07173cfcf987528f1ac97e04c5af4a47642617dfd"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "9cc5e04be8b0a58d1f2b60b8abfc636168edbf23e7018003c40f1dd6952aab0c" => :catalina
     sha256 "761836ac608eb0a59d4a6f6065860c0e809ce454692e0937d9d0d89ad47f3ce4" => :mojave
     sha256 "70cc7566a23c283015368f92dfeaa0d119e53cfc7c1b2276a73ff9f6167b529d" => :high_sierra
-    sha256 "12d575bcdd389906c38dee7968a5509a8417fec1d0fc3ef866c09b977e5454d3" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build
   depends_on "libssh2"
   unless OS.mac?
-    depends_on "openssl"
+    depends_on "gnutls"
+    depends_on "c-ares"
     depends_on "zlib"
   end
 
@@ -22,16 +23,30 @@ class Aria2 < Formula
     ENV.cxx11
 
     args = %W[
-      --disable-dependency-tracking
       --prefix=#{prefix}
-      #{OS.mac? ? "--with-appletls" : "--without-appletls"}
       --with-libssh2
-      #{OS.mac? ? "--without-openssl" : "--with-openssl"}
-      --without-gnutls
-      --without-libgmp
-      --without-libnettle
+      --without-openssl
       --without-libgcrypt
+      --enable-libaria2
+      --disable-silent-rules
+      --disable-maintainer-mode
+      --disable-dependency-tracking
     ]
+
+    # Some options come from Ubuntu:
+    # https://launchpadlibrarian.net/420364343/buildlog_ubuntu-eoan-amd64.aria2_1.34.0-4_BUILDING.txt.gz
+    if OS.mac?
+      args << "--with-appletls"
+      args << "--without-gnutls"
+      args << "--without-libgmp"
+      args << "--without-libnettle"
+    elsif OS.linux?
+      args << "--without-appletls"
+      args << "--with-gnutls"
+      args << "--with-libgmp"
+      args << "--with-libnettle"
+      args << "--with-ca-bundle=#{etc}/openssl@1.1/cert.pem"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Compile options come from Ubuntu: https://launchpadlibrarian.net/420364343/buildlog_ubuntu-eoan-amd64.aria2_1.34.0-4_BUILDING.txt.gz

That makes aria2 support most features such as `Metalink`.

Before:

```
$ LANGUAGE=en aria2c -v
aria2 version 1.35.0
Copyright (C) 2006, 2019 Tatsuhiro Tsujikawa

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

** Configuration **
Enabled Features: BitTorrent, GZip, HTTPS, Message Digest, SFTP
Hash Algorithms: sha-1, sha-224, sha-256, sha-384, sha-512, md5, adler32
Libraries: zlib/1.2.11 OpenSSL/1.1.1d libssh2/1.9.0
Compiler: gcc 5.4.0 20160609
  built by  x86_64-pc-linux-gnu
  on        Oct  8 2019 10:32:28
System: Linux 4.15.0-30deepin-generic #31 SMP Fri Nov 30 04:29:02 UTC 2018 x86_64

Report bugs to https://github.com/aria2/aria2/issues
Visit https://aria2.github.io/
```

After:

```
$ LANGUAGE=en aria2c -v
aria2 version 1.35.0
Copyright (C) 2006, 2019 Tatsuhiro Tsujikawa

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

** Configuration **
Enabled Features: Async DNS, BitTorrent, Firefox3 Cookie, GZip, HTTPS, Message Digest, Metalink, XML-RPC, SFTP
Hash Algorithms: sha-1, sha-224, sha-256, sha-384, sha-512, md5, adler32
Libraries: zlib/1.2.11 libxml2/2.9.9 sqlite3/3.29.0 GnuTLS/3.6.10 nettle GMP/6.1.2 c-ares/1.15.0 libssh2/1.9.0
Compiler: gcc 6.3.0 20170516
  built by  x86_64-pc-linux-gnu
  on        Oct 16 2019 15:04:35
System: Linux 4.15.0-30deepin-generic #31 SMP Fri Nov 30 04:29:02 UTC 2018 x86_64

Report bugs to https://github.com/aria2/aria2/issues
Visit https://aria2.github.io/
```