### PR TITLE
k3d: disable CGO and use the version variable

### DIFF
--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -17,23 +17,27 @@ class K3d < Formula
   def install
     ENV["GO111MODULE"] = "on"
     ENV["GOPATH"] = buildpath
+    ENV["CGO_ENABLED"] = "0"
 
     dir = buildpath/"src/github.com/rancher/k3d"
     dir.install buildpath.children
 
     cd dir do
-      system "go", "build", "-mod", "vendor", "-ldflags", "-X main.version=#{version}", "-o", bin/"k3d"
+      system "go", "build", \
+          "-mod", "vendor", \
+          "-ldflags", "-s -w -X github.com/rancher/k3d/version.Version=v#{version} -X github.com/rancher/k3d/version.K3sVersion=v0.9.1", \
+          "-o", bin/"k3d"
       prefix.install_metafiles
     end
   end
 
   test do
-    assert_match "k3d version dev", shell_output("#{bin}/k3d -v")
+    assert_match "k3d version v#{version}", shell_output("#{bin}/k3d --version")
     code = if File.exist?("/var/run/docker.sock")
       0
     else
       1
     end
-    assert_match "Checking docker...", shell_output("#{bin}/k3d ct 2>&1", code)
+    assert_match "Checking docker...", shell_output("#{bin}/k3d check-tools 2>&1", code)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Related: https://github.com/Homebrew/homebrew-core/pull/45398