### PR TITLE
hwloc: Dependency on libxml2 on linux

### DIFF
--- a/Formula/hwloc.rb
+++ b/Formula/hwloc.rb
@@ -20,6 +20,7 @@ class Hwloc < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libxml2" unless OS.mac?
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
On macOS libxml2 is keg_only. hwloc needs libxml2.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
   - Cannot currently run `brew audit` because gem installation fails and complains about permissions in `/home/sjackman/.linuxbrew/...`. Currently updating portable ruby (although it is building from source 🤔) If it finishes soon I'll report back on audit status.
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
