### PR TITLE
azure: don't tap

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,11 @@ jobs:
       sudo cp -a $(Build.Repository.LocalPath) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
     displayName: Copy homebrew-core
   - bash: |
-      sudo /home/linuxbrew/.linuxbrew/bin/brew tap linuxbrew/xorg
-      sudo /home/linuxbrew/.linuxbrew/bin/brew tap homebrew/homebrew-test-bot
       cd /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
       git checkout -b test
       git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
       git checkout pr
-    displayName: Setup taps and checkout
+    displayName: Checkout PR
   - bash: |
       set -e
       cd /tmp/bottles


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

It is done later by `brew`.