### PR TITLE
azure: report status back if build failed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,15 +43,34 @@ jobs:
       git checkout pr
     displayName: Checkout PR
   - bash: |
-      set -e
       cd /tmp/bottles
-      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot --tap=homebrew/core --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh --keep-old
+      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot \
+        --tap=homebrew/core \
+        --bintray-org=linuxbrew \
+        --git-name=LinuxbrewTestBot \
+        --git-email=testbot@linuxbrew.sh \
+        --keep-old
+      if [ $? -gt 0 ]; then
+        curl -sSL \
+          -H "Content-Type: application/json" \
+          -H "Authorization: token $AZURE_BUILD_STATUS" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -X POST \
+          -d '{
+            "state": "failure",
+            "description": "The Azure build succeeded with issues!",
+            "context": "Check Azure Build Status"
+            }' \
+          "https://api.github.com/repos/Homebrew/linuxbrew-core/statuses/$SYSTEM_PULLREQUEST_SOURCECOMMITID"
+        exit 1
+      fi
     displayName: Run test bot
     env:
       HOMEBREW_DEVELOPER: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_VERBOSE: 1
       HOMEBREW_VERBOSE_USING_DOTS: 1
+      AZURE_BUILD_STATUS: $(AZURE_BUILD_STATUS)
     continueOnError: true
   - bash: |
       cp /tmp/bottles/*.bottle.* $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This should work once `GITHUB_TOKEN` is added as secret in Azure settings.
I believe the token needs only **repo:status** scope, but I can be wrong.