### PR TITLE
Run brew as normal user and other Azure changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,45 +6,35 @@ pr:
     - '*'
 
 jobs:
-
 - job: BuildLinuxbrewCoreBottles
   timeoutInMinutes: 360
-
   pool:
-    vmImage: 'ubuntu-16.04'
-
+    vmImage: ubuntu-latest
   container:
-    image: homebrew/brew:latest
-
+    image: homebrew/brew
   steps:
   - script: printenv
     displayName: Azure printenv
-
   - bash: |
-      mkdir -p /tmp/bottles
-      cd /tmp/bottles
-      umask 022
-    displayName: Setup /tmp/bottles
+      sudo adduser $(whoami) linuxbrew
+    displayName: Setup user
   - bash: |
       git config --global user.name LinuxbrewTestBot
       git config --global user.email testbot@linuxbrew.sh
-      cd /home/linuxbrew/.linuxbrew/Homebrew
-      sudo git fetch origin --tags
-      sudo git reset --hard origin/master
-    displayName: Setup Homebrew
+    displayName: Setup git
   - bash: |
-      sudo rm -rf /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
-      sudo cp -a $(Build.Repository.LocalPath) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
-    displayName: Copy homebrew-core
-  - bash: |
-      cd /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
       git checkout -b test
       git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
       git checkout pr
-    displayName: Checkout PR
+      rm -rf $(brew --repository $BUILD_REPOSITORY_NAME)
+      ln -s $BUILD_REPOSITORY_LOCALPATH $(brew --repository $BUILD_REPOSITORY_NAME)
+    displayName: Setup tap
+  - bash: brew update-reset $(brew --repository)
+    displayName: Update Homebrew
   - bash: |
+      mkdir /tmp/bottles
       cd /tmp/bottles
-      sudo -E /home/linuxbrew/.linuxbrew/bin/brew test-bot \
+      brew test-bot \
         --tap=homebrew/core \
         --bintray-org=linuxbrew \
         --git-name=LinuxbrewTestBot \
@@ -54,25 +44,17 @@ jobs:
         echo "$SYSTEM_PULLREQUEST_SOURCECOMMITID" > build_status.txt
         exit 1
       fi
-    displayName: Run test bot
-    env:
-      HOMEBREW_DEVELOPER: 1
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_VERBOSE: 1
-      HOMEBREW_VERBOSE_USING_DOTS: 1
+    displayName: Build bottles
     continueOnError: true
   - bash: |
-      cp /tmp/bottles/*.bottle.* $(Build.ArtifactStagingDirectory)
-      if [ -f /tmp/bottles/build_status.txt ]; then
-        cp /tmp/bottles/build_status.txt $(Build.ArtifactStagingDirectory)
-      fi
-    displayName: Copy json & bottle files
+      cp /tmp/bottles/*.bottle.* $BUILD_ARTIFACTSTAGINGDIRECTORY
+      cp /tmp/bottles/build_status.txt $BUILD_ARTIFACTSTAGINGDIRECTORY || true
+    displayName: Copy bottles
     condition: always()
-    continueOnError: true
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: bottle-linux
       targetPath: $(Build.ArtifactStagingDirectory)
-    displayName: Publish bottle-linux
+    displayName: Publish bottles
     condition: always()
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

What is happening in this PR:
- remove redundant whitespaces between lines
- remove `latest` from Docker image line (it is the default)
- use `ubuntu-latest`, instead of `ubuntu-16.04` (we use the container anyway)
- use `sudo` only once in the whole process (to add Azure's user to `linuxbrew` group)
- don't export `HOMEBREW_DEVELOPER`, `HOMEBREW_NO_AUTO_UPDATE`, `HOMEBREW_VERBOSE`, these are set by `test-bot` for us
- don't export `HOMEBREW_VERBOSE_USING_DOTS` (it truncates the output and sometimes it is needed to see the whole output)
- reword `displayName`s
- no `continueOnError: true` in `Copy bottles` step (it seems to be redundant)
- use environment variables where possible, instead of Azure's `$()` construct (consistency, less confusion, as environment variables are printed before every job and one can quickly check their value)
- use one `brew` command to update Homebrew, instead of 2 `git` ones
- symlink checked out repository, instead of copying
- RUN `test-bot` AS **NORMAL USER** (instead of root)


---

```
==> brew config
HOMEBREW_VERSION: 2.1.16-23-ga4b3518
ORIGIN: https://github.com/Homebrew/brew
HEAD: a4b3518dd5992c999197788a446edb0041fcf75e
Last commit: 3 hours ago
Core tap ORIGIN: https://github.com/Homebrew/linuxbrew-core
Core tap HEAD: da68b44f23ef500fe002254fafc07b8bb33c0817
Core tap last commit: 4 minutes ago
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CACHE: /home/vsts_azpcontainer/.cache/Homebrew
HOMEBREW_LOGS: /home/vsts_azpcontainer/.cache/Homebrew/Logs
HOMEBREW_AZURE_PIPELINES: 1
HOMEBREW_DEVELOPER: 1
HOMEBREW_FAIL_LOG_LINES: 150
HOMEBREW_LANGUAGES: en-GB
HOMEBREW_NO_ANALYTICS_THIS_RUN: 1
HOMEBREW_NO_AUTO_UPDATE: 1
HOMEBREW_NO_COLOR: 1
HOMEBREW_NO_EMOJI: 1
```