### PR TITLE
libnsl: make it keg_only

### DIFF
--- a/Formula/libnsl.rb
+++ b/Formula/libnsl.rb
@@ -3,12 +3,14 @@ class Libnsl < Formula
   homepage "https://github.com/thkukuk/libnsl"
   url "https://github.com/thkukuk/libnsl/archive/v1.2.0.tar.gz"
   sha256 "a5a28ef17c4ca23a005a729257c959620b09f8c7f99d0edbfe2eb6b06bafd3f8"
+  revision 1
   # tag "linuxbrew"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "fd85dccde71cfaf515bbc24db70fe1c981617fbe10605a55b759cf655b684b06" => :x86_64_linux
   end
+
+  keg_only "it conflicts with glibc"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The library is part of glibc. Hence, it's conflicted with glibc.
