### PR TITLE
Fix `brew style` offenses for Linux-specific code in various formulae

### DIFF
--- a/Formula/a2ps.rb
+++ b/Formula/a2ps.rb
@@ -27,10 +27,12 @@ class A2ps < Formula
   # Software was last updated in 2007.
   # https://svn.macports.org/ticket/20867
   # https://trac.macports.org/ticket/18255
-  patch :p0 do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/0ae366e6/a2ps/patch-contrib_sample_Makefile.in"
-    sha256 "5a34c101feb00cf52199a28b1ea1bca83608cf0a1cb123e6af2d3d8992c6011f"
-  end if OS.mac?
+  if OS.mac?
+    patch :p0 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/0ae366e6/a2ps/patch-contrib_sample_Makefile.in"
+      sha256 "5a34c101feb00cf52199a28b1ea1bca83608cf0a1cb123e6af2d3d8992c6011f"
+    end
+  end
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/0ae366e6/a2ps/patch-lib__xstrrpl.c"

--- a/Formula/ampl-mp.rb
+++ b/Formula/ampl-mp.rb
@@ -26,8 +26,10 @@ class AmplMp < Formula
   def install
     system "cmake", ".", *std_cmake_args, "-DBUILD_SHARED_LIBS=True"
     system "make", "all"
-    MachO::Tools.change_install_name("bin/libasl.dylib", "@rpath/libmp.3.dylib",
-                                     "#{opt_lib}/libmp.dylib") if OS.mac?
+    if OS.mac?
+      MachO::Tools.change_install_name("bin/libasl.dylib", "@rpath/libmp.3.dylib",
+                                       "#{opt_lib}/libmp.dylib")
+    end
     system "make", "install"
 
     # Shared modules are installed in bin

--- a/Formula/cdparanoia.rb
+++ b/Formula/cdparanoia.rb
@@ -18,15 +18,19 @@ class Cdparanoia < Formula
   depends_on "autoconf" => :build
 
   # Patches via MacPorts
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/2a22152/cdparanoia/osx_interface.patch"
-    sha256 "3eca8ff34d2617c460056f97457b5ac62db1983517525e5c73886a2dea9f06d9"
-  end if OS.mac?
+  if OS.mac?
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/2a22152/cdparanoia/osx_interface.patch"
+      sha256 "3eca8ff34d2617c460056f97457b5ac62db1983517525e5c73886a2dea9f06d9"
+    end
+  end
 
-  patch do
-    url "https://raw.githubusercontent.com/drewc/guix/master/gnu/packages/patches/cdparanoia-fpic.patch"
-    sha256 "496f53d21dde7e23f4c9cf1cc28219efcbb5464fe2abbd5a073635279281c9c4"
-  end if OS.linux?
+  if OS.linux?
+    patch do
+      url "https://raw.githubusercontent.com/drewc/guix/master/gnu/packages/patches/cdparanoia-fpic.patch"
+      sha256 "496f53d21dde7e23f4c9cf1cc28219efcbb5464fe2abbd5a073635279281c9c4"
+    end
+  end
 
   def install
     system "autoconf"

--- a/Formula/cdrdao.rb
+++ b/Formula/cdrdao.rb
@@ -20,15 +20,19 @@ class Cdrdao < Formula
 
   # first patch fixes build problems under 10.6
   # see https://sourceforge.net/p/cdrdao/patches/23/
-  patch do
-    url "https://sourceforge.net/p/cdrdao/patches/_discuss/thread/205354b0/141e/attachment/cdrdao-mac.patch"
-    sha256 "ee1702dfd9156ebb69f5d84dcab04197e11433dd823e80923fd497812041179e"
-  end if OS.mac?
+  if OS.mac?
+    patch do
+      url "https://sourceforge.net/p/cdrdao/patches/_discuss/thread/205354b0/141e/attachment/cdrdao-mac.patch"
+      sha256 "ee1702dfd9156ebb69f5d84dcab04197e11433dd823e80923fd497812041179e"
+    end
+  end
 
-  patch do
-    url "https://raw.githubusercontent.com/PacBSD/abs/master/extra/cdrdao/cdrdao-1.2.3-stat.patch"
-    sha256 "ca89b7c56a376d5a9574c5757f0d372236a895334f81867ff5e1703806565bbc"
-  end if OS.linux?
+  if OS.linux?
+    patch do
+      url "https://raw.githubusercontent.com/PacBSD/abs/master/extra/cdrdao/cdrdao-1.2.3-stat.patch"
+      sha256 "ca89b7c56a376d5a9574c5757f0d372236a895334f81867ff5e1703806565bbc"
+    end
+  end
 
   # second patch fixes device autodetection on macOS
   # see https://trac.macports.org/ticket/27819

--- a/Formula/crosstool-ng.rb
+++ b/Formula/crosstool-ng.rb
@@ -45,7 +45,7 @@ class CrosstoolNg < Formula
       system "./bootstrap"
     end
 
-    make = OS.mac? ? "gmake" :  "make"
+    make = OS.mac? ? "gmake" : "make"
     ENV["BISON"] = "#{Formula["bison"].opt_bin}/bison"
     ENV["M4"] = "#{Formula["m4"].opt_bin}/m4"
     ENV["MAKE"] = "#{Formula["make"].opt_bin}/#{make}"

--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -19,10 +19,12 @@ class Flann < Formula
 
   # Fix for Linux build: https://bugs.gentoo.org/652594
   # Not yet fixed upstream: https://github.com/mariusmuja/flann/issues/369
-  patch do
-    url "https://raw.githubusercontent.com/buildroot/buildroot/0c469478f64d0ddaf72c0622a1830d855306d51c/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch"
-    sha256 "aa181d0731d4e9a266f7fcaf5423e7a6b783f400cc040a3ef0fef77930ecf680"
-  end unless OS.mac?
+  unless OS.mac?
+    patch do
+      url "https://raw.githubusercontent.com/buildroot/buildroot/0c469478f64d0ddaf72c0622a1830d855306d51c/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch"
+      sha256 "aa181d0731d4e9a266f7fcaf5423e7a6b783f400cc040a3ef0fef77930ecf680"
+    end
+  end
 
   resource("dataset.dat") do
     url "https://www.cs.ubc.ca/research/flann/uploads/FLANN/datasets/dataset.dat"

--- a/Formula/intltool.rb
+++ b/Formula/intltool.rb
@@ -42,10 +42,12 @@ class Intltool < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--disable-silent-rules"
     system "make", "install"
-    Dir[bin/"intltool-*"].each do |f|
-      inreplace f, %r{^#!\/.*\/perl -w}, "#!/usr/bin/env perl"
-      inreplace f, /^(use strict;)/, "\\1\nuse warnings;"
-    end unless OS.mac?
+    unless OS.mac?
+      Dir[bin/"intltool-*"].each do |f|
+        inreplace f, %r{^#!\/.*\/perl -w}, "#!/usr/bin/env perl"
+        inreplace f, /^(use strict;)/, "\\1\nuse warnings;"
+      end
+    end
   end
 
   test do

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -19,10 +19,12 @@ class IpythonAT5 < Formula
   depends_on "python@2"
   depends_on "zeromq"
 
-  resource "appnope" do
-    url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"
-    sha256 "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-  end if OS.mac?
+  if OS.mac?
+    resource "appnope" do
+      url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"
+      sha256 "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+    end
+  end
 
   resource "backports_abc" do
     url "https://files.pythonhosted.org/packages/68/3c/1317a9113c377d1e33711ca8de1e80afbaf4a3c950dd0edfaf61f9bfe6d8/backports_abc-0.5.tar.gz"

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -38,9 +38,11 @@ class Libgcrypt < Formula
     # normal place on >10.10 where SIP is enabled.
     # https://github.com/Homebrew/homebrew-core/pull/3004
     # https://bugs.gnupg.org/gnupg/issue2056
-    MachO::Tools.change_install_name("#{buildpath}/tests/.libs/random",
-                                     "#{lib}/libgcrypt.20.dylib",
-                                     "#{buildpath}/src/.libs/libgcrypt.20.dylib") if OS.mac?
+    if OS.mac?
+      MachO::Tools.change_install_name("#{buildpath}/tests/.libs/random",
+                                       "#{lib}/libgcrypt.20.dylib",
+                                       "#{buildpath}/src/.libs/libgcrypt.20.dylib")
+    end
 
     system "make", "check"
     system "make", "install"

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -23,10 +23,12 @@ class Lua < Formula
   # Add shared library for linux
   # Equivalent to the mac patch carried around here ... that will probably never get upstreamed
   # Inspired from http://www.linuxfromscratch.org/blfs/view/cvs/general/lua.html
-  patch do
-    url "https://gist.githubusercontent.com/iMichka/dfc8617c85c1a6c21ca22240d4f5407b/raw/0dfef35c31fa41de0bface13e9c9f6ea09bd89fa/lua-5.3.5.patch"
-    sha256 "e74a6ada94e4340e664b35065392ebe5060d5d329b3d8d3e5603df0a8238a961"
-  end unless OS.mac?
+  unless OS.mac?
+    patch do
+      url "https://gist.githubusercontent.com/iMichka/dfc8617c85c1a6c21ca22240d4f5407b/raw/0dfef35c31fa41de0bface13e9c9f6ea09bd89fa/lua-5.3.5.patch"
+      sha256 "e74a6ada94e4340e664b35065392ebe5060d5d329b3d8d3e5603df0a8238a961"
+    end
+  end
 
   # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
   # See: https://github.com/Homebrew/legacy-homebrew/pull/5043

--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -28,11 +28,13 @@ class Minizip < Formula
 
     cd "contrib/minizip" do
       # edits to statically link to libz.a
-      inreplace "Makefile.am" do |s|
-        s.sub! "-L$(zlib_top_builddir)", "$(zlib_top_builddir)/libz.a"
-        s.sub! "-version-info 1:0:0 -lz", "-version-info 1:0:0"
-        s.sub! "libminizip.la -lz", "libminizip.la"
-      end if OS.mac?
+      if OS.mac?
+        inreplace "Makefile.am" do |s|
+          s.sub! "-L$(zlib_top_builddir)", "$(zlib_top_builddir)/libz.a"
+          s.sub! "-version-info 1:0:0 -lz", "-version-info 1:0:0"
+          s.sub! "libminizip.la -lz", "libminizip.la"
+        end
+      end
       system "autoreconf", "-fi"
       system "./configure", "--prefix=#{prefix}"
       system "make", "install"

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -33,15 +33,19 @@ class Openssh < Formula
   end
 
   # Both these patches are applied by Apple.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/patches/1860b0a74/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff"
-    sha256 "d886b98f99fd27e3157b02b5b57f3fb49f43fd33806195970d4567f12be66e71"
-  end if OS.mac?
+  if OS.mac?
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/1860b0a74/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff"
+      sha256 "d886b98f99fd27e3157b02b5b57f3fb49f43fd33806195970d4567f12be66e71"
+    end
+  end
 
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
-    sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
-  end if OS.mac?
+  if OS.mac?
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
+      sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
+    end
+  end
 
   def install
     ENV.append "CPPFLAGS", "-D__APPLE_SANDBOX_NAMED_EXTERNAL__" if OS.mac?

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -94,9 +94,11 @@ class PerconaServer < Formula
     system "make"
     system "make", "install"
 
-    (prefix/"mysql-test").cd do
-      system "./mysql-test-run.pl", "status", "--vardir=#{Dir.mktmpdir}"
-    end if OS.mac?
+    if OS.mac?
+      (prefix/"mysql-test").cd do
+        system "./mysql-test-run.pl", "status", "--vardir=#{Dir.mktmpdir}"
+      end
+    end
     # Test is disabled on Linux as it is currently failing
 
     # Remove the tests directory

--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -36,11 +36,13 @@ class PerconaToolkit < Formula
     sha256 "c4da1f1075878604b7b1f085ff3963e1073ed1c603c3bc9f0b0591e3831a1068"
   end
 
-  resource "DBI::DBD" do
-    url "https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.639.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/T/TI/TIMB/DBI-1.639.tar.gz"
-    sha256 "8e2cb3d6a8425bd68702aebbeee01e754ee11ad00e7f4f9a61b75483de104e8c"
-  end unless OS.mac?
+  unless OS.mac?
+    resource "DBI::DBD" do
+      url "https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.639.tar.gz"
+      mirror "http://search.cpan.org/CPAN/authors/id/T/TI/TIMB/DBI-1.639.tar.gz"
+      sha256 "8e2cb3d6a8425bd68702aebbeee01e754ee11ad00e7f4f9a61b75483de104e8c"
+    end
+  end
 
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"


### PR DESCRIPTION
- These fixes are all to code including `if/unless OS.mac?`, so they live here.