### PR TITLE
Fix looping in issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,6 +10,6 @@ contact_links:
 - name: New issue on Homebrew/homebrew-cask
   url: https://github.com/Homebrew/homebrew-cask/issues/new/choose
   about: Having a `brew cask` problem? Report it to Homebrew/homebrew-cask (the cask tap/repository)
-- name: New issue on Homebrew/linuxbrew-core
-  url: https://github.com/Homebrew/linuxbrew-core/issues/new/choose
-  about: On Linux? Having a `brew` problem with a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/linuxbrew-core (the Linux core tap/repository).
+- name: New issue on Homebrew/homebrew-core
+  url: https://github.com/Homebrew/homebrew-core/issues/new/choose
+  about: On macOS? Having a `brew` problem with a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/homebrew-core (the macOS core tap/repository).


### PR DESCRIPTION
- This sets the last option to point to Homebrew/homebrew-core's issues
  in _this_ repo.
- Otherwise, users end up in an infinite loop of ending up back on the
  same page when the things they need are right there in front of them
  but they've seen the "On Linux? ..." text.
- This might cause conflicts when merging in upstream changes to these
  files, but they shouldn't change very often.