### PR TITLE
mosh: depends_on "openssl@1.1"

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -3,14 +3,13 @@ class Mosh < Formula
   homepage "https://mosh.org"
   url "https://mosh.org/mosh-1.3.2.tar.gz"
   sha256 "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
-  revision 9
+  revision OS.mac? ? 9 : 10
 
   bottle do
     cellar :any_skip_relocation
     sha256 "d98896965ced1c6e299083d563ff2a1267c63d18e9f722024297267ddd286928" => :catalina
     sha256 "441d8beb4dbc1cd5f88ab49835560e841e719838132688b3e3736b02d2d89515" => :mojave
     sha256 "cae33e412eb50e8ccedecf7a3aa6c66b4f7b7b46137927ae6c2309fcf143760a" => :high_sierra
-    sha256 "0970a04951529b9dcd1015acd4e4ee5aa106d642d02e07e786b9afb9edd18bec" => :x86_64_linux
   end
 
   head do
@@ -25,7 +24,7 @@ class Mosh < Formula
   depends_on "protobuf"
   unless OS.mac?
     depends_on "ncurses"
-    depends_on "openssl"
+    depends_on "openssl@1.1"
   end
 
   # Fix mojave build.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Also installed HEAD and that worked too.