### PR TITLE
singularity: depends_on "openssl@1.1"

### DIFF
--- a/Formula/singularity.rb
+++ b/Formula/singularity.rb
@@ -3,15 +3,15 @@ class Singularity < Formula
   homepage "https://www.sylabs.io/singularity/"
   url "https://github.com/sylabs/singularity/releases/download/v3.3.0/singularity-3.3.0.tar.gz"
   sha256 "070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f"
+  revision 1
   # tag "linux"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "d2191946bacd5ff5f095b835edda008cea994e9834e0744aacc43e7de8022295" => :x86_64_linux
   end
 
   depends_on "go" => :build
-  depends_on "openssl" => :build
+  depends_on "openssl@1.1" => :build
   depends_on "libarchive"
   depends_on "pkg-config"
   depends_on "squashfs"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~