### PR TITLE
aria2: depends_on "openssl@1.1"

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -3,20 +3,21 @@ class Aria2 < Formula
   homepage "https://aria2.github.io/"
   url "https://github.com/aria2/aria2/releases/download/release-1.35.0/aria2-1.35.0.tar.xz"
   sha256 "1e2b7fd08d6af228856e51c07173cfcf987528f1ac97e04c5af4a47642617dfd"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "9cc5e04be8b0a58d1f2b60b8abfc636168edbf23e7018003c40f1dd6952aab0c" => :catalina
     sha256 "761836ac608eb0a59d4a6f6065860c0e809ce454692e0937d9d0d89ad47f3ce4" => :mojave
     sha256 "70cc7566a23c283015368f92dfeaa0d119e53cfc7c1b2276a73ff9f6167b529d" => :high_sierra
-    sha256 "12d575bcdd389906c38dee7968a5509a8417fec1d0fc3ef866c09b977e5454d3" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build
   depends_on "libssh2"
   unless OS.mac?
-    depends_on "openssl"
+    depends_on "openssl@1.1"
     depends_on "zlib"
   end
+  uses_from_macos "libxml2"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Also, this didn't cleanly build without "libxml2", [which I've also
  upstreamed](https://github.com/Homebrew/homebrew-core/pull/46891), but for quick fixes to OpenSSL, add it here too.