### PR TITLE
gst-plugins-bad/good: use meson as build system per official requirement

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -21,6 +21,10 @@ class GstPluginsBad < Formula
   depends_on "gobject-introspection" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "linuxbrew/xorg/libdrm" => :build
+  depends_on "openexr" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
   depends_on "faac"
   depends_on "faad2"
   depends_on "gettext"
@@ -37,11 +41,7 @@ class GstPluginsBad < Formula
   def install
     args = %W[
       --prefix=#{prefix}
-      --disable-yadif
-      --disable-examples
-      --disable-debug
-      --disable-dependency-tracking
-      --enable-introspection=yes
+      --libdir=#{lib}
     ]
 
     if build.head?
@@ -50,9 +50,11 @@ class GstPluginsBad < Formula
       system "./autogen.sh"
     end
 
-    system "./configure", *args
-    system "make"
-    system "make", "install"
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja", "-v"
+      system "ninja install"
+    end
   end
 
   test do

--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -24,6 +24,8 @@ class GstPluginsGood < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
   depends_on "cairo"
   depends_on "flac"
   depends_on "gettext"
@@ -42,13 +44,7 @@ class GstPluginsGood < Formula
   def install
     args = %W[
       --prefix=#{prefix}
-      --disable-gtk-doc
-      --disable-goom
-      --with-default-videosink=ximagesink
-      --disable-debug
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --disable-x
+      --libdir=#{lib}
     ]
 
     if build.head?
@@ -56,9 +52,11 @@ class GstPluginsGood < Formula
       system "./autogen.sh"
     end
 
-    system "./configure", *args
-    system "make"
-    system "make", "install"
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja", "-v"
+      system "ninja install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.


The original autotools build system is deprecated -- see for example
https://github.com/GStreamer/gst-plugins-bad.

-----