### PR TITLE
folly: fix build

### DIFF
--- a/Formula/double-conversion.rb
+++ b/Formula/double-conversion.rb
@@ -18,16 +18,18 @@ class DoubleConversion < Formula
 
   def install
     mkdir "dc-build" do
-      system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+      system "cmake", "..", ("-DBUILD_SHARED_LIBS=ON" unless OS.mac?), *std_cmake_args
       system "make", "install"
     end
 
-    # Move lib64/* to lib/ on Linuxbrew
-    lib64 = Pathname.new "#{lib}64"
-    if lib64.directory?
-      system "mkdir -p #{lib}"
-      system "mv #{lib64}/* #{lib}/"
-      rmdir lib64
+    unless OS.mac?
+      # Move lib64/* to lib/ on Linuxbrew
+      lib64 = Pathname.new "#{lib}64"
+      if lib64.directory?
+        mkdir_p lib
+        mv lib64, lib
+        rmdir lib64
+      end
     end
   end
 

--- a/Formula/double-conversion.rb
+++ b/Formula/double-conversion.rb
@@ -4,6 +4,7 @@ class DoubleConversion < Formula
   url "https://github.com/google/double-conversion/archive/v3.1.5.tar.gz"
   sha256 "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13"
   head "https://github.com/google/double-conversion.git"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation
@@ -11,15 +12,22 @@ class DoubleConversion < Formula
     sha256 "faa661750aeda3faf356d445d3d293fa52021c93a08fea35fd6666251b44203b" => :mojave
     sha256 "c948a1b31bc508f9218b6373e5ac3cc92838aa033e15f777aa046675921c3369" => :high_sierra
     sha256 "6fad17756240370dffc053a66fdfff4f17b02669c9456546a591349c3ea0e959" => :sierra
-    sha256 "4ae85649c591969d1131a97cfad7b779ae7b1f2cc2c45215098f32e845b15e0a" => :x86_64_linux
   end
 
   depends_on "cmake" => :build
 
   def install
     mkdir "dc-build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
       system "make", "install"
+    end
+
+    # Move lib64/* to lib/ on Linuxbrew
+    lib64 = Pathname.new "#{lib}64"
+    if lib64.directory?
+      system "mkdir -p #{lib}"
+      system "mv #{lib64}/* #{lib}/"
+      rmdir lib64
     end
   end
 

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -37,7 +37,7 @@ class Folly < Formula
         -DFOLLY_USE_JEMALLOC=OFF
       ]
 
-      system "cmake", "..", *args, "-DBUILD_SHARED_LIBS=ON"
+      system "cmake", "..", *args, "-DBUILD_SHARED_LIBS=ON", "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
       system "make"
       system "make", "install"
 

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -37,7 +37,7 @@ class Folly < Formula
         -DFOLLY_USE_JEMALLOC=OFF
       ]
 
-      system "cmake", "..", *args, "-DBUILD_SHARED_LIBS=ON", "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+      system "cmake", "..", *args, "-DBUILD_SHARED_LIBS=ON", ("-DCMAKE_POSITION_INDEPENDENT_CODE=ON" unless OS.mac?)
       system "make"
       system "make", "install"
 

--- a/Formula/glog.rb
+++ b/Formula/glog.rb
@@ -4,6 +4,7 @@ class Glog < Formula
   url "https://github.com/google/glog/archive/v0.4.0.tar.gz"
   sha256 "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c"
   head "https://github.com/google/glog.git"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any
@@ -11,7 +12,6 @@ class Glog < Formula
     sha256 "034a4d2272b48fd7655b467b92c78eebfb11efb33cc6cd31f7b13ee085b7169b" => :mojave
     sha256 "bbe6c4138b5fe8cd58d269a39644176f640fa62e694ffac36337f87661cacc69" => :high_sierra
     sha256 "08408127c37122614811eae2d925d940912c2cb29eb0fb300116ee4813d50095" => :sierra
-    sha256 "d2e577f5e9b5ecce6470c053cdda74539a6eeaccae6e8629fbd7879fd1f1f5c5" => :x86_64_linux
   end
 
   depends_on "cmake" => :build
@@ -21,6 +21,14 @@ class Glog < Formula
     mkdir "cmake-build" do
       system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
       system "make", "install"
+
+      # Move lib64/* to lib/ on Linuxbrew
+      lib64 = Pathname.new "#{lib}64"
+      if lib64.directory?
+        system "mkdir -p #{lib}"
+        system "mv #{lib64}/* #{lib}/"
+        rmdir lib64
+      end
     end
 
     # Upstream PR from 30 Aug 2017 "Produce pkg-config file under cmake"

--- a/Formula/glog.rb
+++ b/Formula/glog.rb
@@ -22,12 +22,14 @@ class Glog < Formula
       system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
       system "make", "install"
 
-      # Move lib64/* to lib/ on Linuxbrew
-      lib64 = Pathname.new "#{lib}64"
-      if lib64.directory?
-        system "mkdir -p #{lib}"
-        system "mv #{lib64}/* #{lib}/"
-        rmdir lib64
+      unless OS.mac?
+        # Move lib64/* to lib/ on Linuxbrew
+        lib64 = Pathname.new "#{lib}64"
+        if lib64.directory?
+          mkdir_p lib
+          mv lib64, lib
+          rmdir lib64
+        end
       end
     end
 


### PR DESCRIPTION
Fixes for build of folly with shared libraries, may fix #17065

`brew test` passes for glog and double-conversion, but not for folly. It looks like folly requires more flags for linking the test example than just `-lfolly`. My project that uses folly compiles fine though.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
