### PR TITLE
folly: compile with jemalloc

### DIFF
--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -4,13 +4,13 @@ class Folly < Formula
   url "https://github.com/facebook/folly/archive/v2019.11.11.00.tar.gz"
   sha256 "3b050f4ea17a12d7675ec4f1b02ef33dea2a5d46f09cc68e0165ca5b352c34b4"
   head "https://github.com/facebook/folly.git"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any
     sha256 "a31ad6656a7c29184694594bbfb36bd01c5e6a2d92122db4a6ae7f1cefe2007f" => :catalina
     sha256 "28de37ae5613f0da104d696bb67ae801d7d741c6d6f9594cec82388b150b3ceb" => :mojave
     sha256 "4343e3782e251854eae23d5c5eb354eafc13ee9422e7845760ae357c4c5ec382" => :high_sierra
-    sha256 "b30de2bb41cb53a3ab6ca234fb9581bf525a4b67ca732e421a6f021a21a462ba" => :x86_64_linux
   end
 
   depends_on "cmake" => :build
@@ -29,14 +29,14 @@ class Folly < Formula
   depends_on "snappy"
   depends_on "xz"
   depends_on "zstd"
+  depends_on "jemalloc" unless OS.mac?
 
   uses_from_macos "python"
 
   def install
     mkdir "_build" do
-      args = std_cmake_args + %w[
-        -DFOLLY_USE_JEMALLOC=OFF
-      ]
+      args = std_cmake_args
+      args << "-DFOLLY_USE_JEMALLOC=#{OS.mac? ? "OFF" : "ON"}"
 
       system "cmake", "..", *args, "-DBUILD_SHARED_LIBS=ON", ("-DCMAKE_POSITION_INDEPENDENT_CODE=ON" unless OS.mac?)
       system "make"


### PR DESCRIPTION
When combined with #17491, this fix compiles folly with support for jemalloc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
