### PR TITLE
[Actions] Change commit message to make the set of changes more obvious

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -82,7 +82,7 @@ jobs:
           git add _data/analytics-linux _data/formula-linux api/formula-linux formula-linux
 
           if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux _data/formula-linux api/formula-linux formula-linux; then
-            git commit -m "formula: update from ${GITHUB_REPOSITORY} push" _data/analytics-linux _data/formula-linux api/formula-linux formula-linux
+            git commit -m "formula-linux: update from ${GITHUB_REPOSITORY} push" _data/analytics-linux _data/formula-linux api/formula-linux formula-linux
             git push
           fi
         env:


### PR DESCRIPTION
- This isn't all that important, but we should start the commit message with `formula-linux` instead of `formula` so that we can always tell the Action is working without having to squint for `Homebrew/linuxbrew-core`. This makes things consistent with `cask` and `formula`.