### PR TITLE
mpv: Fully Python 3, so remove `uses_from_macos python@2`

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -28,8 +28,6 @@ class Mpv < Formula
   depends_on "vapoursynth"
   depends_on "youtube-dl"
 
-  uses_from_macos "python@2"
-
   def install
     # LANG is unset by default on macOS and causes issues when calling getlocale
     # or getdefaultlocale in docutils. Force the default c/posix locale since


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- `brew install` and `brew test` went fine. There is no `uses_from_macos
  python@2` line in the Homebrew/homebrew-core formula, so we can just
  delete this here.