### PR TITLE
ledger: Remove `uses_from_macos python@2`

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -18,7 +18,6 @@ class Ledger < Formula
   depends_on "gmp"
   depends_on "mpfr"
   uses_from_macos "groff"
-  uses_from_macos "python@2"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- Using Python at all was removed in
  https://github.com/Homebrew/homebrew-core/pull/47053, so we can do the
  same here.