### PR TITLE
[Actions/formulae.brew.sh] Rebase on origin/master before pushing

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -85,6 +85,8 @@ jobs:
 
           if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux _data/formula-linux api/formula-linux formula-linux; then
             git commit -m "formula-linux: update from ${GITHUB_REPOSITORY} push" _data/analytics-linux _data/formula-linux api/formula-linux formula-linux
+            git fetch
+            git rebase origin/master
             git push
           fi
         env:


### PR DESCRIPTION
- When we push lots of commits at once (say, merging multiple bottle PRs) to master and the Action runs to update formulae.brew.sh, it fails on the later one [1] because it doesn't fetch and rebase against the latest master.
- This was also a problem in Homebrew/homebrew-core, so this copies their approach to solving it: `git fetch` and `git rebase origin/master`.

```
[1]
error: failed to push some refs to 'git@github.com:Homebrew/formulae.brew.sh'
hint: Updates were rejected because the remote contains work that you do not have locally.
```