### PR TITLE
Update bazel to depend on zip

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -15,6 +15,7 @@ class Bazel < Formula
   depends_on "python" => :build
   depends_on :java => "1.8"
   depends_on :macos => :yosemite if OS.mac?
+  uses_from_macos "zip"
 
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

I got the error when I installed bazel on a fresh Ubuntu WSL installation

```
$ brew install bazel
Updating Homebrew...
==> Downloading https://github.com/bazelbuild/bazel/releases/download/2.0.0/ba
Already downloaded: /home/kevin/.cache/Homebrew/downloads/9e5397f91b5eb1ce05d7c8c26797ea63f989756a59b061b513649fa0e3695011--bazel-2.0.0-dist.zip



/bin/bash: zip: command not found
Target //src:bazel_nojdk failed to build
INFO: Elapsed time: 60.704s, Critical Path: 0.51s
INFO: 0 processes.
FAILED: Build did NOT complete successfully

ERROR: Could not build Bazel

READ THIS: https://docs.brew.sh/Troubleshooting

These open issues may also help:
bazel: build failure on Debian 9 https://github.com/Homebrew/linuxbrew-core/issues/13619
bazel: build failure with JAVA_HOME not set https://github.com/Homebrew/linuxbrew-core/issues/14087
```