### PR TITLE
nbdime: Fix build for Linux

### DIFF
--- a/Formula/nbdime.rb
+++ b/Formula/nbdime.rb
@@ -16,9 +16,11 @@ class Nbdime < Formula
 
   depends_on "python@3.8"
 
-  resource "appnope" do
-    url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"
-    sha256 "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+  if OS.mac?
+    resource "appnope" do
+      url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"
+      sha256 "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+    end
   end
 
   resource "attrs" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- The `appnope` dependent pip package is [macOS-only](https://pypi.org/project/appnope/):

```
Processing /tmp/nbdime--appnope-20200106-9339-dcs54s/appnope-0.1.0
  Created temporary directory: /tmp/pip-req-build-_b63n51s
  Added file:///tmp/nbdime--appnope-20200106-9339-dcs54s/appnope-0.1.0 to build tracker '/tmp/pip-req-tracker-fiyim87z'
    Running setup.py (path:/tmp/pip-req-build-_b63n51s/setup.py) egg_info for package from file:///tmp/nbdime--appnope-20200106-9339-dcs54s/appnope-0.1.0
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-_b63n51s/setup.py", line 17, in <module>
        raise ValueError("Only meant for install on OS X >= 10.9")
    ValueError: Only meant for install on OS X >= 10.9
```

- Fixes #18623.