### PR TITLE
jo: fix completion folder path on installation

### DIFF
--- a/Formula/jo.rb
+++ b/Formula/jo.rb
@@ -21,7 +21,7 @@ class Jo < Formula
   def install
     system "autoreconf", "-i" if build.head?
 
-    ENV["bashcompdir"] = "#{prefix}/etc/bash_completion.d/"
+    ENV["bashcompdir"] = bash_completion unless OS.mac?
     system "./configure", "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/jo.rb
+++ b/Formula/jo.rb
@@ -21,6 +21,7 @@ class Jo < Formula
   def install
     system "autoreconf", "-i" if build.head?
 
+    ENV["bashcompdir"] = "#{prefix}/etc/bash_completion.d/"
     system "./configure", "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
When trying to upgrade `jo` from `1.2` to `1.3` on Linux a permission error arise when creating bash completion files.

Reported error is: `/usr/bin/install: cannot create regular file '/usr/share/bash-completion/completions/jo.bash': Permission denied`

In Homebrew you generally install everything under the Brew prefix (`/home/linuxbrew/.linuxbrew`), but this does not happen for the completion file, which is being created under `/usr/share/bash-completion/completions/` (failing due to missing permissions because `brew` is not running as root).

The fix is to change the bash completion folder destination to the one specified in the Homebrew documentation (https://docs.brew.sh/Shell-Completion).

This can be achieved in by updating the `bashcompdir` environment variable (thanks to https://github.com/jpmens/jo/issues/111 for pointing that out).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. (I'm not able to provide this as `gist-logs` didn't work)

-----
