### PR TITLE
azure-pipelines: tighten the trigger events

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,14 @@
 trigger: none
 pr:
   autoCancel: true
+  paths:
+    include:
+    - 'Formula/*'
   branches:
     include:
     - '*'
+    exclude:
+    - 'merge-*-*-*-*'
 
 jobs:
 - job: BuildLinuxbrewCoreBottles


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Running this pipeline on merges is unnecessary right now, so why not disable it.

Also, additionally specify that we want to run it only if `Formula/*` path changed.

It's not tested though, will see in production :D.