### PR TITLE
workflow: always run the bottle copying

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -32,6 +32,7 @@ jobs:
             --keep-old
           cp -a ~/bottles $RUNNER_TEMP/
       - name: Upload bottles
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: bottles


### PR DESCRIPTION
We might have some bottles with test failures or other thing we might
still accept to be broken. Whatever happens, we want to upload a bottle
for these.
