### PR TITLE
snapcraft: depends_on :macos

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -13,13 +13,14 @@ class Snapcraft < Formula
     sha256 "1f3e81eb6fc201a56f79903895bb91f05ed44e8ad05cd6c99519ea7c58260c6b" => :high_sierra
   end
 
+  depends_on :macos
+
   depends_on "libsodium"
   depends_on "libyaml"
   depends_on "lxc"
   depends_on "python"
   depends_on "squashfs"
   depends_on "xdelta"
-  depends_on "libffi" unless OS.mac?
 
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/98/c3/2c227e66b5e896e15ccdae2e00bbc69aa46e9a8ce8869cc5fa96310bf612/attrs-19.3.0.tar.gz"
@@ -236,29 +237,7 @@ class Snapcraft < Formula
     sha256 "feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
   end
 
-  unless OS.mac?
-    resource "sphinx" do
-      url "https://files.pythonhosted.org/packages/89/1e/64c77163706556b647f99d67b42fced9d39ae6b1b86673965a2cd28037b5/Sphinx-2.1.2.tar.gz"
-      sha256 "f9a79e746b87921cabc3baa375199c6076d1270cee53915dbd24fdbeaaacc427"
-    end
-
-    resource "distutils-extra" do
-      url "https://deb.debian.org/debian/pool/main/p/python-distutils-extra/python-distutils-extra_2.38.orig.tar.gz"
-      sha256 "3d100d5d3492f40b3e7a6a4500f71290bfa91e2c50dc31ba8e3ff9b5d82ca153"
-    end
-
-    resource "python-apt" do
-      url "https://salsa.debian.org/apt-team/python-apt/-/archive/1.9.0/python-apt-1.9.0.tar.gz"
-      sha256 "6b0bdff48600266fcac1bebd57f04d6241dae32781396217612369421f5d0519"
-    end
-  end
-
   def install
-    unless OS.mac?
-      libffi = Formula["libffi"]
-      ENV.prepend "CPPFLAGS", "-I#{libffi.lib}/libffi-#{libffi.version}/include"
-    end
-
     virtualenv_install_with_resources
   end
 


### PR DESCRIPTION
- A new attempt at building it didn't work. Something about python-apt, Sphinx and `--single-version-externally-managed`.
- So, in the nicest possible way, I'm done. :-)
- If someone wants to fix it, be my guest! There's prior attempts thoroughly documented in https://github.com/Homebrew/linuxbrew-core/pull/14123.