### PR TITLE
[Actions] Re-instate `brew test-bot` CI checks on PRs (without bottles)

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -1,4 +1,4 @@
-name: Build bottles from core merge request
+name: Build bottles from 'brew request-bottle' trigger.
 
 on: repository_dispatch
 

--- a/.github/workflows/test-formula.yml
+++ b/.github/workflows/test-formula.yml
@@ -1,0 +1,24 @@
+name: Non-bottling test-bot checks for formulae.
+
+on: pull_request
+
+jobs:
+  bottling:
+    runs-on: ubuntu-latest
+    container:
+      image: homebrew/brew
+    env:
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup tap
+        run: |
+          rm -rf $(brew --repository ${{github.repository}})
+          ln -s "$GITHUB_WORKSPACE" $(brew --repository ${{github.repository}})
+      - name: brew test-bot
+        run: |
+          brew test-bot \
+            --tap=homebrew/core \
+            --keep-old ${{github.event.client_payload.formula}}
+

--- a/.github/workflows/test-formula.yml
+++ b/.github/workflows/test-formula.yml
@@ -20,5 +20,4 @@ jobs:
         run: |
           brew test-bot \
             --tap=homebrew/core \
-            --keep-old ${{github.event.client_payload.formula}}
-
+            --keep-old


### PR DESCRIPTION
When we fix broken builds, we want to push our fixes to CI and let them run - if it's a long-running or particularly CPU-intensive build, we don't want to always melt our computers rebuilding and rebuilding formulae when GitHub gives us lots of power and time.