### PR TITLE
Use `BrewTestBot` user in all Actions for git operations

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -21,8 +21,8 @@ jobs:
           echo ignore-errors=${{github.event.client_payload.ignore_errors}}
       - name: Setup git
         run: |
-          git config --global user.name LinuxbrewTestBot
-          git config --global user.email testbot@linuxbrew.sh
+          git config --global user.name BrewTestBot
+          git config --global user.email homebrew-test-bot@lists.sfconservancy.org
       - name: Setup tap
         run: |
           rm -rf $(brew --repository ${{github.repository}})
@@ -48,8 +48,6 @@ jobs:
           brew test-bot \
             --tap=homebrew/core \
             --bintray-org=linuxbrew \
-            --git-name=LinuxbrewTestBot \
-            --git-email=testbot@linuxbrew.sh \
             --ci-upload \
             --publish \
             --keep-old \

--- a/.github/workflows/request-bottle-after-merge.yml
+++ b/.github/workflows/request-bottle-after-merge.yml
@@ -24,8 +24,8 @@ jobs:
           ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
       - name: Setup git
         run: |
-          git config --global user.name LinuxbrewTestBot
-          git config --global user.email testbot@linuxbrew.sh
+          git config --global user.name BrewTestBot
+          git config --global user.email homebrew-test-bot@lists.sfconservancy.org
       - name: Tap linux-dev
         run: brew tap homebrew/linux-dev
       - name: Run brew request-bottle

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -122,8 +122,8 @@ jobs:
       - name: Setup git
         if: steps.artifact.outputs.result != 0
         run: |
-          git config --global user.name LinuxbrewTestBot
-          git config --global user.email testbot@linuxbrew.sh
+          git config --global user.name BrewTestBot
+          git config --global user.email homebrew-test-bot@lists.sfconservancy.org
       - name: Install dependencies
         if: steps.artifact.outputs.result != 0
         run: |
@@ -148,8 +148,6 @@ jobs:
           brew test-bot \
             --tap=homebrew/core \
             --bintray-org=linuxbrew \
-            --git-name=LinuxbrewTestBot \
-            --git-email=testbot@linuxbrew.sh \
             --ci-upload \
             --publish \
             --keep-old


### PR DESCRIPTION
- We now push commits as the `BrewTestBot` user, not the
  `LinuxbrewTestBot` user - so I think it makes sense to adjust the Git
  config in the `brew test-bot`-related actions.