### PR TITLE
workflows: try pushing 5 times

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -45,8 +45,12 @@ jobs:
           cd $(brew --repo ${{github.repository}})
           git commit --amend --no-edit
           git show --pretty=fuller
-          git fetch
-          git rebase origin/master
-          git fetch
-          git rebase origin/master
-          git push https://x-access-token:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}} master
+          for try in $(seq 5); do
+            git fetch
+            git rebase origin/master
+            if git push https://x-access-token:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}} master; then
+              break
+            else
+              sleep 3s
+            fi
+          done


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This may prevent situations where the push is rejected.

Like: https://github.com/Homebrew/linuxbrew-core/runs/430180531?check_suite_focus=true
