### PR TITLE
writerperfect: Fix build for Linux

### DIFF
--- a/Formula/writerperfect.rb
+++ b/Formula/writerperfect.rb
@@ -20,6 +20,8 @@ class Writerperfect < Formula
   depends_on "libwpg"
   depends_on "libwps"
 
+  uses_from_macos "libxml2"
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Errored in
https://github.com/Homebrew/linuxbrew-core/runs/430381423?check_suite_focus=true:

```
checking for LIBXML2... no
configure: error: Package requirements (libxml-2.0 >= 2.1.0) were not met:
No package 'libxml-2.0' found
```