### PR TITLE
workflows: create issue comment when CI fails

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -38,6 +38,18 @@ jobs:
             --publish \
             --keep-old \
             ${{github.event.client_payload.formula}}
+      - name: Report upload failure
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          issue-number: 1 # TODO
+          body: |
+            Formula = `${{github.event.client_payload.formula}}`
+            Workflow = `${{github.workflow}}`
+            Run = `${{github.run_id}}`
+            Event = `${{github.event_name}}`
+            Actor = `${{github.actor}}`
       - name: Push bottles
         env:
           GIT_COMMITTER_NAME: ${{github.event.client_payload.name}}
@@ -56,3 +68,15 @@ jobs:
               sleep 3s
             fi
           done
+      - name: Report push failure
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          issue-number: 1 # TODO
+          body: |
+            Formula = `${{github.event.client_payload.formula}}`
+            Workflow = `${{github.workflow}}`
+            Run = `${{github.run_id}}`
+            Event = `${{github.event_name}}`
+            Actor = `${{github.actor}}`


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----