### PR TITLE
Run formulae.brew.sh generation action three times a day

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -1,11 +1,7 @@
 name: Generate formulae.brew.sh data.
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'Formula/*'
+  schedule: '0 02,12,20 * * *'
 
 jobs:
   generate:


### PR DESCRIPTION
- Now we're doing mass bottling and pushing to master every few seconds
  (or it feels that way!), running this on every push is just causing
  queues that don't really add any value.
- This entirely arbitrarily decides some times to run - 2am, 12pm and
  8pm. Should be frequent enough to catch the late evening and morning
  rush hours, and the trickle of changes through the day. ;-)