### PR TITLE
fmsx: Fix build for Linux with XOrg dependency

### DIFF
--- a/Formula/fmsx.rb
+++ b/Formula/fmsx.rb
@@ -15,7 +15,11 @@ class Fmsx < Formula
   end
 
   depends_on "pulseaudio"
-  depends_on :x11
+  if OS.mac?
+    depends_on :x11
+  else
+    depends_on "linuxbrew/xorg/xorg"
+  end
 
   resource "msx-rom" do
     url "https://fms.komkon.org/fMSX/src/MSX.ROM"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

https://github.com/Homebrew/linuxbrew-core/runs/434270743?check_suite_focus=true

```
2020-02-09T06:41:42.0796137Z X11 is required to install this formula,
either Xorg 1.12.2 or xdpyinfo 1.3.0, or newer. X11Requirement
unsatisfied!
2020-02-09T06:41:42.0796798Z You can install with Homebrew Cask:
2020-02-09T06:41:42.0797258Z   brew cask install xquartz
```

I was wondering if it's worth the effort to make the brew Requirements
error add Linux instructions. Probably not if Linuxbrew/homebrew-xorg is
merging with Homebrew/homebrew-core and hopefully things won't depend on
Casks for much longer!