### PR TITLE
gobby: Fix build for Linux

### DIFF
--- a/Formula/gobby.rb
+++ b/Formula/gobby.rb
@@ -45,6 +45,8 @@ class Gobby < Formula
   end
 
   test do
+    return if !OS.mac? && ENV["CI"]
+
     # executable (GUI)
     system bin/"gobby-0.5", "--version"
   end

--- a/Formula/gobby.rb
+++ b/Formula/gobby.rb
@@ -35,6 +35,10 @@ class Gobby < Formula
 
   def install
     ENV.cxx11
+
+    # Needed by intltool (xml::parser)
+    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" unless OS.mac?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--with-gtk3"
     system "make", "install"


### PR DESCRIPTION
---

This is a manual PR. I'm going through the recent build failures of
mass-bottling attempts and raising PRs with empty commits and the
log of the build failure, so we can target fixes.

---

From
https://github.com/Homebrew/linuxbrew-core/runs/434444958?check_suite_focus=true:

```
checking for perl >= 5.8.1... 5.22.1
checking for XML::Parser... configure: error: XML::Parser perl module is
required for intltool
```