### PR TITLE
goffice: Fix build for Linux

### DIFF
--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -32,6 +32,9 @@ class Goffice < Formula
   uses_from_macos "libxslt"
 
   def install
+    # Needed by intltool (xml::parser)
+    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" unless OS.mac?
+
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]
     if build.head?
       system "./autogen.sh", *args


### PR DESCRIPTION
https://github.com/Homebrew/linuxbrew-core/runs/434444981?check_suite_focus=true

```
checking for perl >= 5.8.1... 5.22.1
checking for XML::Parser... configure: error: XML::Parser perl module is
required for intltool

```