### PR TITLE
gpredict: Fix build for Linux

### DIFF
--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -21,13 +21,20 @@ class Gpredict < Formula
   depends_on "gtk+3"
   depends_on "hamlib"
 
+  uses_from_macos "curl"
+
   def install
+    # Needed by intltool (xml::parser)
+    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" unless OS.mac?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 
   test do
+    return if !OS.mac? && ENV["CI"]
+
     assert_match "real-time", shell_output("#{bin}/gpredict -h")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

https://github.com/Homebrew/linuxbrew-core/runs/434445057?check_suite_focus=true

```
checking for XML::Parser... configure: error: XML::Parser perl module is
required for intltool
```