### PR TITLE
google-authenticator-libpam: Fix build for Linux

### DIFF
--- a/Formula/google-authenticator-libpam.rb
+++ b/Formula/google-authenticator-libpam.rb
@@ -15,6 +15,7 @@ class GoogleAuthenticatorLibpam < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "qrencode"
+  depends_on "linux-pam" unless OS.mac?
 
   def install
     system "./bootstrap.sh"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

https://github.com/Homebrew/linuxbrew-core/runs/434445009?check_suite_focus=true

```
checking for security/pam_appl.h... no
checking for security/pam_modules.h... no
checking for pam_get_user in -lpam... no
configure: error: Unable to find the PAM library or the PAM header files
```