### PR TITLE
Add lz4 support to systemd

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -8,7 +8,6 @@ class Systemd < Formula
   # tag "linux"
 
   bottle do
-    sha256 "cf69549f3a8cefabebbb0deeddf2441353c099d54604733be3e046712a2f0eea" => :x86_64_linux
   end
 
   depends_on "coreutils" => :build

--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -3,6 +3,7 @@ class Systemd < Formula
   homepage "https://wiki.freedesktop.org/www/Software/systemd/"
   url "https://github.com/systemd/systemd/archive/v244.tar.gz"
   sha256 "2207ceece44108a04bdd5459aa74413d765a829848109da6f5f836c25aa393aa"
+  revision 1
   head "https://github.com/systemd/systemd.git"
   # tag "linux"
 

--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -24,9 +24,9 @@ class Systemd < Formula
   depends_on "pkg-config" => :build
   depends_on "expat"
   depends_on "libcap"
+  depends_on "lz4"
   depends_on "util-linux" # for libmount
   depends_on "xz"
-  depends_on "lz4"
 
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"

--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -26,6 +26,7 @@ class Systemd < Formula
   depends_on "libcap"
   depends_on "util-linux" # for libmount
   depends_on "xz"
+  depends_on "lz4"
 
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
@@ -46,6 +47,7 @@ class Systemd < Formula
       -Dpamconfdir=#{prefix}/etc/pam.d
       -Dcreate-log-dirs=false
       -Dhwdb=false
+      -Dlz4=true
     ]
 
     mkdir "build" do


### PR DESCRIPTION
Fixes [an issue where brew's `journalct` can't read lz4 compressed logs](https://github.com/Homebrew/linuxbrew-core/issues/19506)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [N/A] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
