### PR TITLE
movgrab: depend on openssl if not mac

### DIFF
--- a/Formula/movgrab.rb
+++ b/Formula/movgrab.rb
@@ -12,7 +12,12 @@ class Movgrab < Formula
     sha256 "b93b158f7774abed4d3ba760afb185798782bf10b257ffbf09954f131387137b" => :high_sierra
   end
 
-  depends_on "libressl"
+  if OS.mac?
+    depends_on "libressl"
+  else
+    depends_on "pkg-config" => :build
+    depends_on "openssl@1.1"
+  end
 
   # Fixes an incompatibility between Linux's getxattr and macOS's.
   # Reported upstream; half of this is already committed, and there's


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----