### PR TITLE
zenity: skip test on CI

### DIFF
--- a/Formula/zenity.rb
+++ b/Formula/zenity.rb
@@ -23,6 +23,9 @@ class Zenity < Formula
   end
 
   test do
+    # (zenity:30889): Gtk-WARNING **: 13:12:26.818: cannot open display
+    return if !OS.mac? && ENV["CI"]
+
     system bin/"zenity", "--help"
   end
 end


### PR DESCRIPTION
(zenity:30889): Gtk-WARNING **: 13:12:26.818: cannot open display


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----