### PR TITLE
xsane: skip test on CI

### DIFF
--- a/Formula/xsane.rb
+++ b/Formula/xsane.rb
@@ -29,6 +29,9 @@ class Xsane < Formula
   end
 
   test do
+    # (xsane:27015): Gtk-WARNING **: 12:58:53.105: cannot open display
+    return if !OS.mac? && ENV["CI"]
+
     system "#{bin}/xsane", "--version"
   end
 end


### PR DESCRIPTION
(xsane:27015): Gtk-WARNING **: 12:58:53.105: cannot open display


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----