### PR TITLE
linux-pam: Bump revision for libprelude

### DIFF
--- a/Formula/linux-pam.rb
+++ b/Formula/linux-pam.rb
@@ -3,10 +3,10 @@ class LinuxPam < Formula
   homepage "http://www.linux-pam.org"
   url "https://github.com/linux-pam/linux-pam/releases/download/v1.3.1/Linux-PAM-1.3.1.tar.xz"
   sha256 "eff47a4ecd833fbf18de9686632a70ee8d0794b79aecb217ebd0ce11db4cd0db"
+  revision 1
   head "https://github.com/linux-pam/linux-pam.git"
 
   bottle do
-    sha256 "4afeecba2eb7b7cac467cd648b3329edba7d3703c2f07e3df99ae698966f84cd" => :x86_64_linux
   end
 
   depends_on :linux


### PR DESCRIPTION
Fixes:
Broken dependencies:
  /home/linuxbrew/.linuxbrew/Cellar/libprelude/3.1.0_3/lib/libprelude.so.23 (libprelude)