### PR TITLE
bedtools: Fix the build from source [Linux]

### DIFF
--- a/Formula/bedtools.rb
+++ b/Formula/bedtools.rb
@@ -12,14 +12,16 @@ class Bedtools < Formula
     sha256 "65f6f96f78e63ee61fe6789e68ff850953665531a647bc3ededfb3b1da24291c" => :x86_64_linux
   end
 
-  depends_on :macos # Due to Python 2
+  depends_on "python" => :build unless OS.mac?
   depends_on "xz"
-  depends_on "python@2" => :build unless OS.mac?
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
   def install
+    # Use system Python 2 on macOS and Python 3 on Linux.
+    inreplace "Makefile", "python", "python3" unless OS.mac?
+
     system "make"
     system "make", "install", "prefix=#{prefix}"
   end


### PR DESCRIPTION
Use system Python 2 on macOS and Python 3 on Linux.
The build-time script `scripts/makeBashScripts.py` works with either Python 2 or Python 3.

Fix the error message:
```
Creating executables for old CLI.
/bin/bash: python: command not found
Makefile:185: recipe for target 'bin/intersectBed' failed
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This PR can be merged without updating the bottle with a squash merge commit.