### PR TITLE
dwarfutils: uses_from_macos zlib for linkage

### DIFF
--- a/Formula/dwarfutils.rb
+++ b/Formula/dwarfutils.rb
@@ -17,6 +17,8 @@ class Dwarfutils < Formula
     depends_on "libelf"
   end
 
+  uses_from_macos "zlib"
+
   def install
     system "./configure"
     system "make"


### PR DESCRIPTION
- This failed to build a bottle after a recent merge due to:

```
==> brew linkage --test dwarfutils
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
  ==> FAILED
```