### PR TITLE
libfido2: Fix build for Linuxbrew

### DIFF
--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -15,6 +15,8 @@ class Libfido2 < Formula
   depends_on "pkg-config" => :build
   depends_on "libcbor"
   depends_on "openssl@1.1"
+  
+  depends_on "systemd" if OS.linux? # libfido2 uses libudev on Linux but IOKit on macOS
 
   def install
     mkdir "build" do
@@ -24,7 +26,7 @@ class Libfido2 < Formula
       system "make", "man_symlink"
       system "make", "install"
     end
-    mv prefix/"man", share/"man"
+    mv prefix/"man", share/"man" if OS.mac? # Path bug on macOS might be upstream
   end
 
   test do

--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -15,7 +15,6 @@ class Libfido2 < Formula
   depends_on "pkg-config" => :build
   depends_on "libcbor"
   depends_on "openssl@1.1"
-  
   depends_on "systemd" if OS.linux? # libfido2 uses libudev on Linux but IOKit on macOS
 
   def install


### PR DESCRIPTION
We introduced libfido2 in Homebrew/homebrew-core#50326, but it has different dependencies on Linux.

Additionally, the upstream CMake code uses share/man/ on Linux but man/ on macOS.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

^ On the last point, I've included the failure here and here only, since CMake is straightforward about what was missing:
```
-- Checking for one of the modules 'libudev'
CMake Error at /home/linuxbrew/.linuxbrew/Cellar/cmake/3.16.4/share/cmake/Modules/FindPkgConfig.cmake:707 (message):
  None of the required 'libudev' found
```

I'm having trouble with the test, though. It works on macOS, but fails to run with a dynamic linker failure on Linux, unable to find the libfido2 shared object (despite it being installed in `/home/linuxbrew/.linuxbrew/lib/`).