### PR TITLE
spades: Use Python 3.8 instead of macOS Python 2

### DIFF
--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -9,19 +9,19 @@ class Spades < Formula
     cellar :any
     sha256 "4761b8cfbaca36fdc4fac08b8122f5519415d86668355224a67c52a5191ae7c5" => :catalina
     sha256 "f3e29120ab665892ba68d2d7c7522b1fea866a2d405f59547071d8c6c31318c8" => :high_sierra
-    sha256 "1eaedf87e51707e0d6d4fe3d7b4a0b9caa7acd038aa7cd848e68941a74796b4f" => :x86_64_linux
   end
 
-  depends_on :macos # Due to Python 2
   depends_on "cmake" => :build
   depends_on "gcc"
-  depends_on "python@2" => :test unless OS.mac?
+  depends_on "python@3.8"
 
   uses_from_macos "bzip2"
 
   fails_with :clang # no OpenMP support
 
   def install
+    inreplace "spades.py", "/usr/bin/env python", Formula["python@3.8"].opt_bin/"python3"
+
     mkdir "src/build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- This is a dependency of some BrewSci/bio formulae, so it not working was breaking users' workflows over there.
- This required minimal hacks to get working with Python 3 (enough to pass the test!) - notably changing the shebang.

----

- I'm not sure about the rest of the Python files that this [supposedly builds and downloads](http://cab.spbu.ru/files/release3.14.0/manual.html#sec2) - I've no need to use this software! - so more changes may be necessary for more shebang updates.