### PR TITLE
literate-git: needs libffi

### DIFF
--- a/Formula/literate-git.rb
+++ b/Formula/literate-git.rb
@@ -13,8 +13,11 @@ class LiterateGit < Formula
     sha256 "8b3458f7e5337f396d85cb00f9cbb5a0be6fe89943f5175b52e0a80f4d37e672" => :high_sierra
   end
 
+  depends_on "pkg-config" => :build unless OS.mac?
   depends_on "libgit2"
   depends_on "python@3.8"
+
+  uses_from_macos "libffi"
 
   resource "cffi" do
     url "https://files.pythonhosted.org/packages/05/54/3324b0c46340c31b909fcec598696aaec7ddc8c18a63f2db352562d3354c/cffi-1.14.0.tar.gz"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----