### PR TITLE
workflows: faster checkout with fetch

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -12,12 +12,11 @@ jobs:
     container:
       image: homebrew/brew
     steps:
-      - name: Checkout tap
-        uses: actions/checkout@v2
       - name: Setup tap
         run: |
-          rm -rf $(brew --repository ${{github.repository}})
-          ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
+          cd $(brew --repository ${{github.repository}})
+          git fetch origin ${{github.sha}}
+          git reset --hard ${{github.sha}}
       - name: Build bottles
         run: |
           mkdir ~/bottles


### PR DESCRIPTION
Avoid doing a full clone from `actions/checkout@v2` + `ln -s` in favor of using the existing repository in the Homebrew/brew Docker image and pointing it to the correct merge commit.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----