### PR TITLE
workflows: use HOMEBREW_GITHUB_API_TOKEN for push

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -53,7 +53,7 @@ jobs:
           for try in $(seq 5); do
             git fetch
             git rebase origin/master
-            if git push https://x-access-token:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}} master; then
+            if git push https://x-access-token:${{secrets.HOMEBREW_GITHUB_API_TOKEN}}@github.com/${{github.repository}} master; then
               EXIT_CODE=0
               break
             else


### PR DESCRIPTION
See https://github.com/Homebrew/linuxbrew-core/actions/runs/45800031

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----