### PR TITLE
gatsby-cli: remove git config from test

### DIFF
--- a/Formula/gatsby-cli.rb
+++ b/Formula/gatsby-cli.rb
@@ -22,10 +22,6 @@ class GatsbyCli < Formula
   end
 
   test do
-    if !OS.mac? && ENV["CI"]
-      system "git", "config", "--global", "user.email", "you@example.com"
-      system "git", "config", "--global", "user.name", "Your Name"
-    end
     system bin/"gatsby", "new", "hello-world", "https://github.com/gatsbyjs/gatsby-starter-hello-world"
     assert_predicate testpath/"hello-world/package.json", :exist?, "package.json was not cloned"
   end


### PR DESCRIPTION
It's handled in `test-bot` now.


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----