### PR TITLE
workflows: sleep random time between 3-10 seconds

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -55,7 +55,7 @@ jobs:
             if git push https://x-access-token:${{secrets.HOMEBREW_GITHUB_API_TOKEN}}@github.com/${{github.repository}} master; then
               exit 0
             else
-              sleep 3s
+              sleep $(shuf -i 3-10 -n 1)
             fi
           done
           exit 1

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -155,7 +155,7 @@ jobs:
             if git push https://x-access-token:${{secrets.HOMEBREW_GITHUB_API_TOKEN}}@github.com/${{github.repository}} master; then
               exit 0
             else
-              sleep 3s
+              sleep $(shuf -i 3-10 -n 1)
             fi
           done
           exit 1


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

I think it might be a good idea to select a random sleep time between 3-10 seconds, cause setting it to fixed value can still introduce racing, like here:
https://github.com/Homebrew/linuxbrew-core/runs/482924986?check_suite_focus=true
https://github.com/Homebrew/linuxbrew-core/runs/482923122?check_suite_focus=true
https://github.com/Homebrew/linuxbrew-core/runs/482924334?check_suite_focus=true
https://github.com/Homebrew/linuxbrew-core/runs/482924396?check_suite_focus=true
https://github.com/Homebrew/linuxbrew-core/runs/482924418?check_suite_focus=true