### PR TITLE
wdc: fix test

### DIFF
--- a/Formula/wdc.rb
+++ b/Formula/wdc.rb
@@ -49,12 +49,24 @@ class Wdc < Formula
     EOS
     pugixml = Formula["pugixml"]
     openssl = Formula["openssl@1.1"]
-    system ENV.cxx, "test.cpp", "-o", "test", "-lcurl", "-std=c++11",
-                   "-L#{lib}", "-lwdc", "-I#{include}",
-                   "-L#{openssl.opt_lib}", "-lssl", "-lcrypto",
-                   "-I#{openssl.opt_include}",
-                   "-L#{pugixml.opt_lib}", "-lpugixml",
-                   "-I#{pugixml.opt_include}"
+    if OS.mac?
+      system ENV.cxx, "test.cpp", "-o", "test", "-lcurl", "-std=c++11",
+                     "-L#{lib}", "-lwdc", "-I#{include}",
+                     "-L#{openssl.opt_lib}", "-lssl", "-lcrypto",
+                     "-I#{openssl.opt_include}",
+                     "-L#{pugixml.opt_lib}", "-lpugixml",
+                     "-I#{pugixml.opt_include}"
+    else
+      curl = Formula["curl"]
+      system ENV.cxx, "test.cpp", "-o", "test", "-std=c++11", "-pthread",
+                     "-L#{lib}", "-lwdc", "-I#{include}",
+                     "-L#{curl.opt_lib}", "-lcurl",
+                     "-I#{curl.opt_include}",
+                     "-L#{openssl.opt_lib}", "-lssl", "-lcrypto",
+                     "-I#{openssl.opt_include}",
+                     "-L#{pugixml.opt_lib}", "-lpugixml",
+                     "-I#{pugixml.opt_include}"
+    end
     system "./test"
   end
 end


### PR DESCRIPTION
by telling the compiler where to find `curl` stuff


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----