### PR TITLE
arm-linux-gnueabihf-binutils: fix

### DIFF
--- a/Formula/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/arm-linux-gnueabihf-binutils.rb
@@ -11,6 +11,8 @@ class ArmLinuxGnueabihfBinutils < Formula
     sha256 "247a0b582523ad5a3af119b223ef17a04ed4cdcf37cee118d3a0971944f63e17" => :high_sierra
   end
 
+  uses_from_macos "texinfo"
+
   def install
     ENV.cxx11
 


### PR DESCRIPTION
/tmp/arm-linux-gnueabihf-binutils-20200303-2601-m503g7/binutils-2.34/missing: 81: /tmp/arm-linux-gnueabihf-binutils-20200303-2601-m503g7/binutils-2.34/missing: makeinfo: not found


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----