### PR TITLE
seal: use gcc@8

### DIFF
--- a/Formula/seal.rb
+++ b/Formula/seal.rb
@@ -13,6 +13,15 @@ class Seal < Formula
 
   depends_on "cmake" => [:build, :test]
 
+  # #pragma GCC error "SEAL requires __GNUC__ >= 6"
+  # In reality gcc@6 does not work because of some missing C++17 features.
+  unless OS.mac?
+    fails_with :gcc => "5"
+    fails_with :gcc => "6"
+    fails_with :gcc => "7"
+    depends_on "gcc@8" => [:build, :test]
+  end
+
   def install
     cd "native/src" do
       system "cmake", "-DSEAL_LIB_BUILD_TYPE=SHARED", ".", *std_cmake_args
@@ -23,6 +32,7 @@ class Seal < Formula
   end
 
   test do
+    ENV["CXX"] = Formula["gcc@8"].opt_bin/"g++-8" unless OS.mac?
     cp_r (pkgshare/"examples"), testpath
     system "cmake", "examples"
     system "make"


### PR DESCRIPTION
> #pragma GCC error "SEAL requires __GNUC__ >= 6"


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----