### PR TITLE
psftools: needs unzip for test

### DIFF
--- a/Formula/psftools.rb
+++ b/Formula/psftools.rb
@@ -16,6 +16,8 @@ class Psftools < Formula
 
   depends_on "autoconf" => :build
 
+  uses_from_macos "unzip" => :test
+
   resource "pc8x8font" do
     url "https://www.zone38.net/font/pc8x8.zip"
     sha256 "13a17d57276e9ef5d9617b2d97aa0246cec9b2d4716e31b77d0708d54e5b978f"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

```
==> brew test psftools --verbose
Testing psftools
==> Downloading https://www.zone38.net/font/pc8x8.zip
Already downloaded: /github/home/.cache/Homebrew/downloads/ea5f6a485687368ff5bc99e4cc43a49b06e081baa51a97ee6ddcd8d1b82d7963--pc8x8.zip
==> Verifying ea5f6a485687368ff5bc99e4cc43a49b06e081baa51a97ee6ddcd8d1b82d7963--pc8x8.zip checksum
unzip -o /github/home/.cache/Homebrew/downloads/ea5f6a485687368ff5bc99e4cc43a49b06e081baa51a97ee6ddcd8d1b82d7963--pc8x8.zip -d /tmp/d20200304-21389-ui0wr0
Error: psftools: failed
undefined method `shelljoin' for nil:NilClass
```