### PR TITLE
git-trim: run cargo without --locked option

### DIFF
--- a/Formula/git-trim.rb
+++ b/Formula/git-trim.rb
@@ -17,7 +17,7 @@ class GitTrim < Formula
   uses_from_macos "zlib"
 
   def install
-    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    system "cargo", "install", "--root", prefix, "--path", "."
   end
 
   test do


### PR DESCRIPTION
> warning: package `structopt v0.3.9` in Cargo.lock is yanked in registry `crates.io`, consider running without --locked

> warning: spurious network error (2 tries remaining): [28] Timeout was reached (download of `git2 v0.10.2` failed to transfer more than 10 bytes in 30s)


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----