### PR TITLE
sn0int: fix

### DIFF
--- a/Formula/sn0int.rb
+++ b/Formula/sn0int.rb
@@ -20,7 +20,7 @@ class Sn0int < Formula
   uses_from_macos "sqlite"
 
   def install
-    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    system "cargo", "install", "--root", prefix, "--path", "."
 
     system "#{bin}/sn0int completions bash > sn0int.bash"
     system "#{bin}/sn0int completions fish > sn0int.fish"


### PR DESCRIPTION
```
==> cargo install --locked --root /home/linuxbrew/.linuxbrew/Cellar/sn0int/0.18.0 --path .
  Installing sn0int v0.18.0 (/tmp/sn0int-20200308-7480-68kf0j/sn0int-0.18.0)
    Updating crates.io index
 Downloading crates ...
  Downloaded atty v0.2.14
warning: spurious network error (2 tries remaining): [28] Timeout was reached (download of `bufstream v0.1.4` failed to transfer more than 10 bytes in 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (failed to download any data for `bs58 v0.3.0` within 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (download of `rustyline v6.0.0` failed to transfer more than 10 bytes in 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (failed to download any data for `regex v1.3.4` within 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (download of `image v0.23.0` failed to transfer more than 10 bytes in 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (failed to download any data for `http v0.2.0` within 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (download of `maxminddb v0.13.0` failed to transfer more than 10 bytes in 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (failed to download any data for `kuchiki v0.8.0` within 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (download of `bytes v0.4.12` failed to transfer more than 10 bytes in 30s)
warning: spurious network error (2 tries remaining): [28] Timeout was reached (failed to download any data for `base64 v0.11.0` within 30s)
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----