### PR TITLE
cups: Fix incorrect `--without-gssapi` flag to be `--disable-gssapi`

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -20,7 +20,7 @@ class Cups < Formula
                           "--with-components=core",
                           "--without-bundledir",
                           "--prefix=#{prefix}",
-                          *("--without-gssapi" unless OS.mac?)
+                          *("--disable-gssapi" unless OS.mac?)
     system "make", "install"
   end
 

--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -8,7 +8,6 @@ class Cups < Formula
     sha256 "028330028dca9194605bdf6ec807b413adae82b1491bb69cbee64d31fc04a6f3" => :catalina
     sha256 "4fd5c5705dfb551e9fd5091f63a69d985bae05bc0b29fb253c9877138b254e7b" => :mojave
     sha256 "932ce69ebe900f3e307939ffb475a1d2d3f46d079b3c6b5238385051bdc110a1" => :high_sierra
-    sha256 "0b406518947c2396af9df83808d95f3ff8413410f946be765a3efb63fde64b2a" => :x86_64_linux
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- We found the fix for this in
  https://github.com/Homebrew/linuxbrew-core/issues/19707#issuecomment-590585914,
  but it was patched incorrectly in
  https://github.com/Homebrew/linuxbrew-core/pull/19709 and I didn't
  notice.
- Thanks to @greghogan in #19707 for reporting this typo!