### PR TITLE
git-trim: build depend on pkg-config

### DIFF
--- a/Formula/git-trim.rb
+++ b/Formula/git-trim.rb
@@ -13,6 +13,7 @@ class GitTrim < Formula
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"
+  depends_on "pkg-config" => :build unless OS.mac?
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
```
It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----