### PR TITLE
python@3.8: Rebuild 3.8.2 bottle

### DIFF
--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -9,7 +9,6 @@ class PythonAT38 < Formula
     sha256 "6088fc578e115c4740a7edef7dc36add1475bba13f6ec5158a48eb45dff5d740" => :catalina
     sha256 "826c933bd7112885dd9c5300e17e8bf6860c2ab6fecd281629a0a6bb0e136edb" => :mojave
     sha256 "6a8f2f3959fd546da861759748fa36936d1539fceeb34b70438d870e3600f5d6" => :high_sierra
-    sha256 "d5e09c1e804f1de3f03a62567a953c220872d05a52fc1ecb8a3468e17f9dc59d" => :x86_64_linux
   end
 
   # setuptools remembers the build flags python is built with and uses them to


### PR DESCRIPTION
- We merged this from Homebrew/homebrew-core in 8d71cfb13edd93bb1cd6fa860d6716c20814579e, but there weren't any conflicts in the bottle lines, so we didn't remove the old SHA, so the new version's bottle didn't build successfully.

```
==> brew bottle --merge --write --no-commit ./python@3.8--3.8.2.x86_64_linux.bottle.json --keep-old
Error: --keep-old was passed but there are changes in:
sha256 => x86_64_linux
==> python@3.8
==> FAILED
```