### PR TITLE
ykman: Rebuild bottle for python@3.8 revision bump

### DIFF
--- a/Formula/ykman.rb
+++ b/Formula/ykman.rb
@@ -13,7 +13,6 @@ class Ykman < Formula
     sha256 "6b0f5422988f06d8fffffed1c81ef4ef37fe577144a9f60eda5bfde0d7a4499a" => :catalina
     sha256 "e55ff26b3e133f483382df475bf2ad9f4852c9aa62c6ad26d360defd674fea21" => :mojave
     sha256 "83758f4f58c383ac3332c5802fafe613c8877369a335f4db6967784fe96f5880" => :high_sierra
-    sha256 "9fadf2c65a1a3bfff4d8d893fb5f912c4894818e1e681de250d9a109cdafaee0" => :x86_64_linux
   end
 
   depends_on "swig" => :build


### PR DESCRIPTION
- We merged this from Homebrew/homebrew-core in 8d71cfb, but there
  weren't any conflicts in the bottle lines, so we didn't remove the old
  SHA, so the new version's bottle didn't build successfully.