### PR TITLE
awscli: Rebuild bottle for python@3.8 revision bump

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -13,7 +13,6 @@ class Awscli < Formula
     sha256 "3033f2cccdaa092b04280859f72b510cab3d680e4b86eaa626ffccdcbfe9790c" => :catalina
     sha256 "10584b5630f3247ecea6cc68b2b3f74ed3b4d165ced46a7646e1b7a02e98db48" => :mojave
     sha256 "d9360809cb789c75c9b379564a8168d7f41baa052d14062473bdbc119077435b" => :high_sierra
-    sha256 "9f5cca9aa3a3491e52b1dc8daced68d69d42fcd04d5d5a05d00f3c890907567c" => :x86_64_linux
   end
 
   # Some AWS APIs require TLS1.2, which system Python doesn't have before High


### PR DESCRIPTION
- We merged this from Homebrew/homebrew-core in 8d71cfb, but there
  weren't any conflicts in the bottle lines, so we didn't remove the old
  SHA, so the new version's bottle didn't build successfully.