### PR TITLE
thefuck: Rebuild bottle for python@3.8 revision bump

### DIFF
--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -13,7 +13,6 @@ class Thefuck < Formula
     sha256 "762a5d749374bbda2f181728c971bc998ce9c32f4ea20d242be0c5879e97356b" => :catalina
     sha256 "2e261bc8017c602761652100d4075a0a2dbb63eb4c385135defdd157ac0a1aaa" => :mojave
     sha256 "e0d301ddb9c3f769939484e9d6078be4edb25f099a10d8d75d7f67f12b04e15d" => :high_sierra
-    sha256 "53dbabfb68f71ded5f60a0e261ebb26156000d40a0a7b39a0e2466373ddd8a13" => :x86_64_linux
   end
 
   depends_on "python@3.8"


### PR DESCRIPTION
- We merged this from Homebrew/homebrew-core in 8d71cfb, but there
  weren't any conflicts in the bottle lines, so we didn't remove the old
  SHA, so the new version's bottle didn't build successfully.