### PR TITLE
Merge 2020-03-12 fd7578b01f

### DIFF
--- a/Formula/ansible-lint.rb
+++ b/Formula/ansible-lint.rb
@@ -9,10 +9,9 @@ class AnsibleLint < Formula
 
   bottle do
     cellar :any
-    sha256 "4bcb0e12b8186301c42be8fdbbedb50e26a5168324807cbc4223b71257f48472" => :catalina
-    sha256 "262b1e46d5b13ced6641be3eba16f31ce92219caaf89ee4ff0a5cb77fb19f3f6" => :mojave
-    sha256 "78465b1854e034eb68cea65f5b37b62e1b6ec07b2b45e8586c7d25039d35b39b" => :high_sierra
-    sha256 "efc4cd6cee61e43580d0410f6f338907f1d9d82c8a20b4a3e0b26c37626b949d" => :x86_64_linux
+    sha256 "3426e9ec96b4e938f4f0004d1323db89737f1f526fecee081771cf30e1689dd7" => :catalina
+    sha256 "6558f69553bf09ebdef982f05a57492c9fd14a9a0baaed61151d8d054e652e73" => :mojave
+    sha256 "83a905c6fedaabb38d7a53692d892ea9e2bd429d5a39b1c338dc2e26ea0d352f" => :high_sierra
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -10,10 +10,9 @@ class Ansible < Formula
 
   bottle do
     cellar :any
-    sha256 "a7cd7807d97993f8faf203e28750446c3d975fecd177fee59b72da89f1c1fae7" => :catalina
-    sha256 "8797cb2e0fe7c625080a0aac6d71514bf2482eeeb4b6e1aa4ee9e1af15f76f7e" => :mojave
-    sha256 "7b41e10c08795543eadaa36c016ae1de44c529e9e41268731025756da7348496" => :high_sierra
-    sha256 "e98b9bb79a413693eb0f41829c9caa740f4441c45e635ac6a25343824d3c95e5" => :x86_64_linux
+    sha256 "ccbafde5854d77e4a0dfb36f136a01715f50e8dfb5d3c48f10a17903caa01acf" => :catalina
+    sha256 "bb6817ecda04aa48bce6e32c18bad49c44f054ce4e669eb23fd47690b383800f" => :mojave
+    sha256 "7e9ddebb8eb7b26e20c5a60dfd448867e8da52c27299351d33a3e2462c58fbde" => :high_sierra
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/asciinema.rb
+++ b/Formula/asciinema.rb
@@ -10,10 +10,9 @@ class Asciinema < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5422076ad38dc1ebeb2b70dc3312a329e0f4e72dd747cdd134d8df25c669b98e" => :catalina
-    sha256 "326c68e10e65f73d1dcd0134ae912e075c7475422b04b90d714a6ee513ceae91" => :mojave
-    sha256 "d665c2d995562ef9c7aadbec4707d567851ba8d46df5e7ae02b23be9cc26c0c3" => :high_sierra
-    sha256 "0dd79ea19b5f2b7ddc02d91941f9e0c4a65d5791b84f79485ad4903dbd1c640e" => :x86_64_linux
+    sha256 "fcfe6fcf14def6bb9881182d67f94c91afdb0455e880aa743153269af7c77eaa" => :catalina
+    sha256 "1ecae96f0952d1ea2156f779c86e09986744249ad5903db5f6da12664a8b5b99" => :mojave
+    sha256 "d279386736b319c8cc83800303f0b3948b2e28bae92279479b69d70ed6c762b6" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/atdtool.rb
+++ b/Formula/atdtool.rb
@@ -9,10 +9,9 @@ class Atdtool < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "d6b4caae97223c76d2d3f41a45ecb7721aac8f90cbcd54de2412abf60e351e59" => :catalina
-    sha256 "b81608e6b0b99684c095c2e0fb88430e4e54f6b285ae85ef1355657a563be373" => :mojave
-    sha256 "c0a9496c43531cd2b3d03da346ada7f938118d7dfab91cd276122feb9eb2b478" => :high_sierra
-    sha256 "bd98c7601218e0655140ab6ebeabb1f938e40fbf9875a7bfe998c3c45451ebdb" => :x86_64_linux
+    sha256 "f02a78aa9dbb19e8ca8670a6890f3d51949d014e6890ba5039fd9695bc1f46ce" => :catalina
+    sha256 "17b2ed63f8b4f8aa53e367572b53344fa3e6fa8569e5a9fb48f3a0d5257d04cc" => :mojave
+    sha256 "0f301757a596e02344c15171a834557e19e4c4145fd440cd9e960b72993e459a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/aws-elasticbeanstalk.rb
+++ b/Formula/aws-elasticbeanstalk.rb
@@ -9,10 +9,9 @@ class AwsElasticbeanstalk < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "bef9c30ba7bb504282de8c2439837b96023ee3e6fb11523c13c03ae771e9ae91" => :catalina
-    sha256 "32c44baeb6c6afc6c61732180dc608151503ba409d42b4c40c984030c3baf8fe" => :mojave
-    sha256 "bc252ae6e9fbecda68f82429b3a5f1c5729b31cdbe7b23f7aa28dfc238aa293d" => :high_sierra
-    sha256 "4a130d445d8fb2721e7221e760016fe848e50be65d984392f8d80716cb77dc0a" => :x86_64_linux
+    sha256 "7edabb48247d09762f1b9caf44dddc6cf66d9ace014dd02487f7e194b9738e4c" => :catalina
+    sha256 "bbdf41f4b6c7b261632efdc85c8350ba74b506bc0ecb9a4482e273a3fc0024c2" => :mojave
+    sha256 "3c43851537447de42d947e2517848548fcdb8adc30ce06c701de9ede71190bdb" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/aws-shell.rb
+++ b/Formula/aws-shell.rb
@@ -9,10 +9,9 @@ class AwsShell < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "31cbbe5d81a4f19927d148cdf09090baf0f3b60d0d879986ebb6de3d86fed78b" => :catalina
-    sha256 "dc1f1951cee4823efe8ab0bdfde72c024aa2a0dee1eafdaaa2c14805852df83a" => :mojave
-    sha256 "db4cb7f0285c0fac6af635083c8921c074995f7fd6c6b1bf4926c601d456b06a" => :high_sierra
-    sha256 "c3a612ccbd6b0d67ec7954379321423d866d5150905aad94936a64cdf48eb852" => :x86_64_linux
+    sha256 "80649fd9dfb5ef9c0506db4f74e0a4ff275617a718249cbc12d2c62efb46657f" => :catalina
+    sha256 "174cce4bc60dfa38babc3bae1dd3b1ab8614c2339340eaaf438012724ebc3646" => :mojave
+    sha256 "e59a26cea8549c99c0f6586db2f85d9400b53911902ec9ebdac1e6379d2518ac" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -10,10 +10,9 @@ class Awscli < Formula
   head "https://github.com/aws/aws-cli.git", :branch => "v2"
 
   bottle do
-    sha256 "3033f2cccdaa092b04280859f72b510cab3d680e4b86eaa626ffccdcbfe9790c" => :catalina
-    sha256 "10584b5630f3247ecea6cc68b2b3f74ed3b4d165ced46a7646e1b7a02e98db48" => :mojave
-    sha256 "d9360809cb789c75c9b379564a8168d7f41baa052d14062473bdbc119077435b" => :high_sierra
-    sha256 "a574e19bfa955e207cb188fb0926632ab93a0bdc8d19c6fe78a2169a99b986fb" => :x86_64_linux
+    sha256 "405a9159cf128dae174f7e5ce24f6824e6b656520a916787bf17e2f22ca7bf08" => :catalina
+    sha256 "31293407962228bf88de5c3e7d387251af8e186a7b4fad5d9fb2f7f5f8f3a80a" => :mojave
+    sha256 "b2f11b2d9871159ad7965dcb20438692027dd4951422860e5f891aa4f09c3bea" => :high_sierra
   end
 
   # Some AWS APIs require TLS1.2, which system Python doesn't have before High

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -10,10 +10,9 @@ class AwscliAT1 < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "2f3e613d4f82356c7fba6fb6cbfde6509832ba20ab240427649e375aac1762d3" => :catalina
-    sha256 "744d529f3857e4e228c6e1506c24107188889b29fbf36670b3c5a0bb4ec732ec" => :mojave
-    sha256 "ee32c9e42fabf80cc5ca05dfa74256fd73d42f7ad25f3c45258d16efa15ceeb8" => :high_sierra
-    sha256 "db8a6d3cde70117ad66d9184fdd378a9f02a563790dce57f46ad6f2773b5408e" => :x86_64_linux
+    sha256 "8232729cfb564d40d37688b604e9beb67785d0b35631d7046693f8f55f3ae04d" => :catalina
+    sha256 "85344466abd054e3aeb238124e5f2be6336f2f9668c30ab9688a45c0c8b9445c" => :mojave
+    sha256 "d461a71f56d4975a4eab9c137aa98b7f497b2ebbc7a0a215ba7e0ee8ad8c4398" => :high_sierra
   end
 
   keg_only :versioned_formula

--- a/Formula/awscurl.rb
+++ b/Formula/awscurl.rb
@@ -10,10 +10,9 @@ class Awscurl < Formula
 
   bottle do
     cellar :any
-    sha256 "9dd84da18a45e016d458999e5d8a703cef475b0a212c4f288f0897d9eb6d14bc" => :catalina
-    sha256 "c86a60007a3e91216efaa564d5e0a3e4d11d8aadaa6b2cc9d832307e30c6cd89" => :mojave
-    sha256 "b79f8ec8705abe4dd8d55d55bf4f4c7d297b7635ddecc7da591797c3e0c295c4" => :high_sierra
-    sha256 "91a50ff333bed1014f5214f9dbc8c2fbabb82ac2b0e855bda8940dff13f7d6f0" => :x86_64_linux
+    sha256 "b6eb9274da3699bce4675068f5476e63c900b9e1aaecaaf3a7d80845143ff919" => :catalina
+    sha256 "2de296f8d1c89e5532526017faba23cdb36ec34bae668308c671d4a56a252995" => :mojave
+    sha256 "38ad9e69f5e0d14d4c8007d059b8faf61cec1f6a6ec9f61cf2e25fc19ba3d005" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/awslogs.rb
+++ b/Formula/awslogs.rb
@@ -10,10 +10,9 @@ class Awslogs < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "f830a44cb54fceac76e0588cc8cbc12ef61bce9fefde7395f6eaa8d459bfaf94" => :catalina
-    sha256 "8dc15f74822ee782d470c17cda9796ab2859639382b6b85196fa95df1e0467c3" => :mojave
-    sha256 "2adb8376393d9f0922bbe8938980d612995389d05794605cd565d4d4cf1874fc" => :high_sierra
-    sha256 "d101fb9cdc5fd445135be02e92f602f661017b0a83af8987dde73cf00eb059ac" => :x86_64_linux
+    sha256 "7918feeb3d8bd6ff0944c55afae7864eaf5cea516029b33647aa2ce87288ce86" => :catalina
+    sha256 "5079a8ee7893316f2febeb41caf7afe6a0a2efad9f553f04dcfb80be9109e1d0" => :mojave
+    sha256 "04e319b2b99b8c62ce50d8c4cce6804aac585d063ac4da9ec8459dc9a8719512" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/awsume.rb
+++ b/Formula/awsume.rb
@@ -10,10 +10,9 @@ class Awsume < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "1697566da97be3e9a067afe9e6af53137d60834244a64dc1fca368a282c53731" => :catalina
-    sha256 "8f8363d9ef1a7c932e27f7848d503b06ef7b10c61f890d672ca185f9dfa2886b" => :mojave
-    sha256 "670e56b9065f8b080be0b6a59b2632396b85ab59d9a2ef9094aa0501e611fd34" => :high_sierra
-    sha256 "8ee0d6efd8b9f46da5e1f6f3a761d0c7e676258f045117e0c79a73c07d64511e" => :x86_64_linux
+    sha256 "e37953394517c3ad482fa7236e1543f0656c8ce850af30e8079a60b500d372aa" => :catalina
+    sha256 "cc9fb242edd68a6503f20b49db02d9bc943d255745c6f2e766891767051173d5" => :mojave
+    sha256 "c41a8393be66c50dc1551bcd6c7077648d1cbb0b6955e8a34a8aa48cfe528ee9" => :high_sierra
   end
 
   depends_on "openssl@1.1"

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -11,10 +11,9 @@ class AzureCli < Formula
 
   bottle do
     cellar :any
-    sha256 "38f8a9ad0c8746ed84d8df5eb73c43ee69fed7517ee3ac5a57367bfaeb99f75a" => :catalina
-    sha256 "09e33ccc27ae0b03277c8b3376eb4d2a74fe6b8e178e3133ceac1dbf1d341853" => :mojave
-    sha256 "014882fbef68b41ff3aed330f651490841c19f42a5b773a36bdcb5f92f8b6d05" => :high_sierra
-    sha256 "67bbe760eb201553a1748045a751ede8385eec2da9f34a06a39e7eeb78bfd3f7" => :x86_64_linux
+    sha256 "bdb75aea255cbb9275332d3bbda5b413b91b9f2d244b2c21c621edd7eb706f91" => :catalina
+    sha256 "60d84c6ecc8820b874f09ba7212d95e117c5039148d3b9e18e7202ff96ca7860" => :mojave
+    sha256 "97d28930c2d603e049e09af0f08ae178998440fe6c32c6284fef057d2271d247" => :high_sierra
   end
 
   depends_on "openssl@1.1"

--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -11,10 +11,9 @@ class BandcampDl < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "fe3d57c5f55bfa6ffda246483c8b5bbd52c26ab870822587a72e6c3b0f76e04e" => :catalina
-    sha256 "6ad6b1d51e051049a4a48d095ebaf7235cfa028101b981885a2a142c08ebedb6" => :mojave
-    sha256 "4976e998158abd58da8af58a171ce4cfe942700ba149aa3541d21dd6ca318543" => :high_sierra
-    sha256 "8f002aeb9ce59229d6e90ca9ac9044543f3a9a9c3b294ea76fe2581e3712855f" => :x86_64_linux
+    sha256 "7906dfa2016495c4e0aeca69d9aa2b7e9bcc2ac4742ba2900f3e4b6a942a3053" => :catalina
+    sha256 "5bce4baa9ae47a78a43206aad853a0a202395dc335d41756050af358967f035f" => :mojave
+    sha256 "9c8c311b18dad230648661c3b981583ece5e647285239c6024efa2f2598f439e" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/black.rb
+++ b/Formula/black.rb
@@ -9,10 +9,9 @@ class Black < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "3f67772566b3334f6a2c6d6d70d3f5b4a775db05b5953e721364d79e54fad369" => :catalina
-    sha256 "0344cc00f35d00398f73346681b4acf5f15eb165e7e8f6ccb4eb69dd44ea5cae" => :mojave
-    sha256 "cdf830b2a2d3e008de06e54afac17eb22e368aca1ff562fa870bf87dc9f26302" => :high_sierra
-    sha256 "df935da364df7e883ecdce5fa2c6697a74e1068e5b61dd8682c98cecdf2f13a7" => :x86_64_linux
+    sha256 "144397ea511cf3baaf36d229797a6329406c47a0bbdffce10821e6458064f59c" => :catalina
+    sha256 "ce49495988a237b4b1463bca860d3eb778c4c9bb4cae1978828fcbe49e40250c" => :mojave
+    sha256 "1b1ec4e639f666ca3ea506e89ea1fffbcc1c2a21111fd494874cffd6f422643c" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/cfn-lint.rb
+++ b/Formula/cfn-lint.rb
@@ -9,10 +9,9 @@ class CfnLint < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "bd6a5f6e8f667c793066ed6812327c7bb2225f64cc177c22f4b9c858bf5de5a6" => :catalina
-    sha256 "3811cf107c29524f521e6fb486b89a7400873779ade6cd10e751e37224781bca" => :mojave
-    sha256 "9cf67adaf076c95b8d1be31a83fbb0d03733b7387f2d1c02ed499a47c14d9e74" => :high_sierra
-    sha256 "e1b4ae0b21d8146a04908917bd166c6fc409108b1c9fd56bea26b189e1400636" => :x86_64_linux
+    sha256 "60cd5d1712de4823405a184ed4c37a77931416af7c963ee63b0736ddbc10f571" => :catalina
+    sha256 "4b285d2f7c13682db72cc4811bfb3ea1981cddaa3cd95066b8b972f9cd648674" => :mojave
+    sha256 "25d1cbfa78336de5d16be4255dd3ce161938f13ed9044602dd0aa2f1f86938ed" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/codemod.rb
+++ b/Formula/codemod.rb
@@ -11,10 +11,9 @@ class Codemod < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "e1f2a505f229e358245b5b4acda1521d779a1571fe28906ba6ff41defb16d3f5" => :catalina
-    sha256 "fd0d17dff4afb9ed4d7198f3fa8accf98ba34315b00c86e154511ac327eb4598" => :mojave
-    sha256 "9a2a53e8930da3bb29f1ba2650ee04583308afc5f3e16a5f7975074da484c099" => :high_sierra
-    sha256 "082c30296e2b2fd4976b569c176395c13a121686bfdeab039b91ba1ab9eb52ef" => :x86_64_linux
+    sha256 "3b32fef1fef317a4544225f6de58e0c1e970de6deb10258fe2d3f937116d5468" => :catalina
+    sha256 "da2eee278c0136d201d2c59db1876f90996600c8a00a0c2434742015846d7457" => :mojave
+    sha256 "31f1ef7e3e6867ef52f0922c807762363b3a4f1c520b0de5bbd448282f95a5e5" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/codespell.rb
+++ b/Formula/codespell.rb
@@ -9,10 +9,9 @@ class Codespell < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "e5bd38be2a2e19da270f6f547efcfdb325418d4554e5572ecf9070f05a6fa0cd" => :catalina
-    sha256 "8d648259f31feb6afa58958f64daf6cd681382ea0cb9a0c4024bec7913502ab7" => :mojave
-    sha256 "4f501e0bc4df951622b9748d11df1b14dadf1d5fa1e79bb11bd49c51f61caa8b" => :high_sierra
-    sha256 "7efdddbb610856ffcf5d5b7bc4e0ea683ac49a8fce769b9e41b927a2092d7691" => :x86_64_linux
+    sha256 "99881ae6b8146c6d2f1920ebe38326ec956fb6f373e0a24e0edb752aba542b39" => :catalina
+    sha256 "5a03b3a7c8ee14881fa1ea4b67704d0669f67947ea4dce63e559563105d9d811" => :mojave
+    sha256 "adf3d2cb26a64b62a1cd57a380330bf5328aa49a8591668445e212d970c820d0" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/conan.rb
+++ b/Formula/conan.rb
@@ -10,10 +10,9 @@ class Conan < Formula
 
   bottle do
     cellar :any
-    sha256 "a2b829b259eebd57153956309485f3d7ff01586ad27ff3dd04af18c613ab4c15" => :catalina
-    sha256 "85af0ee6c31bc850eaae1762d247d27cf49df11e021a1c949100655d4b6fb83f" => :mojave
-    sha256 "e4e455dd6212ba65583a2df45d714d2b9480e0f7c9f8c7d362f06aa525e5836d" => :high_sierra
-    sha256 "420fcaf37ae7bc4c577369ac3f9cbe0a5c34c9c6dcfd725ab6b0bde9fd16b95d" => :x86_64_linux
+    sha256 "ba2bb5f4cff6578ec8da1fca0308ef2cf071ab5645b17b573c9cd221e1452ff9" => :catalina
+    sha256 "bbd877aa41ec793191f097d54ed51c4450e7e24f655f08cd6306b420bfaae6b5" => :mojave
+    sha256 "3f32ebfa284204d60a69ec137f50098a46f460b680f6a4457a41bc00db454c88" => :high_sierra
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -9,10 +9,9 @@ class ConjureUp < Formula
 
   bottle do
     cellar :any
-    sha256 "fd6b4836be1b7814114bc7ec842511827b14e7d9691aa5210e95ffb859b93cef" => :catalina
-    sha256 "77edef65d3b9d34b3f67c7efbdd05cd9ac0e92613e538aa4e022720d024c1061" => :mojave
-    sha256 "ea0e51f5d572449a15021125e9a92c92437f3a85eb69f503d1c8b3d53c2cf7c5" => :high_sierra
-    sha256 "08dcda31dd5993697495b9f9548e55ccb5f71d5ce37d3499ecce3b319543500a" => :x86_64_linux
+    sha256 "e9e7df0108dd3be03a9391a95befbbfa66950bbbb48ae8fd28f4855ae6c69932" => :catalina
+    sha256 "dc221c6071b5a37760a530da1981a96a1f404fa461d44fee7a217897e9a01077" => :mojave
+    sha256 "b20ebbe1aa0c30c713e58c03ac167196f7c3b5635f95c1ce8687e6bfad9a0294" => :high_sierra
   end
 
   depends_on "awscli"

--- a/Formula/cookiecutter.rb
+++ b/Formula/cookiecutter.rb
@@ -10,10 +10,9 @@ class Cookiecutter < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "23b8752332bdb70a0a64dc403c989ac67d1873c3eba069140dba096b41db4b0f" => :catalina
-    sha256 "b446a605afc6477e6bc0feffbc0784244f1ff43c87a5f60f08baed3b5d08e615" => :mojave
-    sha256 "7eb340644aff0deb39a2d6be9d887547e1913063e39709575213734cfaef452b" => :high_sierra
-    sha256 "91b9447956d949281cc1da7363211dbb94eb86f6a4f8e9a4e4df410eb745a3c5" => :x86_64_linux
+    sha256 "77cd3bd1805e433d60f4865c9019d9f0252c4c1e3d440692302d822bba62d5ac" => :catalina
+    sha256 "7a90a88ac29d88f03cb1a1e7e7caa2d201bb8b1d6523eb630bd061c095e79f03" => :mojave
+    sha256 "a0e68ab4e634a115063e292d76ca3ecb7fdfc460a98b62e98bd90d45443469d7" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/cppman.rb
+++ b/Formula/cppman.rb
@@ -9,10 +9,9 @@ class Cppman < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "63448446323c8ea20143657aea0c247257c26b53db415461fbc35d469bc62238" => :catalina
-    sha256 "9d0ebc84c9b1f7b9981c641373b3996869fb6fb876fc8659d3629a861cc375c5" => :mojave
-    sha256 "cea1ac63fb20dd66938bb023d4bad51c2fc704baf0ef5233fcc6bcb036decf64" => :high_sierra
-    sha256 "4e65338c1205ecbb8b05bb174f295054ef2871cc28324c9f1360abd2b065a52f" => :x86_64_linux
+    sha256 "dbb2e70d0843395577a38d7f69ca8d1ad038bdd5f5660cfeb96ae85737d2bfd2" => :catalina
+    sha256 "32ea0e98475d464c6ba0b7abd4471836e1f0a1ab54fba8e37008ac5593601387" => :mojave
+    sha256 "5671d5634754c20e664efdd99f27f5a93adbbbd3e599fdb3a084b73ffc04c8a9" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/csvkit.rb
+++ b/Formula/csvkit.rb
@@ -9,10 +9,9 @@ class Csvkit < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "cfbba95ae561d6427b1e88dfd7840dcec7c768181d340b54777004b7c8d7bf88" => :catalina
-    sha256 "734f089841cc155d0402ea7e32ba114dd7050e923fe805e436fd1b1c53ee4331" => :mojave
-    sha256 "31298f79921aa4c93cbeab914aab65b93a0941de7eacace086f7762520ca6fe9" => :high_sierra
-    sha256 "69389d8691776b065f0a822047574755ee9589360d0bf0cd3263c0e4e1bc3e54" => :x86_64_linux
+    sha256 "1bb059e0420e7f4e117ad9bb0ad9ec2e281547c87ce3dec197dbcbcc2fbb3223" => :catalina
+    sha256 "39eb13816f8ea1ff6e91d759450a1cb56edc558cdc997776eb60a1fbfeaf4881" => :mojave
+    sha256 "2d7e167505bd1635d0fa97f525683c5a938cb6ebf7351299260822a4560cf513" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/csvtomd.rb
+++ b/Formula/csvtomd.rb
@@ -9,10 +9,9 @@ class Csvtomd < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "918cd172ac8636b250cf346f0e5ea4569e9e9f2491607ff631bbe65036f70bb7" => :catalina
-    sha256 "ae7121b0c78dbb3f52159995056a7eaf6c3707ea8b52baa9222fd3eace4cb7f4" => :mojave
-    sha256 "d0d67820b26eec4a770e4b721298792c93dd1239ab78c4f972bf1d657954c852" => :high_sierra
-    sha256 "c2827a320c3b9b92fb58b063624d953d2d6b047f4325657beb28aadcf98fe2c3" => :x86_64_linux
+    sha256 "a095eb1747bdc18b737a5a1a090486cd0b694f33283163007f19b3b9e0abfade" => :catalina
+    sha256 "87c756127704a0211c2dcb8d7e0b7b11dfbaf0a2878dfec9a4881e034f114fd0" => :mojave
+    sha256 "c7ec7a2ff12f6d5707bb51b14bd078c2401840108cf1f6c4a774d04ffedf427b" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/diceware.rb
+++ b/Formula/diceware.rb
@@ -9,10 +9,9 @@ class Diceware < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "f86f57c5ebcdbab709ee24572459743f92cd60a1877225af5124ca56ac592d1e" => :catalina
-    sha256 "83c6ce549c1b824d0bc3c9c550ba8f0837cf0021ce0dc62b22ed43df33a31fbc" => :mojave
-    sha256 "fe863d5aa48b47eb18aa8b294cf0a9e63fea4d9c58c0d14d1938fb649a1e074f" => :high_sierra
-    sha256 "56bfd072e2e3fe7a47d5f3957135ed3cb6397a57a475f6428ad1a2201be3ef40" => :x86_64_linux
+    sha256 "510a0f4aca2e72306d28a54c0c5d5a2d5dd98b6a7c5e8b5a104e637b1499866a" => :catalina
+    sha256 "f5dfaf498b1d3097b8b5346b215e81f1af6dcd98da65ec123a8b129690df3650" => :mojave
+    sha256 "a5838d0d6d69978d1bd9d56699ae4256af9a56bd5636614e783b4e4379c8365f" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/docker-compose.rb
+++ b/Formula/docker-compose.rb
@@ -10,10 +10,9 @@ class DockerCompose < Formula
 
   bottle do
     cellar :any
-    sha256 "ebe367f2fb704314ae2875d865c40c9b8b1e870cf888742c99216356f114961f" => :catalina
-    sha256 "54f367f476359b1a12e8b0f23fc9a7583732f2bd678ab031fd6ea980350dbad3" => :mojave
-    sha256 "ef81d6ad5b72e9fc2233e0f314d7b71eb20a9641e763957a2a1b2adc594791cf" => :high_sierra
-    sha256 "cbedf382149acd07554557f4bde23aa88204e4f9ef36da7e2c5aed91607beb45" => :x86_64_linux
+    sha256 "463bd4a012d5bed971040db53b737bd4c89ae9ee05a14d4d738cf06e9bebd9f9" => :catalina
+    sha256 "e3572703ef4cf05000d0eac018b0a01d2d82d7a54941667f2581bfd26e12959f" => :mojave
+    sha256 "3c74f2f820c364a88e66667a372fa0c5bf06516e8f0e234b70990cc1cf99fd80" => :high_sierra
   end
 
   depends_on "libyaml"

--- a/Formula/docker-squash.rb
+++ b/Formula/docker-squash.rb
@@ -9,10 +9,9 @@ class DockerSquash < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "8ead2027bde16b9a95669e7cf27c4a2bbc62062866d3f22fb689ee265e648e93" => :catalina
-    sha256 "f8fffacef91f2f33bffd9b48a7d3e7441e1b9518ec3b8bff3692c2c96ab048e2" => :mojave
-    sha256 "a7620d50b1b463b766f034a0369e2b78fefc4cad238511b8e7e135638be69a8a" => :high_sierra
-    sha256 "b2f0a92c9aac412de61e99875ef772cef49faa1214408bf36d21301141b90d9d" => :x86_64_linux
+    sha256 "acf125fff4af17093f168aa89c5e1d5842970435f1016749e4250d37d5653552" => :catalina
+    sha256 "cdeaa159137369db885656b13f7f893b0ebff19898eabb3577d3fcac567b5f8d" => :mojave
+    sha256 "afdfce8a93406db973df50f90527e4554769207e0c3b0b5de323fe2b0de1a419" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/duplicity.rb
+++ b/Formula/duplicity.rb
@@ -9,10 +9,9 @@ class Duplicity < Formula
 
   bottle do
     cellar :any
-    sha256 "dfa4f6fd8f00871878c37acce859f7ed7f43d7013325f1a2ad0deaf0a8ed74ac" => :catalina
-    sha256 "c8a4cd7dda69365f7777ca8b85e18009eb1b657bc180c766f495cd378885d671" => :mojave
-    sha256 "fdb22b911d91d2c9642733e4461f7d11bf6ed00231487491adec2b17a4a5ec10" => :high_sierra
-    sha256 "b084000b14c800e6c38b8acafe84e2a180acbc1ba2e48326523a76b7e2cdf76d" => :x86_64_linux
+    sha256 "821a9e25d59e45eb7135ad1004d16703cd909ce82026c6a5ebbe1571b85b9053" => :catalina
+    sha256 "1a72d6deb2862829e243372540b006c1df69aa11e4a6ec58a999d8266ffce5c8" => :mojave
+    sha256 "d31c4f7cfd95290bf9fe29011c447a58efc6e0283fa690dfa5782cb914af6d23" => :high_sierra
   end
 
   depends_on "gnupg"

--- a/Formula/dxpy.rb
+++ b/Formula/dxpy.rb
@@ -9,10 +9,9 @@ class Dxpy < Formula
 
   bottle do
     cellar :any
-    sha256 "e609718132a27c8a6477239b7f2be06a620c1f6c5d7f05faaefc00d0e1f62a8a" => :catalina
-    sha256 "963176d06ebb52f5d7f6c209a30c3a36283a0419da80160e1c594b294897f2c6" => :mojave
-    sha256 "e11aad72c95d6cd93728f0e62e689107046f51bfb8fdbb3a35696e870e8101ee" => :high_sierra
-    sha256 "e7be08f0ae87b9730fad34f126303bc6ca0487a5ce6054b7735867b929823719" => :x86_64_linux
+    sha256 "45b284e67465c32efc3c61c19817b94dd530cbbdc876b8b0bb9a1898cd28405f" => :catalina
+    sha256 "50398e7cf18f3b9f36acfa984ff9bdad4fc0a04af0a90dd6201ad386fce9d0e5" => :mojave
+    sha256 "787d70a5c6d0ced96d7bc96c8b98488851d1027116d0a9769a9e9569a70f9c4b" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/eg-examples.rb
+++ b/Formula/eg-examples.rb
@@ -9,9 +9,9 @@ class EgExamples < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "a8453abcc4cc4cc2919b78e1649ac3640279d8f9fe0e44f9db083b3d3f4aa9f1" => :catalina
-    sha256 "330a1d604b7889bedc72b8fb2d73a8c42ef1cea5234ade62a7db094debb6d9a1" => :mojave
-    sha256 "d5f28b0a7c13377e6cc43ff4f13d2beadfea46b471bb2b52721d60e904d78189" => :high_sierra
+    sha256 "46a9ac200202e3701ced8127521ef3d717675d8460453b4c4280990381e4f4b7" => :catalina
+    sha256 "882c95a2e4ff16639e596869fab1459acc2b40326ad85d1a2e22352933522cb7" => :mojave
+    sha256 "1e806034a1d7ec1f50654e33e71e72670237ffa33358c7e7490af5d703ec4d62" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/esptool.rb
+++ b/Formula/esptool.rb
@@ -9,10 +9,9 @@ class Esptool < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "0957ff12323413dfd8d106c492c2eae375b4d77d73f085ff36f11404bb9d490e" => :catalina
-    sha256 "408cf90221d809ffe687c897ae5ecd510b4cc894348f03a38c4da682f0497cfb" => :mojave
-    sha256 "c11b3731a7895ecea413fffb4de8455493f7f9db15066d42f2fcc79971ff4f30" => :high_sierra
-    sha256 "170e1fc2cd9c846d4c3cac35a735f71d5a1b12773ca849f110cd1c1d492d5e6e" => :x86_64_linux
+    sha256 "76e3c103172aca7021c785f9cfa3c5832353b439b7d1fa16db134f529c3ae331" => :catalina
+    sha256 "00903c838ed3185dad44f25793111f1298824df11ba5864820e3c7224f7080f4" => :mojave
+    sha256 "48cbb59cf7b2af574997ee6c9afe9d0c4dab75617179f66cce07030059941d4d" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -9,10 +9,9 @@ class Fdroidserver < Formula
 
   bottle do
     cellar :any
-    sha256 "25fd697491d5db059f852694dab4fc66b2fc31bc8797e41197cd7f051c38b776" => :catalina
-    sha256 "3a6925e4f7c0ead584c59aa6e4bf5633433cffd3cd2e23c7dd878f1792e64d8b" => :mojave
-    sha256 "915531a9d4a1a347dc1e209b0f1378341f4445e657c56f867c93277b2dc5d39a" => :high_sierra
-    sha256 "7a4abb185dcf7c54819df75e099b99aef9616b893995e8583695f8c2548e603d" => :x86_64_linux
+    sha256 "1699a24a781e6fd51a36ca8a7a97ef0478a80119b27bbea9f8d8eaa4b4d21d70" => :catalina
+    sha256 "f07f50564384845bcbb8622d718f9471b59214b7487bfed7180d5fe75605ab5b" => :mojave
+    sha256 "657d6aaf9e40e10d4644f14f97a02394260da7ea35bc1fa42a09c9b21d2693fc" => :high_sierra
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/flintrock.rb
+++ b/Formula/flintrock.rb
@@ -9,9 +9,9 @@ class Flintrock < Formula
 
   bottle do
     cellar :any
-    sha256 "cbcdc0ca71ec9ca94b34c1b6c40efddcea7c2e39e983ac2de9a44719d1027e63" => :catalina
-    sha256 "05b99ad00afca0ff160f16d7001c91eb6f73c39ee18b144d7f4be79c6e155f8a" => :mojave
-    sha256 "455d1000e90d3a0beb263a187932e003d652997efa819785352f766008746dc1" => :high_sierra
+    sha256 "eaea3de603b5de09db1f5a3ae25a8d7d66c8cebd3ffe86127aad5338f256b0ee" => :catalina
+    sha256 "3df41a8993ccffb8c0ec17e8a00d04fb88b6dc85dfc77e77bd35b27036f4a17b" => :mojave
+    sha256 "be533982ff4e9728f21df253959ceef4e735be58329a59db7cca80dc05a3dbc2" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/fonttools.rb
+++ b/Formula/fonttools.rb
@@ -10,10 +10,9 @@ class Fonttools < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "9b86e2401eb4d2fa17c575b4cee04a5862fdcd31ac4fe68a40bb03550d1660b9" => :catalina
-    sha256 "82a00184d499362f9344c1fbc45954a90388fd82499f356bcd2f6f4497b21cbb" => :mojave
-    sha256 "48765d50a7430d867a4c8e17acb6f16d30624b16b8d5c809afca6265fa686cfe" => :high_sierra
-    sha256 "a2f61853b0f5de584a438723cd79cf14160bb2e9dafa769e475dc3c4655d6d50" => :x86_64_linux
+    sha256 "4082e4a4664732108b58f90cb4dccac4f18afda8f8d8528bee54a2b5f03dd39b" => :catalina
+    sha256 "03eae2ed4b35b659dd25174fcb55597b0429da559d3afff7f0ca3eedc69c3e16" => :mojave
+    sha256 "44776de6f63e7b6e45b62e74968d90fd41d3b3ff5903cf4715a43899c87d8d3a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/gandi.cli.rb
+++ b/Formula/gandi.cli.rb
@@ -9,10 +9,9 @@ class GandiCli < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "8352e05f231539e572aafd55f31b12cd4489a1fea6cf199cf5f8ca05e6875f71" => :catalina
-    sha256 "17e23022f977b02f9ae895087afffc7935a6e7785855875cbab1f4c35a8e3fc5" => :mojave
-    sha256 "549610862a4f5400d12e2f45cd63c56bf0cc7a7fa60d9018d6e8123861239adc" => :high_sierra
-    sha256 "5c7ddda6fb9311d678ba23d0d50e198f3987e1b5523339c6b477cbe069b31bf3" => :x86_64_linux
+    sha256 "22779ab21e92c826c99ade2c24c9a8ebd7b8ab952fcf70b7c3ddd312e0419ee7" => :catalina
+    sha256 "4a0a55dbe51a2c20328b95fc90b8a89f6d4fc6c3118579e78d1a526a0712b351" => :mojave
+    sha256 "987991ebd9c8be956e4e2a358e5bc1310a18f98be561b8ce007b5582d033ba3b" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/gimme-aws-creds.rb
+++ b/Formula/gimme-aws-creds.rb
@@ -9,10 +9,9 @@ class GimmeAwsCreds < Formula
 
   bottle do
     cellar :any
-    sha256 "6817c604e6980c47652d33a84a79f930d4f9c6abb55ccf51730933ed0346d451" => :catalina
-    sha256 "f7f0c28acf2733c1bf4b43b7e68133f7efce924af1f1c658ca22216748d675b1" => :mojave
-    sha256 "069697429d780e0f076215e7ddb8e7324fc8e538601cb99847e05daff073da85" => :high_sierra
-    sha256 "eef607019fe940dce62a0e8b39cf76b8d7947b327b6224743d106632cd5eb9d5" => :x86_64_linux
+    sha256 "c9e13bca884634326430de7d4695cab7bd02521fd0ec3f8bb8e69377df52bfdf" => :catalina
+    sha256 "6cfa1c0c00adbe19a5dff9fca00f900b1b781d04532a48430036cf9221adf743" => :mojave
+    sha256 "1ccccf741140716020eef7ecb3cf003eedacda58e0d7edbddf98f7d3678f2dd1" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/git-plus.rb
+++ b/Formula/git-plus.rb
@@ -10,10 +10,9 @@ class GitPlus < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "6bdcfe17d7687fad2e523e104b473744831806b1bf5915d9248a6d36dd6d28e6" => :catalina
-    sha256 "ee281bb04fe93d458c63dba2648861dd30e2003f5bb8871e650959134c6daca7" => :mojave
-    sha256 "72ec0aecb258232a837709d55ae03b4068db623c5f6b214bb2cbedd826c1152e" => :high_sierra
-    sha256 "c09b15d3473727362c484f01cb5958c04d8c0a71e4a637c86e8f4810e329ddcd" => :x86_64_linux
+    sha256 "468fa18f8d027cf6218c48d2ca2a593c70bea13a0138ef5a10c0e8f02ce673ff" => :catalina
+    sha256 "603af1693567409c616a81e382176dc22ab9623404e78ca2b024668ca3a6e17e" => :mojave
+    sha256 "fdf09b61e60b1e9b8bbd880f8ab39163c8caf07e545fb88adea90823b36eda3d" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/git-review.rb
+++ b/Formula/git-review.rb
@@ -10,10 +10,9 @@ class GitReview < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "219c2d8d7a31eb8b574abd3cab053662e3e9c3303a4b0238f2f6dee84159b9a5" => :catalina
-    sha256 "6d348cd0ef827adf60c6f6c569ef4fc606777abfc3413055eaa7dcfaebc8c921" => :mojave
-    sha256 "4dea8ae739c4855b2858b875c13f11b91a8221497f7b62d6ae22651c7eda3750" => :high_sierra
-    sha256 "5229b3b4c99c5438ae17e889af7d8fe93c9caaefa279a7066dfdc628f0bed28b" => :x86_64_linux
+    sha256 "8bb267cb74c37af45200381f60f84dc49af52a0d2eed65c23db6e582d0d407b9" => :catalina
+    sha256 "acd209ffed9affc75582b7ef94e3232abc0f2ab6490b634fc9abcb53a2e0f08d" => :mojave
+    sha256 "cb9721c5b767816de394884dbb83a7274b43fcb495015d445253d3820ac07b32" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/git-revise.rb
+++ b/Formula/git-revise.rb
@@ -10,10 +10,9 @@ class GitRevise < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "72ca393035b15d0cf921632069389001266a1106f1ff943c34dc923af866c77b" => :catalina
-    sha256 "2800e4ffabf68b829e4d8fe2b32e605e88c9a93eb52c42966f7cb162b49e95cc" => :mojave
-    sha256 "6444ff85b3cc61e10bc9c48fee39319684837d5d7de762d94c4c41a6152fde3a" => :high_sierra
-    sha256 "23baef7f05a72e476ea3c842ca9dfc2a7ac41f6ce946be935ab110c13551d28f" => :x86_64_linux
+    sha256 "2fe7e2bef591f6217c5f3a9a6b3e1f2ff6b3f466c45bf1fdff93eb374a45c4d0" => :catalina
+    sha256 "7bcefb4419a81a205bae28b633718a5bcd3fd0b8c21543159d19e3e2a2684db8" => :mojave
+    sha256 "e59554a284ee4aed9ce5d65b65c998f359af9de928064c6b857befe9551335ba" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/gitup.rb
+++ b/Formula/gitup.rb
@@ -10,10 +10,9 @@ class Gitup < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5dcdbf2449908ad41fbcc4609087cd4634ddf55178b9e9e584f99fb90f171b3e" => :catalina
-    sha256 "57c43e99e03b2010963444a9725f9b2255585090a7cc7286b1ce026a1e5898a6" => :mojave
-    sha256 "69c69212d8a8444997b197b33f65e9821b597240147f918982fcd8111c033a60" => :high_sierra
-    sha256 "e09511b800838b90cb988055f8c99cf5a94cc4299d4703ba5be148d707685588" => :x86_64_linux
+    sha256 "61b9abe9e481e9fa3a86074756d065f48f92cf71420e6855e95ad1ecdc92cecb" => :catalina
+    sha256 "2e1fb0d6519682a80737b73136fd6cf1c81928d993e88e835cb053725ff40bf2" => :mojave
+    sha256 "63c2169d68aed5aca9a91bba014cdb96238b61316267691dd7c63ef566b89fc8" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/homeassistant-cli.rb
+++ b/Formula/homeassistant-cli.rb
@@ -10,10 +10,9 @@ class HomeassistantCli < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "577de4e084789c32b7722a90b83039f1d858729bc18037cb06a45405c5bc9990" => :catalina
-    sha256 "8c35c7ac779508f0eef5519c68dd660ab685b1ad799526c1a739eb15bb1fee4a" => :mojave
-    sha256 "6161df03584c4230a7b2c671aef41bdf59d8971f9b2cc42fd3e09a210ed67d8e" => :high_sierra
-    sha256 "6160096d790eaee7390b75e38651becd4c2b70e6a26b195a72fef65c10b8f5c3" => :x86_64_linux
+    sha256 "3e99d8bc328fa67c38269669b51fb5b43ed9b572998e4cc1698278ba626758e3" => :catalina
+    sha256 "0fd429943b405be892f66ba101caab0cf2d4f15cd87b082b956ab67fd207503e" => :mojave
+    sha256 "9d496c8d8c0a02046348a7c5277d3a721ac986985c6d0776dc2d3dc1c5c73fc0" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/howdoi.rb
+++ b/Formula/howdoi.rb
@@ -9,10 +9,9 @@ class Howdoi < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "576f5aba58a444486f8cb57ac06bde018ffb17be52a024bf7f21a75f1267c0c1" => :catalina
-    sha256 "edb6184fc8ce91e409ec1914f7cac62c203b336c1a96071380f9f7b51204bd3d" => :mojave
-    sha256 "b61bddf5e645a2916ae87b4791fc13a882eb18c6bd0bfca1ce27df9f2f070cd5" => :high_sierra
-    sha256 "8b8df5c969373ff1a34dd7f8cfdf9fa7122d3b333bf2317efe5b12e7cf68a4a4" => :x86_64_linux
+    sha256 "b2a140c27beb5eb6cf0828112a4c90983014d36d50c66096a68773b0d47410a8" => :catalina
+    sha256 "eba1481a04f930805a0033c3213ae837464c600d6bc4f7bf3a3db4d17e328ae2" => :mojave
+    sha256 "bb5109a1450ea626cfaacae8001b086495ba7b33a14e7ea6b27dcb243f2421be" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/httpie.rb
+++ b/Formula/httpie.rb
@@ -10,10 +10,9 @@ class Httpie < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "56b55a29dde9f5288dc1803b42b9934a012939cd7c05ed1d21ae3c9a95024d9b" => :catalina
-    sha256 "39f6e57a70ee1998f730123a85c893757ecbe4660c949906590456a07a3bbdd6" => :mojave
-    sha256 "4a77117bde4316dbf115c3d636d00047f10ecffd219423608821f09afc71a19a" => :high_sierra
-    sha256 "49f6b186e4cedfaf80134ae3d04cdd901f8ac9545fe08ae39742d9550e49bf8f" => :x86_64_linux
+    sha256 "1fb33d9c85dc462c2549a03cf08670edad8014a5fdf0a7cb26493c64af40283d" => :catalina
+    sha256 "a22030f0b96c698c90265286ee80ffbb03079d1d008a80c0bdb3ea15a17d3fbb" => :mojave
+    sha256 "9f994ecf826efe53a3a49d1c3193e271629068d11306df55adeea2842a8afb8c" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/instalooter.rb
+++ b/Formula/instalooter.rb
@@ -9,10 +9,9 @@ class Instalooter < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "d92a3563c5ec99f272ae547aa781b611f909d9fe50f14c3f0036e74779229199" => :catalina
-    sha256 "270c856593fa3dee1b0650b73f05ea938944dd0e4fc56b5a071b66cf8ace7552" => :mojave
-    sha256 "3906bde9eba23b61b9e83d91a28c3f35ffa563fded04683bc6ec89bf2a7e6279" => :high_sierra
-    sha256 "b25b4058a8f29173e6d00d0f337a10e3b76aa4ef57627e4de3d7714481256558" => :x86_64_linux
+    sha256 "e104124fc1aea7acb2827e8fd99af7d177051044d8847263c80346322a1a0f62" => :catalina
+    sha256 "1aa93b38cdbfd6dd4d91fa1e74c432dae4f0c36aee7f3f82534f10c5006f6375" => :mojave
+    sha256 "9197e9cf489480f2ec933bdde662b736a99dfb52179e4f7858d99b51bccd3348" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/internetarchive.rb
+++ b/Formula/internetarchive.rb
@@ -9,10 +9,9 @@ class Internetarchive < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "57f86174583ae4ce3a151c2caddaca95da89acc177fa15be72cf4a88f7800013" => :catalina
-    sha256 "de550a1ea15165b80feb9d0b0d75a0879107071c6e0d67543c1b0635a481b509" => :mojave
-    sha256 "6c78f9ce965b08e08272f1c0c54ad0b704878671773c7b6f0a67b26d04f04996" => :high_sierra
-    sha256 "87710e6fd0448476c537fa04359ff845ee2a805e860630fe7fba3c1dc517f51c" => :x86_64_linux
+    sha256 "94aee05412f4f7389b422504863b85a433bf9f947a5de37625e8a73b3e69e1b2" => :catalina
+    sha256 "7421d0fa3d6618108771dc6bb7cafe920f34f6855dee980ca87f7c16fc421847" => :mojave
+    sha256 "5586ef6c1de81e7cabeaa9aa620ea9695b58668415231314bbcacf997177d3f7" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/jinja2-cli.rb
+++ b/Formula/jinja2-cli.rb
@@ -9,10 +9,9 @@ class Jinja2Cli < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "4b5f190961c1fef880d3228ff7de263cae3a0af1fc9823e2f2a727018be6d6be" => :catalina
-    sha256 "70d4911837f36db19e26e3f0761e39dd8f00432536f67115732156ccd70a7d87" => :mojave
-    sha256 "08e713022ccb6c30eb4cff5d6d483798cf6da722e2fb5335967d74a611242fa5" => :high_sierra
-    sha256 "e006c49bf6f31a895e919f50ef525aa5acfbf2862bcfce7bc8eada182aae9676" => :x86_64_linux
+    sha256 "31848f994850d25890342ec76c1259e6b19738105cf7cb8d58eae1f3abb29252" => :catalina
+    sha256 "c1f403a72668b4ffdc5da4e02d6d35cdb712a3b0cd8cf2b91a844b34e5b21370" => :mojave
+    sha256 "972f68142054b8201968d19962ad237b29f9ab2d15b1f5b7b27d5798685db797" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/jrnl.rb
+++ b/Formula/jrnl.rb
@@ -9,10 +9,9 @@ class Jrnl < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "cc3c51a9fae2ded1b38be04fe88f912a8af510841c3eded1601d637c68f45fa9" => :catalina
-    sha256 "c2d1e90ee23e1e4b272a2a8ffc4167282cd06882203993d25f6d5d2a23b349c9" => :mojave
-    sha256 "d887c5052a8b4e950e7ff1184ed0f00bceab72032685815b9fb02ed08e2651bc" => :high_sierra
-    sha256 "4d55286b65fbfdf42c83fe464073ad19a0304c0e3d71dab6ed11b74152d550f5" => :x86_64_linux
+    sha256 "66560351ee5ed2909729339bdc23d86d1b6b10d36b31a45eccdf76410f174334" => :catalina
+    sha256 "44f0dad29c60b5cc69e1c6b537d61ca3af1c560159b2ec6ff975b944a24666bc" => :mojave
+    sha256 "5a82ad2e43651f7c0947dc11aa1e155ed5dc5cd1bc27b6e99d651459949df19f" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/juju-wait.rb
+++ b/Formula/juju-wait.rb
@@ -9,10 +9,9 @@ class JujuWait < Formula
 
   bottle do
     cellar :any
-    sha256 "8e0d6f6c1aa40131623c5887e7672ef24717c7a44e6612415058a2255a911d9a" => :catalina
-    sha256 "b39426fec696dedd4087810b09af692931f020f015e784dad756aa38dd269445" => :mojave
-    sha256 "7708ed278031301cc73db50c41aafeab82d5d25d7152e7f8c906a6ea7d0accf7" => :high_sierra
-    sha256 "cd24cec9170498a3d02adf28f1dad927467de7f24f698bf9f037a106d78deab6" => :x86_64_linux
+    sha256 "a969b35744d3fad4f45802d53bf1dd5da96eed56ae01e0ba6d246ea4b4a89a32" => :catalina
+    sha256 "88d585b8cf738d97549f138d0fc49195d78e55ce4eaa4e2596e8e7af19827e68" => :mojave
+    sha256 "d7b4c5a6f83f55f5f5084d6a2c58d8119923ee203f2770fb4affa3cebeefe96e" => :high_sierra
   end
 
   depends_on "juju"

--- a/Formula/keepkey-agent.rb
+++ b/Formula/keepkey-agent.rb
@@ -9,9 +9,9 @@ class KeepkeyAgent < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "87c1e88b122c66019f24a0c21cc0a6a2b01803129279a4e8ae2e13ab5641b9d8" => :catalina
-    sha256 "6b75efd2438d4486e182a5f269575f42cccdf967adef0899836cd9eb8da9c6c4" => :mojave
-    sha256 "1eaef62aac81c53d99bbcf743151301de5bcfdb6c37bf15732757c9cc3c82eba" => :high_sierra
+    sha256 "d63b20fa73ca477c96862ff34e60bd54ff52ba88408212960dd4a772e8fa5643" => :catalina
+    sha256 "143afaf234c996ac776b3eb09cf271bdf8d70f91ce17de9dfb6f60b08f6dfe98" => :mojave
+    sha256 "90f8bed92a8c541ae0d3b4ba75f03094249d2081abd92be51a90feb4dbf2e401" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/khard.rb
+++ b/Formula/khard.rb
@@ -9,10 +9,9 @@ class Khard < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5ca37c0a1a80df10f491b06daa364ad7da2249b0445fb7792dadc51b097530a2" => :catalina
-    sha256 "89cb3be869d6cd31867f2bcac8a2155ab05e749b652c725f33a35a3ab2af554f" => :mojave
-    sha256 "79c73982870dc90a9053f1ead53fc3ac030517e8a2f4cade0a23b6263723c24e" => :high_sierra
-    sha256 "f86b490291d16334ed351f921a7e0df3354e74af714cbdbb7c901477b8fc96f8" => :x86_64_linux
+    sha256 "e52491d70166c2919a0ddf1d31cdb29c68aa66950e2b6b0338ea168b7b85cad8" => :catalina
+    sha256 "ddf64becc35493212418f1855bfdcad659b1fe3e541f4a2dca49528afe3c8a67" => :mojave
+    sha256 "9978c59849d3f400b89596318010908b9d5d41970d0b9870afa556d6157dde81" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/legit.rb
+++ b/Formula/legit.rb
@@ -10,10 +10,9 @@ class Legit < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "127d027cd0814c3920c22040f9f55ce0e0d840799309208668dbfadc5f50bff0" => :catalina
-    sha256 "8169a1412d7051abf9c9f1d3006e4632650cf958a8ca67b53f85a9f1c46f71e4" => :mojave
-    sha256 "557a989c72baf8bdef6a23600cc473bd1002c64ea9ef8571432c8862695999e4" => :high_sierra
-    sha256 "587273e185bb11abf94a05f6901a9f919827f93a05935c150e98e49d59371bf1" => :x86_64_linux
+    sha256 "6f7e454a8d416d41ec0a3a002c54e9db0563afc4a1cc8ad6be14eeaaf21c4f9b" => :catalina
+    sha256 "68f2b1e810daaa6ff691a756055d833c69578c441b390e04f365942f5dd64a3f" => :mojave
+    sha256 "47c79ac839d525b1df535fd72bd790675a1b05b96b75153e2bdb6f3ce65e0f0a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/literate-git.rb
+++ b/Formula/literate-git.rb
@@ -9,10 +9,9 @@ class LiterateGit < Formula
 
   bottle do
     cellar :any
-    sha256 "fbf303ecbea9942380695ec4fc385ee6cd61713b88da4681f61b2aeca8f4ed6f" => :catalina
-    sha256 "4b2b1cc91d729459c5effdb9a9b5e425589208bbd68764c9e2dd241747e91aed" => :mojave
-    sha256 "8b3458f7e5337f396d85cb00f9cbb5a0be6fe89943f5175b52e0a80f4d37e672" => :high_sierra
-    sha256 "25f68c744e4615723e9dd24ed30547f6ca73ad724d2cf7533c812c3710aabaa6" => :x86_64_linux
+    sha256 "9178197fb25710c7a75643218dd8089a042d6bb4a9f7aa5559807d62d451d723" => :catalina
+    sha256 "13e3bfb78683ef24b7eb6bade4986fb92a1934cf9f976c5c561b1c05589da241" => :mojave
+    sha256 "a9c03c8bbc4aab6043f663ca9dcc78c8fa94d080080625fbe22b2341ef8b50d9" => :high_sierra
   end
 
   depends_on "pkg-config" => :build unless OS.mac?

--- a/Formula/mackup.rb
+++ b/Formula/mackup.rb
@@ -10,10 +10,9 @@ class Mackup < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "06bf4f9daac1ea99a2610a8aa999759143910000c99dccba20e026ac996e196d" => :catalina
-    sha256 "b7c11a4fcd021392c3a7f290143f7f971e6c5608f3a1ce03e8f61ea04dc66f8b" => :mojave
-    sha256 "d19deabf63c0518d4733458caa7f7f502ef90e30611836b8d3ffe394a46bfcb6" => :high_sierra
-    sha256 "160c2f0af8c400ebe0e875d036411e533e1c4a396ecff04a9ff00d7bd3c42107" => :x86_64_linux
+    sha256 "dbc5ac8b84c362ff421aff6b75819145c9033b72cb1f819dc182964e59b8221e" => :catalina
+    sha256 "dcd2364073468374ed2d60f921546db1948ca14efc5e7f0751873b7d89b5c8ba" => :mojave
+    sha256 "3af5af899b13058a5887831beffbeada93ceb76a0c2598cbd9675cf11162d8c1" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/magic-wormhole.rb
+++ b/Formula/magic-wormhole.rb
@@ -5,14 +5,13 @@ class MagicWormhole < Formula
   homepage "https://github.com/warner/magic-wormhole"
   url "https://files.pythonhosted.org/packages/77/15/9438290bab8146efc0213f7c3d9645d9bc5a2e885e4049477e7432e40336/magic-wormhole-0.11.2.tar.gz"
   sha256 "ae79667bdbb39fba7d315e36718db383651b45421813366cfaceb069e222d905"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
-    sha256 "0d5c0f43bbdd700df491ddd05e4c8a327d54390750d846d554d600846a32cb2b" => :catalina
-    sha256 "9bc906cb2342a5f650f8f87b4e7eb3f2176806d11bf50352751dd9d7d079bdcc" => :mojave
-    sha256 "295cd7a104ffac498435325d1a98bfa098ae75886ed86c3162750667bf6933eb" => :high_sierra
-    sha256 "b15511bd7a324a9b8c040b3532ebf86091b452ecf8bcf252de55d61e08758462" => :x86_64_linux
+    sha256 "4a87746735a5a32fe36192717f4048f004b485f99aa18e884aa16c5012c16fea" => :catalina
+    sha256 "8451d4f3536521063429103abf169176d65b911a35dfd363de9164fc4eb306ff" => :mojave
+    sha256 "183ae4d0f054889bbf4d5fe594af92ecd18a5a45cb17605124183807ce89281a" => :high_sierra
   end
 
   depends_on "libsodium"
@@ -23,49 +22,29 @@ class MagicWormhole < Formula
 
   uses_from_macos "libffi"
 
-  resource "Automat" do
-    url "https://files.pythonhosted.org/packages/4c/9a/3052851fa3a888d1ff32f053fba424ed929b47383fb5327855fdf70018cd/Automat-0.8.0.tar.gz"
-    sha256 "269a09dfb063a3b078983f4976d83f0a0d3e6e7aaf8e27d8df1095e09dc4a484"
-  end
-
-  resource "PyHamcrest" do
-    url "https://files.pythonhosted.org/packages/a4/89/a469aad9256aedfbb47a29ec2b2eeb855d9f24a7a4c2ff28bd8d1042ef02/PyHamcrest-1.9.0.tar.gz"
-    sha256 "8ffaa0a53da57e89de14ced7185ac746227a8894dbd5a3c718bf05ddbd1d56cd"
-  end
-
-  resource "PyNaCl" do
-    url "https://files.pythonhosted.org/packages/61/ab/2ac6dea8489fa713e2b4c6c5b549cc962dd4a842b5998d9e80cf8440b7cd/PyNaCl-1.3.0.tar.gz"
-    sha256 "0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c"
-  end
-
-  resource "Twisted" do
-    url "https://files.pythonhosted.org/packages/0b/95/5fff90cd4093c79759d736e5f7c921c8eb7e5057a70d753cdb4e8e5895d7/Twisted-19.10.0.tar.bz2"
-    sha256 "7394ba7f272ae722a74f3d969dcf599bc4ef093bc392038748a490f1724a515d"
-  end
-
-  resource "asn1crypto" do
-    url "https://files.pythonhosted.org/packages/9f/3d/8beae739ed8c1c8f00ceac0ab6b0e97299b42da869e24cf82851b27a9123/asn1crypto-1.3.0.tar.gz"
-    sha256 "5a215cb8dc12f892244e3a113fe05397ee23c5c4ca7a69cd6e69811755efc42d"
-  end
-
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/98/c3/2c227e66b5e896e15ccdae2e00bbc69aa46e9a8ce8869cc5fa96310bf612/attrs-19.3.0.tar.gz"
     sha256 "f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
   end
 
   resource "autobahn" do
-    url "https://files.pythonhosted.org/packages/d0/5d/4ae77653bc742b0e38cac302e260fdd0cbeae17e899676435432057cd54e/autobahn-19.11.2.tar.gz"
-    sha256 "64fa063b3a1ab16588037d4713f13f66167f7ad2a2e95fd675decbc3bc85c089"
+    url "https://files.pythonhosted.org/packages/54/bc/ec75ee259752ad65ddc30782a3128dadd79345f1aa0d4f76722996f37480/autobahn-20.3.1.tar.gz"
+    sha256 "88e150e4b3d284b83daafd8e0b289a5625ee00c633a2c580055bf1be2d391002"
+  end
+
+  resource "Automat" do
+    url "https://files.pythonhosted.org/packages/80/c5/82c63bad570f4ef745cc5c2f0713c8eddcd07153b4bee7f72a8dc9f9384b/Automat-20.2.0.tar.gz"
+    sha256 "7979803c74610e11ef0c0d68a2942b152df52da55336e0c9d58daf1831cbdf33"
   end
 
   resource "cffi" do
-    url "https://files.pythonhosted.org/packages/2d/bf/960e5a422db3ac1a5e612cb35ca436c3fc985ed4b7ed13a1b4879006f450/cffi-1.13.2.tar.gz"
-    sha256 "599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346"
+    url "https://files.pythonhosted.org/packages/05/54/3324b0c46340c31b909fcec598696aaec7ddc8c18a63f2db352562d3354c/cffi-1.14.0.tar.gz"
+    sha256 "2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6"
   end
 
   resource "click" do
-    url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
-    sha256 "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+    url "https://files.pythonhosted.org/packages/4e/ab/5d6bc3b697154018ef196f5b17d958fac3854e2efbc39ea07a284d4a6a9b/click-7.1.1.tar.gz"
+    sha256 "8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"
   end
 
   resource "constantly" do
@@ -84,8 +63,8 @@ class MagicWormhole < Formula
   end
 
   resource "humanize" do
-    url "https://files.pythonhosted.org/packages/8c/e0/e512e4ac6d091fc990bbe13f9e0378f34cf6eecd1c6c268c9e598dcf5bb9/humanize-0.5.1.tar.gz"
-    sha256 "a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19"
+    url "https://files.pythonhosted.org/packages/7a/fb/4b2cbff4a7a93647db08f80a99f79c92ff077302d7e11a946a869b31f4ab/humanize-2.0.0.tar.gz"
+    sha256 "1766e8b82772abdf54a0b3620b14b21b36feba5160401838f97d18a4c58c7f71"
   end
 
   resource "hyperlink" do
@@ -94,18 +73,13 @@ class MagicWormhole < Formula
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/ad/13/eb56951b6f7950cadb579ca166e448ba77f9d24efc03edd7e55fa57d04b7/idna-2.8.tar.gz"
-    sha256 "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+    url "https://files.pythonhosted.org/packages/cb/19/57503b5de719ee45e83472f339f617b0c01ad75cba44aba1e4c97c2b0abd/idna-2.9.tar.gz"
+    sha256 "7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"
   end
 
   resource "incremental" do
     url "https://files.pythonhosted.org/packages/8f/26/02c4016aa95f45479eea37c90c34f8fab6775732ae62587a874b619ca097/incremental-17.5.0.tar.gz"
     sha256 "7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3"
-  end
-
-  resource "pyOpenSSL" do
-    url "https://files.pythonhosted.org/packages/0d/1d/6cc4bd4e79f78be6640fab268555a11af48474fac9df187c3361a1d1d2f0/pyOpenSSL-19.1.0.tar.gz"
-    sha256 "9a24494b2602aaf402be5c9e30a0b82d4a5c67528fe8fb475e3f3bc00dd69507"
   end
 
   resource "pyasn1" do
@@ -119,8 +93,23 @@ class MagicWormhole < Formula
   end
 
   resource "pycparser" do
-    url "https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz"
-    sha256 "a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+    url "https://files.pythonhosted.org/packages/0f/86/e19659527668d70be91d0369aeaa055b4eb396b0f387a4f92293a20035bd/pycparser-2.20.tar.gz"
+    sha256 "2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"
+  end
+
+  resource "PyHamcrest" do
+    url "https://files.pythonhosted.org/packages/58/05/7b993fabb44ff0b52a90916d96bfd91a65ecf90b8248e72bba325ba8e438/PyHamcrest-2.0.2.tar.gz"
+    sha256 "412e00137858f04bde0729913874a48485665f2d36fe9ee449f26be864af9316"
+  end
+
+  resource "PyNaCl" do
+    url "https://files.pythonhosted.org/packages/61/ab/2ac6dea8489fa713e2b4c6c5b549cc962dd4a842b5998d9e80cf8440b7cd/PyNaCl-1.3.0.tar.gz"
+    sha256 "0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c"
+  end
+
+  resource "pyOpenSSL" do
+    url "https://files.pythonhosted.org/packages/0d/1d/6cc4bd4e79f78be6640fab268555a11af48474fac9df187c3361a1d1d2f0/pyOpenSSL-19.1.0.tar.gz"
+    sha256 "9a24494b2602aaf402be5c9e30a0b82d4a5c67528fe8fb475e3f3bc00dd69507"
   end
 
   resource "service_identity" do
@@ -129,8 +118,8 @@ class MagicWormhole < Formula
   end
 
   resource "six" do
-    url "https://files.pythonhosted.org/packages/94/3e/edcf6fef41d89187df7e38e868b2dd2182677922b600e880baad7749c865/six-1.13.0.tar.gz"
-    sha256 "30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+    url "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz"
+    sha256 "236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"
   end
 
   resource "spake2" do
@@ -139,13 +128,18 @@ class MagicWormhole < Formula
   end
 
   resource "tqdm" do
-    url "https://files.pythonhosted.org/packages/cd/22/f15bb3c0a2810da0e825d193fb76d782015d82c676c4f682a957814926d7/tqdm-4.41.1.tar.gz"
-    sha256 "4789ccbb6fc122b5a6a85d512e4e41fc5acad77216533a6f2b8ce51e0f265c23"
+    url "https://files.pythonhosted.org/packages/7a/cf/625e53bb8c6ad88302192c7aa50d45cdfb2b0fe97892869ec3dd9309f67f/tqdm-4.43.0.tar.gz"
+    sha256 "f35fb121bafa030bd94e74fcfd44f3c2830039a2ddef7fc87ef1c2d205237b24"
+  end
+
+  resource "Twisted" do
+    url "https://files.pythonhosted.org/packages/0b/95/5fff90cd4093c79759d736e5f7c921c8eb7e5057a70d753cdb4e8e5895d7/Twisted-19.10.0.tar.bz2"
+    sha256 "7394ba7f272ae722a74f3d969dcf599bc4ef093bc392038748a490f1724a515d"
   end
 
   resource "txaio" do
-    url "https://files.pythonhosted.org/packages/c1/99/81de004578e9afe017bb1d4c8968088a33621c05449fe330bdd7016d5377/txaio-18.8.1.tar.gz"
-    sha256 "67e360ac73b12c52058219bb5f8b3ed4105d2636707a36a7cdafb56fe06db7fe"
+    url "https://files.pythonhosted.org/packages/50/ea/dd4c34ade00ddfcd2f32b4f1e7136a50ae13894009d64024a9d03f8c594f/txaio-20.1.1.tar.gz"
+    sha256 "f24e10396f026c75364ae23ffac8d72c156dc5f3733d332febb356c9d8d6b58d"
   end
 
   resource "txtorcon" do
@@ -154,8 +148,8 @@ class MagicWormhole < Formula
   end
 
   resource "zope.interface" do
-    url "https://files.pythonhosted.org/packages/c3/05/bf3130eb799548882ce61b7c3d2dbc5d4d5cc6e821efa8786c5273d56844/zope.interface-4.7.1.tar.gz"
-    sha256 "4bb937e998be9d5e345f486693e477ba79e4344674484001a0b646be1d530487"
+    url "https://files.pythonhosted.org/packages/f8/44/8531e65de6fde76e6055f5ce93e8a482dff534cea9bebcac7845e2273efd/zope.interface-4.7.2.tar.gz"
+    sha256 "fd1101bd3fcb4f4cf3485bb20d6cb0b56909b94d3bd2a53a6cb9d381c3da3365"
   end
 
   def install

--- a/Formula/mdv.rb
+++ b/Formula/mdv.rb
@@ -9,10 +9,9 @@ class Mdv < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "2fcb9eccdbbea185a283d4b56da15cbf71fdb8a8d34139d7d9a54d8523981591" => :catalina
-    sha256 "22a148919646e046da5af4c20c465cb16655add99fad11579a58178112a791f9" => :mojave
-    sha256 "2e3db65a118614ea9cc3f734b5158460dce1e07f50ed241a468e0fe4d53136b1" => :high_sierra
-    sha256 "d4f2b5eb56fa347f67548da7c9bc8738129bc9f18f37dcc902ed93f7c349ccde" => :x86_64_linux
+    sha256 "890a4b74e721fb435e1d4ef0ff0c8f5b6e3571bf36e0d57562d720ef197524ef" => :catalina
+    sha256 "b9570e94bcc659b48b3c3629e16e03f12f484f0d9212108ebae958c5464294ab" => :mojave
+    sha256 "89ca2ef413cebd689db91754227919ebbc28934558fadd81dde681bccabe99a7" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/mitmproxy.rb
+++ b/Formula/mitmproxy.rb
@@ -10,10 +10,9 @@ class Mitmproxy < Formula
 
   bottle do
     cellar :any
-    sha256 "a1b0aadf39823745758c8231dcad3755c22fc25bc8d618ff310b1fb2f00269ff" => :catalina
-    sha256 "253e69b24c5463c0418c0cbe8f42431c87fdf230d38d9da581b0c9df0c654638" => :mojave
-    sha256 "4d450c121682eefe4791ccab5bfb73eb9ecc8511f1dcdf777b3d88ee580b156a" => :high_sierra
-    sha256 "b8dea3c17d9b5da31d27d4df781afd84af60d8ac2c5123cc0cb7c559dc071cba" => :x86_64_linux
+    sha256 "2f86b864c98a08413287b05471c1adc0cb8e06ae687c290c5e91014ecd859072" => :catalina
+    sha256 "128d7843b37b5fad2cb41f4825c5e7e72eadde0b1aed3a0ea5b3f7aa2339b485" => :mojave
+    sha256 "381f6c495e9a196ac54e675054f520b705efad947864ff8f661a621ef1da9a13" => :high_sierra
   end
 
   depends_on "openssl@1.1"

--- a/Formula/mkdocs.rb
+++ b/Formula/mkdocs.rb
@@ -5,61 +5,70 @@ class Mkdocs < Formula
   homepage "https://www.mkdocs.org/"
   url "https://github.com/mkdocs/mkdocs/archive/1.0.4.tar.gz"
   sha256 "c9a0e1637c1e92b663d290a74ed1370ee7d50c6af165f49215df3a0c10b5bafa"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "7ecd9fdfdb559dbd1fa66b36711a2949ac5ae8781d78d209fe0abdad812e71e9" => :catalina
-    sha256 "864a0f3119006f065d631d1825a428595e960cb7e5498ed466079b679bede15f" => :mojave
-    sha256 "a30d402b53530b3a372a0353c4c41a41416f09df074de849e38252c9faafc80f" => :high_sierra
-    sha256 "1af96a97aead1787398fc3dfb0853e38ab66551fa983783575b155b5fe25339e" => :x86_64_linux
+    sha256 "0c09ad3efe25fbf040db6b5028311a1f63d84f326dba2583a4564a9be69783fe" => :catalina
+    sha256 "7a7c7bf5645567cb775a90156da26705f31ed7b4f3981e91dda8266dd2137c31" => :mojave
+    sha256 "7395cd3eea2efb8a58c42bd5b53fb2debb0b263f9874d62c9818b46ed2797227" => :high_sierra
   end
 
   depends_on "python@3.8"
 
   resource "click" do
-    url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
-    sha256 "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+    url "https://files.pythonhosted.org/packages/4e/ab/5d6bc3b697154018ef196f5b17d958fac3854e2efbc39ea07a284d4a6a9b/click-7.1.1.tar.gz"
+    sha256 "8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"
+  end
+
+  resource "future" do
+    url "https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz"
+    sha256 "b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
   end
 
   resource "Jinja2" do
-    url "https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz"
-    sha256 "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+    url "https://files.pythonhosted.org/packages/d8/03/e491f423379ea14bb3a02a5238507f7d446de639b623187bccc111fbecdf/Jinja2-2.11.1.tar.gz"
+    sha256 "93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250"
   end
 
   resource "livereload" do
-    url "https://files.pythonhosted.org/packages/f7/1b/aa5fb8c59fc683bbabdfdcfd4455673d07ac05f391d6b1244ad204b33ebc/livereload-2.5.2.tar.gz"
-    sha256 "dd4469a8f5a6833576e9f5433f1439c306de15dbbfeceabd32479b1123380fa5"
+    url "https://files.pythonhosted.org/packages/27/26/85ba3851d2e4905be7d2d41082adca833182bb1d7de9dfc7f623383d36e1/livereload-2.6.1.tar.gz"
+    sha256 "89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66"
+  end
+
+  resource "lunr" do
+    url "https://files.pythonhosted.org/packages/38/0d/7246e257d4b6013047b46b2ab97b148fe076df1a6ca0c55c70688490565f/lunr-0.5.6.tar.gz"
+    sha256 "7be69d7186f65784a4f2adf81e5c58efd6a9921aa95966babcb1f2f2ada75c20"
   end
 
   resource "Markdown" do
-    url "https://files.pythonhosted.org/packages/3c/52/7bae9e99a7a4be6af4a713fe9b692777e6468d28991c54c273dfb6ec9fb2/Markdown-3.0.1.tar.gz"
-    sha256 "d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c"
+    url "https://files.pythonhosted.org/packages/98/79/ce6984767cb9478e6818bd0994283db55c423d733cc62a88a3ffb8581e11/Markdown-3.2.1.tar.gz"
+    sha256 "90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902"
   end
 
   resource "MarkupSafe" do
-    url "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-    sha256 "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+    url "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
+    sha256 "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+  end
+
+  resource "nltk" do
+    url "https://files.pythonhosted.org/packages/f6/1d/d925cfb4f324ede997f6d47bea4d9babba51b49e87a767c170b77005889d/nltk-3.4.5.zip"
+    sha256 "bed45551259aa2101381bbdd5df37d44ca2669c5c3dad72439fa459b29137d94"
   end
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz"
-    sha256 "3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
-  end
-
-  resource "singledispatch" do
-    url "https://files.pythonhosted.org/packages/d9/e9/513ad8dc17210db12cb14f2d4d190d618fb87dd38814203ea71c87ba5b68/singledispatch-3.4.0.3.tar.gz"
-    sha256 "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c"
+    url "https://files.pythonhosted.org/packages/3d/d9/ea9816aea31beeadccd03f1f8b625ecf8f645bd66744484d162d84803ce5/PyYAML-5.3.tar.gz"
+    sha256 "e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
   end
 
   resource "six" do
-    url "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz"
-    sha256 "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+    url "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz"
+    sha256 "236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"
   end
 
   resource "tornado" do
-    url "https://files.pythonhosted.org/packages/e6/78/6e7b5af12c12bdf38ca9bfe863fcaf53dc10430a312d0324e76c1e5ca426/tornado-5.1.1.tar.gz"
-    sha256 "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409"
+    url "https://files.pythonhosted.org/packages/95/84/119a46d494f008969bf0c775cb2c6b3579d3c4cc1bb1b41a022aa93ee242/tornado-6.0.4.tar.gz"
+    sha256 "0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc"
   end
 
   def install

--- a/Formula/molecule.rb
+++ b/Formula/molecule.rb
@@ -9,10 +9,9 @@ class Molecule < Formula
 
   bottle do
     cellar :any
-    sha256 "aa6a5fbbce99b418bcfeb8380a313f4cbfa9b7dc59faf63b13d95838ef271c90" => :catalina
-    sha256 "b4247ab8a1a108da6371287b39de29906357a4389dd022df5981fde4f3593309" => :mojave
-    sha256 "065614a528fee0d3a624409aba80c7adff7df4f9546439e8d757e1d1269e2f0a" => :high_sierra
-    sha256 "1354bc82e2da04f5bf5e7c6d3ea98555f470f23f598922d8ce18d4f3c1901e15" => :x86_64_linux
+    sha256 "5d73e58a2b2a087010ac3a4e8c330be9c8e77916398dbbbe2da4e9b557d081e2" => :catalina
+    sha256 "4f530e5039d489a25c68b22160595d98382d91a1e38e309a1fb3c018c4dfb94d" => :mojave
+    sha256 "fb866b6f623ba7d2858b0a8c09a72dc6091c0faaeadae5137f7a61f1d962e39c" => :high_sierra
   end
 
   depends_on "ansible"

--- a/Formula/mongo-orchestration.rb
+++ b/Formula/mongo-orchestration.rb
@@ -10,10 +10,9 @@ class MongoOrchestration < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "d850df4424b4e55814ddc7b881957cf07476810284c495cfa461b342ce0c6534" => :catalina
-    sha256 "14ba4c270f31ce76279e5c0072d2962bca3908ff74fab6460cbe424a4e3b6a81" => :mojave
-    sha256 "7f750e2e677a1ec32e07c6270c3391ce294ac821d77fd81b7cdf135488917be0" => :high_sierra
-    sha256 "81c2c81a5a70985bd4efa521af5486963fc2b786310eba80b8b91766bdc358dc" => :x86_64_linux
+    sha256 "ca2f1aa5e42d7034892714d40e880b55c2c600c41340469a0c7920f5745ee318" => :catalina
+    sha256 "74f0f48ec48f2e52b4ce7787ba03b4dd67673bc434f90ab0f209eea1cae05a57" => :mojave
+    sha256 "fbb1f7ae46b230e912072383e54150c2a48ded086fa25f3f5a4c030dd92458d4" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/mycli.rb
+++ b/Formula/mycli.rb
@@ -9,10 +9,9 @@ class Mycli < Formula
 
   bottle do
     cellar :any
-    sha256 "aa58544a49ad7ead938ab76e697d7ee9970713caebe3fc4159a02c7849a2a909" => :catalina
-    sha256 "f0f080d264f4e6290a254091c840fbe4db23c7872e8bcb451d79d920618dfb43" => :mojave
-    sha256 "7c7c30472e81644846dc5cbdf32835042101bfbedd40988cb7fa1f596b7725d6" => :high_sierra
-    sha256 "9027c192aab99712e53289bd7d1b2f3c345f1ef776dbf5d6082b0e209daae321" => :x86_64_linux
+    sha256 "3878fbee0b13b6f1f46929fb2bb53796dfb2b5d266a63013b6beeb3303a109a1" => :catalina
+    sha256 "ebda849b7984a7b0193c33a518ca5ac0ab475d3895a0535b27f93bc8a696cea5" => :mojave
+    sha256 "0c206cfc2421b7ed96652323971ab1f373b0b3e1eca334f5bf616c6710f29cb0" => :high_sierra
   end
 
   depends_on "openssl@1.1"

--- a/Formula/nbdime.rb
+++ b/Formula/nbdime.rb
@@ -9,10 +9,9 @@ class Nbdime < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "76bd49bd43d155497fdff3f443add92f515ecc64551b9aedeae7e7ad215455ad" => :catalina
-    sha256 "10fa3c2b2837e1ce129b0a870ae4033f46518f1098df66a32ca41ba97c5a61be" => :mojave
-    sha256 "ed8ddb9629b85848a9d8c9732c8ee6858a47b2de38c1c8c13bd2d749180ab4f6" => :high_sierra
-    sha256 "78a6cd1ef9d2e02fa9909150d3ea7072eb2ef4d99318c0ad0098954e153a0639" => :x86_64_linux
+    sha256 "b37544fc5ef05a8806f5a5dca20e42da28b8457c7367ae348e2f71991d040483" => :catalina
+    sha256 "8e4ef07377e943334251e1aad455f8860a39e763932bf89d95898d644f128c97" => :mojave
+    sha256 "cb96a8d004fae5d57ffb0bee6b64d51b0951226e636d9f8484a6aa6b34e2892d" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/pgcli.rb
+++ b/Formula/pgcli.rb
@@ -9,10 +9,9 @@ class Pgcli < Formula
 
   bottle do
     cellar :any
-    sha256 "44b3f922acb64cac67fc7990bfcd946901be9179fd48c6add12b4ae4819701ab" => :catalina
-    sha256 "1c144d1b06e7e55d7f1aa798999ba011cd7c86218a374eedf0dbb3e905fa60d8" => :mojave
-    sha256 "d546dc1fead85d9efa9273532c631687f8eda8964e6bb05747f0effe534351ab" => :high_sierra
-    sha256 "c910bb3123b25c81473402ee53886cc5a3c2a56fb8486d3aedeefafca247dfaf" => :x86_64_linux
+    sha256 "a05f2c18a2af4331c154b459eb87356ab060ba3f964e051de37cbc9ebce5399e" => :catalina
+    sha256 "6394a205330cbdc055738905c181221eb562056c5612fc39de21139477c50fa7" => :mojave
+    sha256 "93c38659eb15fbd603eb5cf633be78b44f514cf7aee88c7958282e3beaa65ef5" => :high_sierra
   end
 
   depends_on "libpq"

--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -5,26 +5,45 @@ class Pipenv < Formula
   homepage "https://pipenv.kennethreitz.org/"
   url "https://files.pythonhosted.org/packages/fd/e9/01822318551caa0d62a181ba3b10f0f3757bb1e270da97165bd52db92776/pipenv-2018.11.26.tar.gz"
   sha256 "a673e606e8452185e9817a987572b55360f4d28b50831ef3b42ac3cab3fee846"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "db8a0ff25976267cfe7abc95a5a4660dc2e30ee7b96c447019c7ac53e4303300" => :catalina
-    sha256 "b9cb743f74deb9a403e0c1a4cc9131658874035ae79c4a7462ad08a8f96bdad5" => :mojave
-    sha256 "0c078b19e35de1e9834049a8c1836285a5a85b483ce8ffa90263c138e71f6161" => :high_sierra
-    sha256 "ddf0d466aa2a96edf018a122f645f909724a006ff11d73e74c0d1c7b4f74987f" => :x86_64_linux
+    sha256 "d8835620147f13436c15400db7d12d1d5b72769c7b67c5fe7f7a1d0e1dcbd88f" => :catalina
+    sha256 "ccac725119c70e8f857e23d9448a61079697711aa5ad4a6a9b3b95ab5f747e5f" => :mojave
+    sha256 "e58ee2436caed1a20c18b45067f1c28b987e542e7ebac17fe4d20f4e556f2b47" => :high_sierra
   end
 
   depends_on "python@3.8"
+
+  resource "appdirs" do
+    url "https://files.pythonhosted.org/packages/48/69/d87c60746b393309ca30761f8e2b49473d43450b150cb08f3c6df5c11be5/appdirs-1.4.3.tar.gz"
+    sha256 "9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"
+  end
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/41/bf/9d214a5af07debc6acf7f3f257265618f1db242a3f8e49a9b516f24523a6/certifi-2019.11.28.tar.gz"
     sha256 "25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
   end
 
+  resource "distlib" do
+    url "https://files.pythonhosted.org/packages/7d/29/694a3a4d7c0e1aef76092e9167fbe372e0f7da055f5dcf4e1313ec21d96a/distlib-0.3.0.zip"
+    sha256 "2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+  end
+
+  resource "filelock" do
+    url "https://files.pythonhosted.org/packages/14/ec/6ee2168387ce0154632f856d5cc5592328e9cf93127c5c9aeca92c8c16cb/filelock-3.0.12.tar.gz"
+    sha256 "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz"
+    sha256 "236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"
+  end
+
   resource "virtualenv" do
-    url "https://files.pythonhosted.org/packages/aa/3b/213c384c65e17995cccd0f2bb993b7b82c41f62e74c2f8f39c8e60549d86/virtualenv-16.7.9.tar.gz"
-    sha256 "0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3"
+    url "https://files.pythonhosted.org/packages/d0/b6/2c6da6a79279023c305c4b1d974daec075d5e59cddd88d820d136976ad8a/virtualenv-20.0.10.tar.gz"
+    sha256 "8512e83f1d90f8e481024d58512ac9c053bf16f54d9138520a0929396820dd78"
   end
 
   resource "virtualenv-clone" do

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -9,10 +9,9 @@ class Platformio < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "611439fe6e3d60db763c8efea5ea43cfd82b24bc8859d4a8642a56bf4900d016" => :catalina
-    sha256 "9d5681ba68d6abcbec242bc2fabef125f9e6185b7dd47b54aec142b407b28982" => :mojave
-    sha256 "318a9c72435c4fbb6a8b078c593184da4a5ea7ac03c200a43d2e7d6d226d97a1" => :high_sierra
-    sha256 "63dd426a79f4ac9d1c8a5d4291c1c8f6414bb1f55cd6608ecf7d2e593ee3134c" => :x86_64_linux
+    sha256 "7f2e25cc622fe4540c80d7220f60ac23575a1a74ac97d2d6555081b48000a4d6" => :catalina
+    sha256 "187d8da185000471826b81ef06c35af85dffb88f8700e653d5e6a93dab98ce24" => :mojave
+    sha256 "f1602a50db77cab3e0bd09730e3bb7a023b052b0d625e8fd803cfbc7a2fea6e5" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/proselint.rb
+++ b/Formula/proselint.rb
@@ -10,10 +10,9 @@ class Proselint < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "934c3ea516ed2186a6154d86a44df7114fda4d0f44ba4812ed5de1e94ed8fb40" => :catalina
-    sha256 "db7413fb635e0af1e1d89a734ea74a44c313c8aed7a6ecad84ee533c17d3d276" => :mojave
-    sha256 "c1269a4a9d18ca7f66bcea841cb482afa7fec49188dfaaa388085da9a915e0f2" => :high_sierra
-    sha256 "137908691de2668ae12798a3748441ddb8edf49a515f02b9802034f4bad0c552" => :x86_64_linux
+    sha256 "16677bb488b626f2a5ebab9c85b52e5aa34501861aaf146dd093fdeab9c8d7af" => :catalina
+    sha256 "2cb69c3b259812c1eeb11cc83ec7fcd5d0e6a01485a784ecdb76c75e55a5ad18" => :mojave
+    sha256 "51b225461669feb8926219f46de1fa4c438e875e9b6b9669f9191bd883679617" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/pssh.rb
+++ b/Formula/pssh.rb
@@ -8,10 +8,9 @@ class Pssh < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "15a2e96dc3e0a2f8bc5e757d98db2f846169bd119dacd9e48d21cc0ca3cf9681" => :catalina
-    sha256 "fd0ad782abf8cd1c26ad22dee75cbff7752e1d802e2f2b6012baf49c4e37811f" => :mojave
-    sha256 "63e2c5fff24e3c39e7c905d6baf2bb47bc0fc5a5299fa2afceccb9c6e914eb15" => :high_sierra
-    sha256 "5e1350d5018ee7b8385ff8d1382c3ab212462b8ddbf768532b1ece951bd2a286" => :x86_64_linux
+    sha256 "62460d1e1e69472684b09842c05d80e9b6da5f9510815b6d40b527a452067c3c" => :catalina
+    sha256 "5b456c61d419a842c5c979a41494c5e2d7c4beb71190a621635a89c9c603c772" => :mojave
+    sha256 "c06b726eead0f61a02e2c0a8f6fcdf8cf78f437deb841112b08447829b828e90" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/pwntools.rb
+++ b/Formula/pwntools.rb
@@ -9,9 +9,9 @@ class Pwntools < Formula
 
   bottle do
     cellar :any
-    sha256 "e6f0a0e76060ff3204153e51f5b90e55b35430e7bd21654d3baf9c5f2e5c2e98" => :catalina
-    sha256 "df885db96480262ded84f3e1bb43092abea0fd44e650010d83fe8afee7b84618" => :mojave
-    sha256 "22c30c298a42f2a49b286270675521d63b7185a54b68e897137b0f427920c2cb" => :high_sierra
+    sha256 "b1afc874b8374f8e1963f0cc4b0c02401210cd74ba064f001381b490ef9711b3" => :catalina
+    sha256 "06fd27211ebe7ef3aadf37e7b05c9e78cdb40fdc33b7d10a3f0c73ab4f07b5d8" => :mojave
+    sha256 "28eda39a5179c7634edcd1eab79524c1e5b68316d387374a768e62d5258942f0" => :high_sierra
   end
 
   depends_on "openssl@1.1"

--- a/Formula/pygitup.rb
+++ b/Formula/pygitup.rb
@@ -9,10 +9,9 @@ class Pygitup < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "535d9c749a2ea498835c4356ce3a05428ca3a305d81ec2cc00685ab718bccbc7" => :catalina
-    sha256 "3f80fe10471034b180dea8c1bac7ea8e8ebc06bb0faf20a6d17bc3e24b2bf722" => :mojave
-    sha256 "0bec4921eda77d3c688a6d295fbc71bf2693a2c01dbaa8a7ddbf7cbaa4688b31" => :high_sierra
-    sha256 "3ab80faa6df0afdca20553406f18b7333f75e4d4aee71637dcaef0d443bc3564" => :x86_64_linux
+    sha256 "8dff3146af82b507e97ba0305f76d4aa6296b53b1a094e6cb3ed8b5cd8a4608c" => :catalina
+    sha256 "bb4c2a88b4063544712c1f8a9704d7af97b11fb76d18ff9c6150a63d9bd59c5b" => :mojave
+    sha256 "9ca0aeb55d9722c77c77616f2b95d8d53a8c685f5a9c515ddce380b2ae5ad672" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/pygments.rb
+++ b/Formula/pygments.rb
@@ -11,10 +11,9 @@ class Pygments < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "f623227947b0aa895470efaef4bba20c00188b27bdb4167eba6813f96d6f5dd7" => :catalina
-    sha256 "67101433038da4ebfcaff73d4a0c5a7309944b3032d869f388599ce49f3f0ee6" => :mojave
-    sha256 "046daa85b6bb22c1c27e21f0f3d7da64c7c4c9a32e1310321db4a58d92514ea2" => :high_sierra
-    sha256 "683f54a42c8ecf403deb6ae3b3e14305fa945ed593962a092e4ba82042ff4aee" => :x86_64_linux
+    sha256 "ec50d18901c80c4edeea23b739953b983a96105fd52096097b0185073d1d8e15" => :catalina
+    sha256 "044c895f0bc8c914b00fecf118e43ae0913c92d0ce8da674e2d6ea36539506b7" => :mojave
+    sha256 "f58a13d528e45c7979a8b392b6e45200379b7a32292d9fb139c977fc726e1121" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -10,10 +10,9 @@ class Pyinvoke < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "1e1a631ba72c2a1796ea334071b4347c14f7274ee434f69142f7defde83ce65b" => :catalina
-    sha256 "a1b6e87e50e74316445c4f1e7f31c2727740348074e671e61864b030bd086307" => :mojave
-    sha256 "ee84ddb3d03af8d0826526e4d3cb3b5dc2968a8497b2478160b9ce7a0c37a57a" => :high_sierra
-    sha256 "65eeac9dd7107cc772257bbb02efe8e3ac1d7d831e07afbf3938298a3e5b4b78" => :x86_64_linux
+    sha256 "6e576690387b7433b3795c926672cebc76f51c1a78d64798db3a9b4fba2a584e" => :catalina
+    sha256 "576bd35748ea63fcc0a8bd6f42e68755e34c3736b5233adb0f86293dcaf912f3" => :mojave
+    sha256 "44224c0c6d1c175ddccf9bc20dcc6a0b3c48bd7ab72a30fde8f40db055406eee" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/pylint.rb
+++ b/Formula/pylint.rb
@@ -9,10 +9,9 @@ class Pylint < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "0bbd3649c3351d92408a4148511f34fc4caae13cb8c10abd97b45fb7647f00a8" => :catalina
-    sha256 "b6fbfb2a34d9779ac80e6019dcbc2cea14b228021db76b393fc0ab4ac0b960e0" => :mojave
-    sha256 "005ac3a5b2d5ef4185a16f6ffc6fdbe7efb2e35da818e25f6d715451a1f129ea" => :high_sierra
-    sha256 "299faa606ad502f9b0655ac6885bb91ddc3f1a61e52c8bf127ab6fb983dac8bf" => :x86_64_linux
+    sha256 "0b062d125fcf53cffa54ce4748b4045a0afae14786e97a63823d5d22e92cc637" => :catalina
+    sha256 "ae12c952ed80a1d5a737e94ab0b5c4f14111b38099a98745fdcb3f018957f74d" => :mojave
+    sha256 "b130a630d5fe4662dc363e727aceef2bbd491c274fcb3b70b5b3c47a6c0629f2" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -5,11 +5,9 @@ class PythonAT38 < Formula
   sha256 "2646e7dc233362f59714c6193017bb2d6f7b38d6ab4a0cb5fbac5c36c4d845df"
 
   bottle do
-    rebuild 1
-    sha256 "6088fc578e115c4740a7edef7dc36add1475bba13f6ec5158a48eb45dff5d740" => :catalina
-    sha256 "826c933bd7112885dd9c5300e17e8bf6860c2ab6fecd281629a0a6bb0e136edb" => :mojave
-    sha256 "6a8f2f3959fd546da861759748fa36936d1539fceeb34b70438d870e3600f5d6" => :high_sierra
-    sha256 "20bfe31515333451de4450eb72b54e610dc7a12974aa6c504377b6a45bc45ec4" => :x86_64_linux
+    sha256 "4bd9406b5d69313fcef3e572f85398ff9d7e2ab34eaf40c087bd0b4e87439ea8" => :catalina
+    sha256 "511b4f2c3993f000516938ed0700936c8a7d8c054b5171fa733ac7d344291c30" => :mojave
+    sha256 "86652428afa471b42ddba7028de02767d933f35f55e538b362c9cc219e972405" => :high_sierra
   end
 
   # setuptools remembers the build flags python is built with and uses them to

--- a/Formula/pyvim.rb
+++ b/Formula/pyvim.rb
@@ -9,10 +9,9 @@ class Pyvim < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "1abd88f14a1a2ff16970a2c1ab81aa816005ed2f66c1fb7a17ea8966e9282e0e" => :catalina
-    sha256 "01238569b2364d691a3500fb834f00e9eaaad5e498d4e3ffbc2875ff30ea9b5d" => :mojave
-    sha256 "810c63ff6194ee71848d1b0b5d138b5aaa7146b0675b67374f18aabfe301db96" => :high_sierra
-    sha256 "40c88b7b5a9b30d3440d3cda409e0f54291feb0eb53e3b9530c5380ca9c74122" => :x86_64_linux
+    sha256 "4160647aa00e725c752f86c8a712c22f5a885b89bd36c93bae53da3ed4c94d9c" => :catalina
+    sha256 "675f003fcf19dc2f5d319c29aa091f10487d93a7a6977533e01bede6ef16ab83" => :mojave
+    sha256 "8c2ba98a742053f1a7ba99fa11a92ef81641ff571934c38df26d05235ddc923a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/remarshal.rb
+++ b/Formula/remarshal.rb
@@ -10,10 +10,9 @@ class Remarshal < Formula
 
   bottle do
     cellar :any
-    sha256 "838a5c8b35bb130ec4ba8f7f0a1bff42c53b483f59b6f895cbbb61c87e8acaac" => :catalina
-    sha256 "93382c3689ea68644435c6b1d552718d05e22d52bd60540ef422638b08ea84a6" => :mojave
-    sha256 "bdfdd97a2c095ad6d391e2f7c258fa8301e5597222061b0f88b24675cff5bf84" => :high_sierra
-    sha256 "0535f43b2c86b7d3e3188187d48a0453b8c718a754187eb63dc3312c530aebdc" => :x86_64_linux
+    sha256 "2e239a6f7fed381016f36bffa0e287731b5e2bcb61334b8f2d9efa88b88918f1" => :catalina
+    sha256 "eea1d2b51cc88366a1da55464cf58545286f9d26a74c9e93fca775dab47db006" => :mojave
+    sha256 "8fa23a4540ddb0cc04b0f25ce5faa83ca0dc31a456cb6da28a94e8a7365cde2a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/rst-lint.rb
+++ b/Formula/rst-lint.rb
@@ -9,10 +9,9 @@ class RstLint < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5de2e78e3830b41f34e19e15d0a8d8c8922005e08f21be4c46778af5b0a65764" => :catalina
-    sha256 "fc083735d0449b72bc1934c1e06bf832e12b390e565ab2af82138442474394b6" => :mojave
-    sha256 "653b51d8d1b356ff314042c6f4d596abdfe0a703724ede6bd85df9e30eb97449" => :high_sierra
-    sha256 "77dd64fdb783899a966b402db83b8b80447aa800ee1b0358e2a109a99d508211" => :x86_64_linux
+    sha256 "f2e1f46bf019b4f7d1b7b5e749fe729ea070539c211626d5a0e69f059c39c30a" => :catalina
+    sha256 "a4c02982ae36f5ae3d2ac2b961e0f20d77bbf5135fe789fdc64196d8f307bc92" => :mojave
+    sha256 "791c788f3bf1f97cf11513fa8c2c775268c382c8d41bd406b6d45bd4dfabdac5" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/rtv.rb
+++ b/Formula/rtv.rb
@@ -10,10 +10,9 @@ class Rtv < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "6696970e4ef065c0de51b1bcebcd8299ee5ef1af006f61b7b7c2826ffba1772b" => :catalina
-    sha256 "b604b939703f82ad867a4a8921b1cef0745dfb45da74244d420878da0e1b2aae" => :mojave
-    sha256 "d4f6689640d868afa9340d4f00dd240b3ba0529a84bfeb1c45a035215c6b2ff3" => :high_sierra
-    sha256 "6196ebcc7460f3ee630711518fe57bf40ee5819ccbd9f7643086f4adfb658956" => :x86_64_linux
+    sha256 "bcb3e97de9fc2df6b3903b0286dfd47b4599c7bbfe3e557561884b84fe1dd83b" => :catalina
+    sha256 "a3c02e3552df47986bc5a0f3a92e7317fd873167b2aac429f188646994c71b9d" => :mojave
+    sha256 "a12678c3f7c95c3d45c2e631fda28d1da29fd6768f8dcce235b3599f580e264b" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/s3cmd.rb
+++ b/Formula/s3cmd.rb
@@ -10,10 +10,9 @@ class S3cmd < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "9b1bec3d698b4a94ecad38a8a6321923465200724ef58fd7d05fbe3c1204d86b" => :catalina
-    sha256 "20d486647abe96f6ec32069ad52b4a191983073aceb836f9837e352af33f9de1" => :mojave
-    sha256 "876980c1a4073e32dbd58d6c63bf81ad57c5d30fdf9a00445e636e5279df73a2" => :high_sierra
-    sha256 "7a395043236caf8340504a71ce9e0e71c71261c92e966c1ba09807d695b3b820" => :x86_64_linux
+    sha256 "f0627257d8f5f897d8e256646ec08ab3a5275b8eb0f477f3227a95d5fed9ba8c" => :catalina
+    sha256 "b64f9fa8cb6ba4c2eb5183f6bf40735dbee52d673d198cdf1fdcedf4d29ed1b3" => :mojave
+    sha256 "570fd3c229506b4afaf8f9a78e9566537d649ed53f99a3a732bd35eb637f85ac" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/sceptre.rb
+++ b/Formula/sceptre.rb
@@ -10,9 +10,9 @@ class Sceptre < Formula
   bottle do
     cellar :any_skip_relocation
     sha256 "610a8004f3c4239f6e38fde562ebd96caec34a1f582f0420d75516750f08ae86" => :catalina
-    sha256 "abe14b4eb1021c936cc5d1c25a8c9fa820b5fd5d8ddcc53b4811302721a2ac34" => :mojave
-    sha256 "6685a772d3fc7b653586065bbe996f68f2b9a7a177affa18a86190cd742439e7" => :high_sierra
-    sha256 "43152bb4ddddd0d49a0716889630537429ec8c5a8f6ae8896114f7785eb20825" => :x86_64_linux
+    sha256 "3e9cb526aeb4a6d0bc956d9b29b6cc24fc21cc682381affbac2771e219f05545" => :catalina
+    sha256 "6873fc9abb41027ed7bc53a2b6b3d920790df9df87e29dac5a76e5be183e9dfa" => :mojave
+    sha256 "931cddd4dafe380cb9cd4ac8d13a8e44e1b2a438ac9f39dc7aaf51240fd03d4f" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/scour.rb
+++ b/Formula/scour.rb
@@ -10,10 +10,9 @@ class Scour < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "cfd43767bc7e4fa7ee903db637b45c3117ea2e3250e5459387546c97bc8f08ca" => :catalina
-    sha256 "c2a82bca29949c3162b21d35af0e1ec7ab54697511ac3e25e79abbb2ea418161" => :mojave
-    sha256 "51e2a9e3abba88c05924fb48b2337836c3baf147bd1058d8e1e4af9343cb596a" => :high_sierra
-    sha256 "83f71820405f6c174e78a81722eed65e78c91f2f72b5178a9abcf2e6c9f3309c" => :x86_64_linux
+    sha256 "03bac92a88319ff21d807b0d7438284b299262003b592987b38dda5a49389e48" => :catalina
+    sha256 "927a6beeb623f29806e592eed6e2e3ee99861bc946bc24d5fd711dab50c29d15" => :mojave
+    sha256 "4c5956feecd0b017e5165a4602d3d42ef4403141f35280fd1e4a0bc2369b69ea" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/sqlparse.rb
+++ b/Formula/sqlparse.rb
@@ -9,10 +9,9 @@ class Sqlparse < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "444a821e9f86c2c006adf21fd8a7634fa2b29297048645369ff277699cb380a9" => :catalina
-    sha256 "0f61f9a78b26948c3c8d5fcc28a0674daa03e1cc42f12a60141e635cda39f057" => :mojave
-    sha256 "ad46edd169ea0545a88bec251cbd87619b6777dd166fe382fa126d9be70d06fe" => :high_sierra
-    sha256 "6cbb40f574f424352e302ddc687b95b52a0fc08c8742c237a305c0c1e65dc87d" => :x86_64_linux
+    sha256 "439ec9e76d4cb0bd66dde0e9bd3cf471d0c067ae19e5ccac0d8fcfaee0f08d62" => :catalina
+    sha256 "a3f4a494651de7aca86d4743e9a54a2ba9209d4ca4785deaf21d6da51512ae63" => :mojave
+    sha256 "73dbdb834b2d5cd10bf0629f7c7fe9631e3eda5b8a704c2b65e278f5ad94b741" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/sshuttle.rb
+++ b/Formula/sshuttle.rb
@@ -11,10 +11,9 @@ class Sshuttle < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "49be10db18c5b06daddb5d3000fc4a4d4914f85c00d451d5585c8125d62bc1fe" => :catalina
-    sha256 "62634bac69ab54fd612e149785894aa3cd851124591f8bfa11c47d8ae7b2da46" => :mojave
-    sha256 "9ffaac430d8dd88cd9c1177cb719fa0259e224fda293a5dde2790ccf87c95d71" => :high_sierra
-    sha256 "da8f0843eb0d02f879ad4e0009991e1221940a57d0bb29cd166e1b3df5d9bd5e" => :x86_64_linux
+    sha256 "a28c54b3fa4e1c98b4d94e04366841e031e55a85ee0f161cdea37e17dd145830" => :catalina
+    sha256 "ca553c22200e1c4a502750d2d50efcfbd689546ae2abca5fc80653bc9916d103" => :mojave
+    sha256 "ca1764f22635b38fa2b66a3aae9677c42ce896d0b58a88be82c2f24e4b1ef592" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/streamlink.rb
+++ b/Formula/streamlink.rb
@@ -9,10 +9,9 @@ class Streamlink < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "f3089f0534194d738e51626d70900ba418b8a3bae122f6ee2c272733d273325b" => :catalina
-    sha256 "2b8274bd795e1ec131f2cfd3b18c8a2b127fde67876f5d4099c46ca819a85f57" => :mojave
-    sha256 "7643fdffaa5fa03309c83fb2ffe8efb8a2290787b23100b9180ff45b0e40c82a" => :high_sierra
-    sha256 "51bf46c22144143e5ee5c1ec8f5d0ba4b6549b3a8b1b5ac01e16043a138c6b7c" => :x86_64_linux
+    sha256 "83a7a42ffc99436daf495cb9bbcfe09a483cb31e0f76c0ba11212cf58155ad0d" => :catalina
+    sha256 "5e8aadebb77954be29c1cf97e9e66763c01667e27c87270b740f77ce96a4c80b" => :mojave
+    sha256 "9c9f19cbc7352c0a4f31b3d86dd26740f863ae2761263947c23340dbe20840b3" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/supervisor.rb
+++ b/Formula/supervisor.rb
@@ -9,10 +9,9 @@ class Supervisor < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "864dad06b94bbcf67d080e8b810595bee7aa8dae9de0dc1db8e9d2360cde7875" => :catalina
-    sha256 "e84857d56cc7842a28e367e7323490f5ab804f98d54e17d3ed5ba15562446cc8" => :mojave
-    sha256 "ace5d03a4dd4c166f10af675a375cac75961fa5498f27fb19a8abfc3e0b78ef2" => :high_sierra
-    sha256 "78bad7f67e90f16aa1ea9836c5e51f3b5370668c24769fe84bbd0843a7a63ff4" => :x86_64_linux
+    sha256 "51effbdc862aa25784afe39cf8bc8d8c00cec6e2b16666a6f29ca8834119731b" => :catalina
+    sha256 "0462b3c5acf4292902d25aa6d2706c1803696fbfea3a74b3eac6e5b65dc44228" => :mojave
+    sha256 "d842313361e1c465bcd8813c490aefcb19071bf55629414f0117c74c92d7c2b3" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/svtplay-dl.rb
+++ b/Formula/svtplay-dl.rb
@@ -9,9 +9,9 @@ class SvtplayDl < Formula
 
   bottle do
     cellar :any
-    sha256 "7ae6430ed2d32e68527c3f271aaf83ca6674a667c282d44339c53c072132d37d" => :catalina
-    sha256 "b17347b4554938e86d10fed73317705a9b7b0f357cb13b1125670bbd60bb83f2" => :mojave
-    sha256 "adb2764eb31d032300bbaf97152581cf16ac04d357881d49054731fbb4561b49" => :high_sierra
+    sha256 "c1604b5e5ea983254d487160d36c58e25c7211c5d6093eba4b83e7446d0eba09" => :catalina
+    sha256 "2d9f0213ed6bdf558fb3da4beb03081c4b7bde285aee8a429cc4589a657f1148" => :mojave
+    sha256 "8674391ac83165aa74bcf27f6384c31de8f2dad9dccae36d5b5d4e3287612a80" => :high_sierra
   end
 
   depends_on "openssl@1.1"

--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -10,10 +10,9 @@ class Thefuck < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "762a5d749374bbda2f181728c971bc998ce9c32f4ea20d242be0c5879e97356b" => :catalina
-    sha256 "2e261bc8017c602761652100d4075a0a2dbb63eb4c385135defdd157ac0a1aaa" => :mojave
-    sha256 "e0d301ddb9c3f769939484e9d6078be4edb25f099a10d8d75d7f67f12b04e15d" => :high_sierra
-    sha256 "89a6c7e7867c539547f7fe3bb8788370208ee5d9ae10b476ab4d4a6d0d8edbe3" => :x86_64_linux
+    sha256 "0a822134480ccd55e4205981e40d087b22ef54997f3c552139cbe80b2bbe24af" => :catalina
+    sha256 "6148a67e60772143a89ba87beb4715d88218ea21b40f85495ffa6b1b53e3b65f" => :mojave
+    sha256 "8f051631681251d562de831c82ea46f586b031de242ccc73517e6943d301bb74" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/todoman.rb
+++ b/Formula/todoman.rb
@@ -10,10 +10,9 @@ class Todoman < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "339bef292df297e3e4e0eec51f57f49cbf70e0ae3b5c19f0fbf71c0e46578d41" => :catalina
-    sha256 "5c5cbcb5df2132b9d683e5e6ae4cc3b86fca5fa26c4603e8a7d9f7b6be6f84b8" => :mojave
-    sha256 "981eaa665b9fdce0c1a63d5b15032efbd366dd7fe5bc1a108a48354c743bacc1" => :high_sierra
-    sha256 "cda5641e06549d7d5143e29bf4bd599bfebdf3c06f4bc2fa72e77c442676cf18" => :x86_64_linux
+    sha256 "e9d8d359bb2660250a0d0f6f3b34963d6968f048d59d9a96d392bf3b8d85d427" => :catalina
+    sha256 "b3376663c5e13b7ac84d71c6c65f2b725ac430034100401bf9172109df309dda" => :mojave
+    sha256 "2e0974ab0353f8bd10c19dd19ec7ca9e807997a1f3cbd2ac8d15ca5de548f936" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/tox.rb
+++ b/Formula/tox.rb
@@ -5,13 +5,13 @@ class Tox < Formula
   homepage "https://tox.readthedocs.org/"
   url "https://files.pythonhosted.org/packages/5b/e1/138ed5fa49ca20fdc05ab52f260276f9d0a1b464af831b43231f9df1f185/tox-3.14.5.tar.gz"
   sha256 "676f1e3e7de245ad870f956436b84ea226210587d1f72c8dfb8cd5ac7b6f0e70"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5f5a758ec8bc702ee43d7642dff34eef2cebd013e4399a58d327a2332d008732" => :catalina
-    sha256 "1ce3bdd561a6dd4cea639c64601faba37e9a08b5e61ddfab3a92c4a4da9469e6" => :mojave
-    sha256 "7a6d25b5af4e382643d169fb671966e1d4e1501adcfe689ff05da30066f8ba0f" => :high_sierra
-    sha256 "d0478f7076afd165a7901d6b1cb60b059d36716bf2b83ac5f1539d6bdf49c4d2" => :x86_64_linux
+    sha256 "1dbb3025cb109262125c0b36cb24867ee1f1aa9030de75103968ec9b71f43e23" => :catalina
+    sha256 "36bd039b64519a823fdff9bf8cf6f4ef134d4b0fdea9dfade0addab7cb4c4a8e" => :mojave
+    sha256 "ecfaca7917af12bc5601c1bfd4ae1d2d3ed5fb629bdd14a123758d0dfca9a5fc" => :high_sierra
   end
 
   depends_on "python@3.8"
@@ -21,24 +21,19 @@ class Tox < Formula
     sha256 "9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"
   end
 
+  resource "distlib" do
+    url "https://files.pythonhosted.org/packages/7d/29/694a3a4d7c0e1aef76092e9167fbe372e0f7da055f5dcf4e1313ec21d96a/distlib-0.3.0.zip"
+    sha256 "2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+  end
+
   resource "filelock" do
     url "https://files.pythonhosted.org/packages/14/ec/6ee2168387ce0154632f856d5cc5592328e9cf93127c5c9aeca92c8c16cb/filelock-3.0.12.tar.gz"
     sha256 "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
   end
 
-  resource "importlib-metadata" do
-    url "https://files.pythonhosted.org/packages/0d/e4/638f3bde506b86f62235c595073066e7b8472fc9ee2b8c6491347f31d726/importlib_metadata-1.5.0.tar.gz"
-    sha256 "06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"
-  end
-
-  resource "more-itertools" do
-    url "https://files.pythonhosted.org/packages/a0/47/6ff6d07d84c67e3462c50fa33bf649cda859a8773b53dc73842e84455c05/more-itertools-8.2.0.tar.gz"
-    sha256 "b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
-  end
-
   resource "packaging" do
-    url "https://files.pythonhosted.org/packages/7b/d5/199f982ae38231995276421377b72f4a25d8251f4fa56f6be7cfcd9bb022/packaging-20.1.tar.gz"
-    sha256 "e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
+    url "https://files.pythonhosted.org/packages/65/37/83e3f492eb52d771e2820e88105f605335553fe10422cba9d256faeb1702/packaging-20.3.tar.gz"
+    sha256 "3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"
   end
 
   resource "pluggy" do
@@ -66,15 +61,9 @@ class Tox < Formula
     sha256 "229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"
   end
 
-  # keep at 16.7.9 until compatible with virtualenv's rewrite
   resource "virtualenv" do
-    url "https://files.pythonhosted.org/packages/aa/3b/213c384c65e17995cccd0f2bb993b7b82c41f62e74c2f8f39c8e60549d86/virtualenv-16.7.9.tar.gz"
-    sha256 "0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3"
-  end
-
-  resource "zipp" do
-    url "https://files.pythonhosted.org/packages/60/85/668bca4a9ef474ca634c993e768f12bd99af1f06bb90bb2655bc538a967e/zipp-2.2.0.tar.gz"
-    sha256 "5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50"
+    url "https://files.pythonhosted.org/packages/d0/b6/2c6da6a79279023c305c4b1d974daec075d5e59cddd88d820d136976ad8a/virtualenv-20.0.10.tar.gz"
+    sha256 "8512e83f1d90f8e481024d58512ac9c053bf16f54d9138520a0929396820dd78"
   end
 
   def install

--- a/Formula/translate-toolkit.rb
+++ b/Formula/translate-toolkit.rb
@@ -10,10 +10,9 @@ class TranslateToolkit < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "b26b15dd5cad2f33db55a095c5c122249f374201cf7768f4f1e203c53097b30f" => :catalina
-    sha256 "db113798b83ef63ad4b7de9615a6fa3ceb5282480784931ebad375cbbd6ccf93" => :mojave
-    sha256 "78e607805c484ec8be1d1e0381c33e50a2519f1be0b868681e9ab2013307ff1b" => :high_sierra
-    sha256 "0650f8d8f011ab54b0367ff062121bf3c36e08960b0ec29b83ec5d5f029b7adb" => :x86_64_linux
+    sha256 "208b9953ae03816389f657b76987fce9f531a5db82a8e06fbd35822229eea63b" => :catalina
+    sha256 "9c42f38793ab7f4ede212d258b94bcc776482143f283b38f798723e3901dad8a" => :mojave
+    sha256 "5ee42d0176b78e8c2b2093376f9a5043271838b2863724fcdb84897a9d763a5a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/trash-cli.rb
+++ b/Formula/trash-cli.rb
@@ -10,10 +10,9 @@ class TrashCli < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5eed46cd5290cbb7db8ca2cd272e3334727f02e33d696bc7cdf161bdc1bbeb00" => :catalina
-    sha256 "28570bf1d2f37d27ceac413d0dbfb191af1a764d42e543e1f7f102f63cf84ccf" => :mojave
-    sha256 "c91899fb2e3eea76501cd3961abe8537e77eed264cf25b3a214a6123a37c6391" => :high_sierra
-    sha256 "80651b28348a35c790f87fbf8f6315d8d1d449b5c237eff7642b18d053ce3ed3" => :x86_64_linux
+    sha256 "11d325db1d011fbc8e148e21418fc7b28acc5ed709f1650326691fd276342494" => :catalina
+    sha256 "da23c8fae828c479cf01dffeb4c9838d734b9da6022991a1561572a82e913ef2" => :mojave
+    sha256 "2bdc29f08a37d62fabc5ff53535209320f009b6f8c5a94a091d3acb3c3e16118" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/twine-pypi.rb
+++ b/Formula/twine-pypi.rb
@@ -10,9 +10,9 @@ class TwinePypi < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "bf24fa66bd707af6c82b9f4a15ae9f9d0f89d2979e8728c45bee4fc2e232d526" => :catalina
-    sha256 "3361f04b027e09a3816c8faba24ea9ad18381754a420605be2070dab048ac0c2" => :mojave
-    sha256 "d83e742f2d90a6c7154073189be2903ce35773f589c2bd637e95e20dc495adf3" => :high_sierra
+    sha256 "2a790f856202eb237908d07767a1b048605c8fe8e23af2858ccf2bd49b30ea98" => :catalina
+    sha256 "5a3c9250a67a5f3986ee5bac5b8d0093d8675e70b137ac0911fa640841657258" => :mojave
+    sha256 "e6ba4437d91e869216f794753492df41c0c875034f6c63e93721a3c6a971989a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -9,10 +9,9 @@ class VstsCli < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "fff87d43f92ff97b5e094754215674a31a359f6f5420d18a67d9f173d69cba56" => :catalina
-    sha256 "f9a79bfd88a3b20cfc74c657341ecce3b10c0ef10f1c6c46bc9434cfd46d829c" => :mojave
-    sha256 "1e128e9095734bbd8e8b673ebe132e5e8657436aa30427b5421ce968e3a4b441" => :high_sierra
-    sha256 "c8571423a8d3b04779ff91840e5567a5d578d4eaa23ebdcdabf48ff8607fbcc5" => :x86_64_linux
+    sha256 "b37f51f73b543f2c9403e0a982aa1ae625f170b971a75b1ab07a23a62aa01949" => :catalina
+    sha256 "27a52ac2afc49b4392804ce47984f8ea1986dde0a221d599d2f3afa0e93ca6b3" => :mojave
+    sha256 "59d1ccaa24e3356771bd998de79c226803957811170765933d5ca03f3547f99a" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/watson.rb
+++ b/Formula/watson.rb
@@ -10,10 +10,9 @@ class Watson < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "033f41b9a2a5bc31aeaa860c604ff9b553655e772c9403146da47331212fdc17" => :catalina
-    sha256 "2e2e4bcf2986efb662cd72a4e323646d1791bf17d729c19a406cbd3212b508f0" => :mojave
-    sha256 "4d1a0d8dae1ad2dbed073b67d34e4c34b030a7b2ec096133d69f2b8e62522e1b" => :high_sierra
-    sha256 "b98957650b0e8eefea1173180954623c33787f0864c1c60462e0c4632a6ad064" => :x86_64_linux
+    sha256 "9c9cd611721cff1d748e7b2bcddf12a0557e6254028633f8b66fa68a4f3ad74e" => :catalina
+    sha256 "218620ce1032be731400fde457475bf115826f0d5ba256151db12f676ca88856" => :mojave
+    sha256 "c1c59a05d2f41111afcd8f9607d200357d14a20eafb6fbfc1c2c056baff0bdb8" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/xonsh.rb
+++ b/Formula/xonsh.rb
@@ -10,10 +10,9 @@ class Xonsh < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "6518ee6e314bc7a44270f8dacea2a3b5e5f3b5808ff2c653aded834b8aee1af1" => :catalina
-    sha256 "61fcfd71f7368311e12e98f01c39aaec15a47f9024492a9e5e83950c814ff70f" => :mojave
-    sha256 "dd20b590171005fc7918a789dedb2eb2c5d1f7be734aae26ac64650e0996a079" => :high_sierra
-    sha256 "882fbcfaac5328316f52e2f603cad3aadad601ed6bf88a5faf07180eefedbe34" => :x86_64_linux
+    sha256 "7402482d0b7ff76ae36abb9335bd485395df4669d5db608d18c397be02e89dc2" => :catalina
+    sha256 "3f26068cef87a0ef23c3f181efb50c521b690366dfde198519a88a4fecd7bce5" => :mojave
+    sha256 "077dd4221373e8adb5b6039a2aa4ce1935f34dbc7543ba551ef06dd7a45b5001" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/yamllint.rb
+++ b/Formula/yamllint.rb
@@ -9,10 +9,9 @@ class Yamllint < Formula
 
   bottle do
     cellar :any
-    sha256 "1a39e71f5471a2ef25cbb48d4ad7978171385ff38d5c40125f2c258cc6682244" => :catalina
-    sha256 "ee0e9115ae2423d3691c59c85ee10e03a0109706e24b2f51e21773ff15096a6b" => :mojave
-    sha256 "cb73a80359f4c689e5051d11cb3931b23268c573e00f52900875391442e10f51" => :high_sierra
-    sha256 "0dd48be50572ebcdac35d9ca22f613587631c44bbc6158d891d2e3ade9c47b7f" => :x86_64_linux
+    sha256 "c9af991306882a4fe21500a52a63d6e110d09e9c4ba6c9da2558a99bdcfcce8f" => :catalina
+    sha256 "1aee52bbc89a796c87eb838ec79de9f2d7e1ea371bf64bd4ca70b430966f8360" => :mojave
+    sha256 "16ff7600ad8d42d077f931bbd968ee41425e1a6c6a9e5fd4f827e83ca5b40bf1" => :high_sierra
   end
 
   depends_on "libyaml"

--- a/Formula/yapf.rb
+++ b/Formula/yapf.rb
@@ -9,10 +9,9 @@ class Yapf < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "6bbe6c40b433bee94f923c479ca8020314960edae9452eedd627b031603180dd" => :catalina
-    sha256 "158dcb7867a2572a30caa27951dd11431554de050a432691ab250796aa76b30b" => :mojave
-    sha256 "b794952a1ac7f0d1537745d89c8d88846b45ff8758019d1cf594789f552a05cd" => :high_sierra
-    sha256 "1aad5e49ffc4e8624a087de9c729a975fc1009928b4db51b2d7c1039c9843d28" => :x86_64_linux
+    sha256 "8f94ec7a91fe28d85f005c33f5318e3c31d75164c43cc7ea2823e909b59a4483" => :catalina
+    sha256 "d7a90b18dbc7231c34183ff55064026f113607791cd29e3bec3a88ef71cde4c5" => :mojave
+    sha256 "fbb3fa64390834fe642fadc06632c6916976cb4b4e36bc97c19b2f339769465f" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/ydcv.rb
+++ b/Formula/ydcv.rb
@@ -9,9 +9,9 @@ class Ydcv < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "3006d55cd6f84acacbeaf18006ef35182b07f23dacb15ccb034958ae8d2be1d6" => :catalina
-    sha256 "52d7d12528b70474438cfa6fa6b78fe2769297e3f7ca2867ddfa83f537ae001a" => :mojave
-    sha256 "669241fe767681f5728da484a6d8f70769675ba0bec96ca73200c2fecd3333e3" => :high_sierra
+    sha256 "c58351df91ff5461873cb5cae4dcecc40d8f2c64d15152b95c279a1624fe01d0" => :catalina
+    sha256 "8ea0db97fbede09e11d8890652db0128197c8fb551796efdf795c73021c1d578" => :mojave
+    sha256 "906ce5ee60c5b2c8d4c90b42fbc8e08cafd67de0df9f9b63bd7f4a0f428073c7" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/ykman.rb
+++ b/Formula/ykman.rb
@@ -10,10 +10,9 @@ class Ykman < Formula
 
   bottle do
     cellar :any
-    sha256 "6b0f5422988f06d8fffffed1c81ef4ef37fe577144a9f60eda5bfde0d7a4499a" => :catalina
-    sha256 "e55ff26b3e133f483382df475bf2ad9f4852c9aa62c6ad26d360defd674fea21" => :mojave
-    sha256 "83758f4f58c383ac3332c5802fafe613c8877369a335f4db6967784fe96f5880" => :high_sierra
-    sha256 "73b3f6352dea832c2c85282dc802bb384ceb3fb601965611b42c64bc69568f5c" => :x86_64_linux
+    sha256 "c06a8cb44d6cd76c638c88ef5812e4c2dcce922f30014f875eaf61bf63ae7404" => :catalina
+    sha256 "e1d502f836a9403fd191f8f7bab1cec7b09236de0f035d24385b0f55e82ea63a" => :mojave
+    sha256 "8c00a4aa2502ef29c8dc9c02f0ce0f6a04299aeeae00168536f55623c1c21b8a" => :high_sierra
   end
 
   depends_on "swig" => :build

--- a/Formula/you-get.rb
+++ b/Formula/you-get.rb
@@ -10,10 +10,9 @@ class YouGet < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "8dacfac03f1b0af5b35777d90b7250e893bcfc5d0fa4fd205c837c5af061fc9e" => :catalina
-    sha256 "8092347a7b929f69f27b918164651bc55fa86f515ac629cd315c23d9fe5cc1f1" => :mojave
-    sha256 "101fbc6ddbf613e1d690e383143ced8260b6d308dae646e9880a8da121e1c7b1" => :high_sierra
-    sha256 "5a3d458e16ba7969f9e927010295277c3f9b774d5b9211a85dc51bae27482461" => :x86_64_linux
+    sha256 "58831026cf9e75bf6e64593b5801575fa6813bc5f467128c58cf5567f7a93593" => :catalina
+    sha256 "00c0171d2bb859189e776bd49533d904680858a7584f9135bc4af2db69f61453" => :mojave
+    sha256 "99542b4f6a4e32e3d63319935b74f273f8fb1ed995fa03bd1ccb39d0430c8341" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/zabbix-cli.rb
+++ b/Formula/zabbix-cli.rb
@@ -10,10 +10,9 @@ class ZabbixCli < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "7071c34bc3936777f0e2e8b00dc444e824ea6c0e728c773c5aa3d25f6186b008" => :catalina
-    sha256 "103d5b399b782c2e34da9cd4fdaac537cbc237fecf95afb97541b75f52c9c41a" => :mojave
-    sha256 "b1fea65428370a415bc3befc71501d5eb1ca837096171bce1333a55c8c14965f" => :high_sierra
-    sha256 "f511864e71859fed6e6fac5ed89fab83fe4ae10d214a3269a7d3b21f9ffdfbb3" => :x86_64_linux
+    sha256 "1de709f622175741a89adf30f3a8ea05086a097cde9e10dde9a336fafc119245" => :catalina
+    sha256 "c2a0ee909fac52fb169b0b92e3d044345cbe22dacee92f6d200651424c5f361b" => :mojave
+    sha256 "2839bc5c52224d4a193383ede100d0ad390eef2b4343364adc99b3e89a3e60e4" => :high_sierra
   end
 
   depends_on "python@3.8"


### PR DESCRIPTION
Merge Homebrew/homebrew-core into Homebrew/linuxbrew-core

+ [ ] ansible-lint
+ [ ] ansible
+ [ ] asciinema
+ [ ] atdtool
+ [ ] aws-elasticbeanstalk
+ [ ] aws-shell
+ [ ] awscli
+ [ ] awscli@1
+ [ ] awscurl
+ [ ] awslogs
+ [ ] awsume
+ [ ] azure-cli
+ [ ] bandcamp-dl
+ [ ] black
+ [ ] cfn-lint
+ [ ] codemod
+ [ ] codespell
+ [ ] conan
+ [ ] conjure-up
+ [ ] cookiecutter
+ [ ] cppman
+ [ ] csvkit
+ [ ] csvtomd
+ [ ] diceware
+ [ ] docker-compose
+ [ ] docker-squash
+ [ ] duplicity
+ [ ] dxpy
+ [ ] esptool
+ [ ] fdroidserver
+ [ ] fonttools
+ [ ] gandi.cli
+ [ ] gimme-aws-creds
+ [ ] git-plus
+ [ ] git-review
+ [ ] git-revise
+ [ ] gitup
+ [ ] homeassistant-cli
+ [ ] howdoi
+ [ ] httpie
+ [ ] instalooter
+ [ ] internetarchive
+ [ ] jinja2-cli
+ [ ] jrnl
+ [ ] juju-wait
+ [ ] khard
+ [ ] legit
+ [ ] literate-git
+ [ ] mackup
+ [ ] magic-wormhole
+ [ ] mdv
+ [ ] mitmproxy
+ [ ] mkdocs
+ [ ] molecule
+ [ ] mongo-orchestration
+ [ ] mycli
+ [ ] nbdime
+ [ ] pgcli
+ [ ] pipenv
+ [ ] platformio
+ [ ] proselint
+ [ ] pssh
+ [ ] pygitup
+ [ ] pygments
+ [ ] pyinvoke
+ [ ] pylint
+ [ ] python@3.8
+ [ ] pyvim
+ [ ] remarshal
+ [ ] rst-lint
+ [ ] rtv
+ [ ] s3cmd
+ [ ] sceptre
+ [ ] scour
+ [ ] sqlparse
+ [ ] sshuttle
+ [ ] streamlink
+ [ ] supervisor
+ [ ] thefuck
+ [ ] todoman
+ [ ] tox
+ [ ] translate-toolkit
+ [ ] trash-cli
+ [ ] vsts-cli
+ [ ] watson
+ [ ] xonsh
+ [ ] yamllint
+ [ ] yapf
+ [ ] ykman
+ [ ] you-get
+ [ ] zabbix-cli