### PR TITLE
openssl@1.1: fetch certs before removing old certs

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -86,6 +86,7 @@ class OpensslAT11 < Formula
     unless OS.mac?
       # Download and install cacert.pem from curl.haxx.se
       cacert = resource("cacert")
+      cacert.fetch
       rm_f openssldir/"cert.pem"
       filename = Pathname.new(cacert.url).basename
       openssldir.install cacert.files(filename => "cert.pem")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Fixes https://github.com/Homebrew/linuxbrew-core/issues/19802

```console
% brew postinstall openssl@1.1
==> Postinstalling openssl@1.1
==> Downloading https://curl.haxx.se/ca/cacert-2020-01-01.pem
curl: (77) error setting certificate verify locations:
  CAfile: /home/linuxbrew/.linuxbrew/etc/openssl@1.1/cert.pem
  CApath: /home/linuxbrew/.linuxbrew/etc/openssl@1.1/certs

Trying a mirror...
==> Downloading https://gist.githubusercontent.com/dawidd6/16d94180a019f31fd31bc679365387bc/raw/ef02c78b9d6427585d756528964d18a2b9e318f7/cacert-2020-01-01.pem
curl: (77) error setting certificate verify locations:
  CAfile: /home/linuxbrew/.linuxbrew/etc/openssl@1.1/cert.pem
  CApath: /home/linuxbrew/.linuxbrew/etc/openssl@1.1/certs

Warning: The post-install step did not complete successfully
You can try again using `brew postinstall openssl@1.1`
==> An exception occurred within a child process:
  DownloadError: Failed to download resource "openssl@1.1--cacert"
```