### PR TITLE
cups: re-bottle

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -8,7 +8,6 @@ class Cups < Formula
     sha256 "028330028dca9194605bdf6ec807b413adae82b1491bb69cbee64d31fc04a6f3" => :catalina
     sha256 "4fd5c5705dfb551e9fd5091f63a69d985bae05bc0b29fb253c9877138b254e7b" => :mojave
     sha256 "932ce69ebe900f3e307939ffb475a1d2d3f46d079b3c6b5238385051bdc110a1" => :high_sierra
-    sha256 "0e4c1889cc3b7a86856b00b6fe8c0dd0a252cab1d343935143f4db3f89562977" => :x86_64_linux
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
`cups` was debottled in https://github.com/Homebrew/linuxbrew-core/pull/19816 along with a bug fix, but the bottle upload post-merge failed due to the fact that bottles already existed for this version. `cups` was re-bottled in https://github.com/Homebrew/linuxbrew-core/runs/505644732 via request-bottles trigger and the bottle commit pushed in https://github.com/Homebrew/linuxbrew-core/commit/4d0e714a5d10a5a9dc58d4d4272dda3cd39720ae, but the bottle upload to bintray failed again because bottles were already there, leading to a bottle sha mismatch.

I've deleted the bottle from Bintray so this pull request should succeed.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----