### PR TITLE
workflows: upload as artifact in dispatch jobs

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -25,7 +25,17 @@ jobs:
             --tap=homebrew/core \
             --keep-old \
             ${{github.event.client_payload.formula}}
+      - name: Copy bottles
+        if: always()
+        run: |
+          cp -a ~/bottles $GITHUB_WORKSPACE
       - name: Upload bottles
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          name: bottles
+          path: bottles
+      - name: Upload bottles to Bintray
         env:
           HOMEBREW_BINTRAY_USER: LinuxbrewTestBot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}


### PR DESCRIPTION
This is in addition to uploading to Bintray. In the event that an upload fails, we should still be able to retrieve any bottles from the workflow as well.


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----