### PR TITLE
workflows: post comments as BrewTestBot

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -78,6 +78,7 @@ jobs:
           SENDER: ${{github.event.sender.login}}
           FORMULA: ${{github.event.client_payload.formula}}
         with:
+          github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           script: |
             const run_id = process.env.GITHUB_RUN_ID
             const actor = process.env.GITHUB_ACTOR

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -111,6 +111,7 @@ jobs:
         if: failure()
         uses: actions/github-script@0.8.0
         with:
+          github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           script: |
             const run_id = process.env.GITHUB_RUN_ID
             const actor = process.env.GITHUB_ACTOR


### PR DESCRIPTION
This is achieved by using the `HOMEBREW_GITHUB_API_TOKEN` secret, rather than the automatic `GITHUB_TOKEN` secret.


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----