### PR TITLE
workflows: set issue number for core merge bottles

### DIFF
--- a/.github/workflows/request-bottle-after-merge.yml
+++ b/.github/workflows/request-bottle-after-merge.yml
@@ -17,6 +17,24 @@ jobs:
       - name: Tap linux-dev
         run: |
           brew tap homebrew/linux-dev
+      - name: Get associated pull request
+        uses: actions/github-script@0.8.0
+        id: pr
+        with:
+          result-encoding: string
+          script: |
+            const prs = await github.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.head_commit.id
+            })
+            console.log(prs.data.length + " prs")
+            if (prs.data.length === 0) {
+              console.log("No pull requests are associated with this merge commit.")
+              return 0
+            }
+            const pr = prs.data[0]
+            return pr.number
       - name: Request bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
@@ -25,4 +43,4 @@ jobs:
         run: |
           cd $(brew --repo ${{github.repository}})
           git reset --hard ${{github.sha}}
-          brew find-formulae-to-bottle | xargs -n1 brew request-bottle
+          brew find-formulae-to-bottle | xargs -n1 brew request-bottle --issue=${{steps.pr.outputs.result}}


### PR DESCRIPTION
Setting the issue number for `brew request-bottle` after a core merge pull request should post comments on that merged pull request to notify maintainers when requested bottles have failed to be uploaded for any reason.

This should hopefully give us more visibility than the (now extremely cluttered) Actions tab.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----