### PR TITLE
workflows: prevent BrewTestBot from pinging itself

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -75,31 +75,34 @@ jobs:
         uses: actions/github-script@0.8.0
         env:
           ISSUE_NUMBER: ${{github.event.client_payload.issue}}
-          SENDER: ${{github.event.sender.login}}
           FORMULA: ${{github.event.client_payload.formula}}
         with:
           github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           script: |
             const run_id = process.env.GITHUB_RUN_ID
             const actor = process.env.GITHUB_ACTOR
-            const sender = process.env.SENDER
-            const issue = process.env.ISSUE_NUMBER
+            const issue_number = process.env.ISSUE_NUMBER
             const formula = process.env.FORMULA
             console.log("run_id=" + run_id)
             console.log("actor=" + actor)
-            console.log("sender=" + sender)
-            console.log("issue=" + issue)
+            console.log("issue=" + issue_number)
             console.log("formula=" + formula)
 
-            let source_str = '@' + sender
-            if (sender != actor) source_str += ' (via @' + actor + ')'
+            const issue = github.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number
+            })
+
+            # Ping the issue owner if the requestor is BrewTestBot
+            const ping = (actor == "BrewTestBot") ? issue.user.login : actor
 
             const repository = context.repo.owner + '/' + context.repo.repo
             const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
 
             github.issues.createComment({
-              issue_number: issue,
+              issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: source_str + ' bottle request for ' + formula + ' failed: ' + url
+              body: '@' + ping + ' bottle request for ' + formula + ' failed: ' + url
             })


### PR DESCRIPTION
This pull request fixes the request bottles workflow by detecting whether BrewTestBot initiated the bottle request, and if that was the case, then the issue or pull request creator should be pinged, and not BrewTestBot.


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----