### PR TITLE
defaultbrowser: depends on macOS

### DIFF
--- a/Formula/defaultbrowser.rb
+++ b/Formula/defaultbrowser.rb
@@ -13,6 +13,8 @@ class Defaultbrowser < Formula
     sha256 "f0ccf84abbd31469f80c4d232292dd280a978d3f04a1a6db46079902d9821d1e" => :el_capitan
   end
 
+  depends_on :macos
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end


### PR DESCRIPTION
Has a hard dependency on Foundation and ApplicationServices

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **Not applicable**
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

```
make
install
PREFIX=/home/linuxbrew/.linuxbrew/Cellar/defaultbrowser/1.1

gcc -o defaultbrowser -O2 -framework Foundation -framework ApplicationServices src/main.m
gcc-5: error: Foundation: No such file or directory
gcc-5: error: ApplicationServices: No such file or directory
gcc-5: error: unrecognized command line option '-framework'
gcc-5: error: unrecognized command line option '-framework'
make: *** [Makefile:11: all] Error 1
```

See https://gist.github.com/rwhogg/e8a357741ccba8919b4af1e1b2ae0b7d for the rest