### PR TITLE
fileicon: depends on macOS

### DIFF
--- a/Formula/fileicon.rb
+++ b/Formula/fileicon.rb
@@ -11,6 +11,8 @@ class Fileicon < Formula
     sha256 "154c80c94f29f209b78252e71d914647a8300c66c02acda672b8574e8e704e92" => :high_sierra
   end
 
+  depends_on :macos
+
   def install
     bin.install "bin/fileicon"
     man1.install "man/fileicon.1"


### PR DESCRIPTION
Requires Cocoa

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **Not applicable**
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **Not applicable**

-----

The home page says the only supported platform is macOS.

`fileicon` doesn't need to be compiled, so it installs fine and `brew gist-logs fileicon` shows nothing interesting. `brew test fileicon` gives much more interesting output:

```
Testing fileicon
==> /home/linuxbrew/.linuxbrew/Cellar/fileicon/0.2.4/bin/fileicon set /tmp/fileicon-test-20200319-23161-1o0z06l /home/linuxbrew/.linuxbrew/Homebre
Last 15 lines from /home/me/.cache/Homebrew/Logs/fileicon/test.01.fileicon:
2020-03-19 20:29:17 -0400

/home/linuxbrew/.linuxbrew/Cellar/fileicon/0.2.4/bin/fileicon
set
/tmp/fileicon-test-20200319-23161-1o0z06l
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/support/fixtures/test.png

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named Cocoa
fileicon: ERROR: ABORTING due to unexpected error.
Error: fileicon: failed
Failed executing:
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1968:in `block in system'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1905:in `open'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1905:in `system'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fileicon.rb:21:in `block in <class:Fileicon>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1775:in `block (3 levels) in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:478:in `with_env'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1774:in `block (2 levels) in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:865:in `with_logging'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1773:in `block in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2018:in `block in mktemp'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:57:in `block in run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:57:in `chdir'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:57:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2017:in `mktemp'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1767:in `run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:33:in `block in <main>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:32:in `<main>'

```