### PR TITLE
timedog: requires macOS

### DIFF
--- a/Formula/timedog.rb
+++ b/Formula/timedog.rb
@@ -7,6 +7,8 @@ class Timedog < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "timedog"
   end


### PR DESCRIPTION
It's specifically meant to interact with Time Machine,
making use of the mac-only command tmutil.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **Not applicable**
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **Not applicable**

-----

Timedog installs fine, but fails at runtime:

```
Can't exec "tmutil": No such file or directory at /home/linuxbrew/.linuxbrew/bin/timedog line 191.
Use of uninitialized value $tmpath in scalar chomp at /home/linuxbrew/.linuxbrew/bin/timedog line 191.
No TimeMachine backups found at /home/linuxbrew/.linuxbrew/bin/timedog line 192.
```
