### PR TITLE
unrtf: Fix build for Linuxbrew

### DIFF
--- a/Formula/unrtf.rb
+++ b/Formula/unrtf.rb
@@ -18,7 +18,7 @@ class Unrtf < Formula
 
   def install
     system "./bootstrap"
-    system "./configure", "LIBS=-liconv", "--prefix=#{prefix}"
+    system "./configure", *("LIBS=-liconv" if OS.mac?), "--prefix=#{prefix}"
     system "make", "install"
   end
 


### PR DESCRIPTION
Only link against libiconv on macOS

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
See https://gist.github.com/rwhogg/04090125d4e7201e175207e294500e13

```
configure:3173: gcc-5    conftest.c -liconv >&5
/home/linuxbrew/.linuxbrew/bin/ld: cannot find -liconv
collect2: error: ld returned 1 exit status
configure:3177: $? = 1
configure:3215: result: no
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "unrtf"
| #define PACKAGE_TARNAME "unrtf"
| #define PACKAGE_VERSION "0.21.10"
| #define PACKAGE_STRING "unrtf 0.21.10"
| #define PACKAGE_BUGREPORT "bug-unrtf@gnu.org"
| #define PACKAGE_URL ""
| #define PACKAGE "unrtf"
| #define VERSION "0.21.10"
| /* end confdefs.h.  */
| 
| int
| main ()
| {
| 
|   ;
|   return 0;
| }
configure:3220: error: in `/tmp/unrtf-20200320-44361-5qqmlm/unrtf-0.21.10':
configure:3222: error: C compiler cannot create executables
See `config.log' for more details
```