### PR TITLE
starship: needs pkg-config and openssl

### DIFF
--- a/Formula/starship.rb
+++ b/Formula/starship.rb
@@ -13,6 +13,10 @@ class Starship < Formula
   end
 
   depends_on "rust" => :build
+  unless OS.mac?
+    depends_on "pkg-config" => :build
+    depends_on "openssl@1.1"
+  end
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
```
run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----