### PR TITLE
workflows: set PATH for push step

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           GIT_COMMITTER_NAME: ${{github.event.client_payload.name}}
           GIT_COMMITTER_EMAIL: ${{github.event.client_payload.email}}
+          PATH: /bin:/usr/bin
         if: success() || github.event.client_payload.ignore_errors
         run: |
           cd $(brew --repo ${{github.repository}})


### PR DESCRIPTION
When testing `git` formula, at the end all dependencies are uninstalled
leaving brewed `git` broken:

```
/home/linuxbrew/.linuxbrew/Cellar/git/2.26.0/libexec/git-core/git-remote-https: error while loading shared libraries: libcurl.so.4: cannot open shared object file: No such file or directory
```

Set the `PATH` manually to only use system `git`.


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----