### PR TITLE
rust: fix audit

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -85,7 +85,9 @@ class Rust < Formula
 
     resource("cargo").stage do
       ENV["RUSTC"] = bin/"rustc"
-      system "cargo", "install", "--root", prefix, "--path", ".", *("--features" if OS.mac?), *("curl-sys/force-system-lib-on-osx" if OS.mac?)
+      args = %W[--root #{prefix} --path . --features curl-sys/force-system-lib-on-osx]
+      args -= %w[--features curl-sys/force-system-lib-on-osx] unless OS.mac?
+      system "cargo", "install", *args
     end
 
     rm_rf prefix/"lib/rustlib/uninstall.sh"


### PR DESCRIPTION
See upstream https://github.com/Homebrew/homebrew-core/commit/b354733de29fb636000c92309749504b266f7b71 (tested locally)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----