### PR TITLE
pytouhou: depend on libx11

### DIFF
--- a/Formula/pytouhou.rb
+++ b/Formula/pytouhou.rb
@@ -25,6 +25,8 @@ class Pytouhou < Formula
   depends_on "sdl2_mixer"
   depends_on "sdl2_ttf"
 
+  depends_on "linuxbrew/xorg/libx11" unless OS.mac?
+
   resource "Cython" do
     url "https://files.pythonhosted.org/packages/b3/ae/971d3b936a7ad10e65cb7672356cff156000c5132cf406cb0f4d7a980fd3/Cython-0.28.3.tar.gz"
     sha256 "1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
