### PR TITLE
flickcurl: fix build on Linux

### DIFF
--- a/Formula/flickcurl.rb
+++ b/Formula/flickcurl.rb
@@ -16,6 +16,8 @@ class Flickcurl < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "curl"
+  depends_on "libxml2"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/flickcurl.rb
+++ b/Formula/flickcurl.rb
@@ -16,8 +16,9 @@ class Flickcurl < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "curl"
-  depends_on "libxml2"
+
+  uses_from_macos "curl"
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

flickcurl fails to build from source on Linux (specifically, Ubuntu 18.04 on WSL). `./configure` picks up Linuxbrew's curl but seems to prefer the system libxml2, even though Linuxbrew's version is installed. I don't know why this should be a problem, but the build step fails to find `libxml/tree.h`, even though the gcc commands include `-I/usr/include/libxml2` and the file is present where it ought to be. The full build log can be found at https://gist.github.com/ff87285cf67aebb41abdbae02cc7ad67. Here's the relevant output:

```text
Making install in libmtwist
make[1]: Entering directory '/tmp/flickcurl-20200326-20511-7qbmbl/flickcurl-1.26/libmtwist'
/bin/bash ../libtool  --tag=CC   --mode=compile gcc-5 -DHAVE_CONFIG_H -I. -I../src  -DMTWIST_CONFIG -I../src -DFLICKCURL_INTERNAL=1   -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c -o mt.lo mt.c
/bin/bash ../libtool  --tag=CC   --mode=compile gcc-5 -DHAVE_CONFIG_H -I. -I../src  -DMTWIST_CONFIG -I../src -DFLICKCURL_INTERNAL=1   -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c -o seed.lo seed.c
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -I../src -DMTWIST_CONFIG -I../src -DFLICKCURL_INTERNAL=1 -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c mt.c  -fPIC -DPIC -o .libs/mt.o
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -I../src -DMTWIST_CONFIG -I../src -DFLICKCURL_INTERNAL=1 -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c seed.c  -fPIC -DPIC -o .libs/seed.o
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -I../src -DMTWIST_CONFIG -I../src -DFLICKCURL_INTERNAL=1 -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c seed.c -o seed.o >/dev/null 2>&1
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -I../src -DMTWIST_CONFIG -I../src -DFLICKCURL_INTERNAL=1 -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c mt.c -o mt.o >/dev/null 2>&1
/bin/bash ../libtool  --tag=CC   --mode=link gcc-5  -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2   -o libmtwist.la  mt.lo seed.lo  -lxml2 -L/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/lib -lcurl
libtool: link: ar cru .libs/libmtwist.a .libs/mt.o .libs/seed.o 
ar: `u' modifier ignored since `D' is the default (see `U')
libtool: link: ranlib .libs/libmtwist.a
libtool: link: ( cd ".libs" && rm -f "libmtwist.la" && ln -s "../libmtwist.la" "libmtwist.la" )
make[2]: Entering directory '/tmp/flickcurl-20200326-20511-7qbmbl/flickcurl-1.26/libmtwist'
make[2]: Nothing to be done for 'install-exec-am'.
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/tmp/flickcurl-20200326-20511-7qbmbl/flickcurl-1.26/libmtwist'
make[1]: Leaving directory '/tmp/flickcurl-20200326-20511-7qbmbl/flickcurl-1.26/libmtwist'
Making install in src
make[1]: Entering directory '/tmp/flickcurl-20200326-20511-7qbmbl/flickcurl-1.26/src'
/bin/bash ../libtool  --tag=CC   --mode=compile gcc-5 -DHAVE_CONFIG_H -I.   -DFLICKCURL_INTERNAL=1  -DMTWIST_CONFIG -I../libmtwist  -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c -o activity.lo activity.c
/bin/bash ../libtool  --tag=CC   --mode=compile gcc-5 -DHAVE_CONFIG_H -I.   -DFLICKCURL_INTERNAL=1  -DMTWIST_CONFIG -I../libmtwist  -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c -o args.lo args.c
/bin/bash ../libtool  --tag=CC   --mode=compile gcc-5 -DHAVE_CONFIG_H -I.   -DFLICKCURL_INTERNAL=1  -DMTWIST_CONFIG -I../libmtwist  -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c -o blog.lo blog.c
/bin/bash ../libtool  --tag=CC   --mode=compile gcc-5 -DHAVE_CONFIG_H -I.   -DFLICKCURL_INTERNAL=1  -DMTWIST_CONFIG -I../libmtwist  -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c -o category.lo category.c
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -DFLICKCURL_INTERNAL=1 -DMTWIST_CONFIG -I../libmtwist -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c args.c  -fPIC -DPIC -o .libs/args.o
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -DFLICKCURL_INTERNAL=1 -DMTWIST_CONFIG -I../libmtwist -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c blog.c  -fPIC -DPIC -o .libs/blog.o
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -DFLICKCURL_INTERNAL=1 -DMTWIST_CONFIG -I../libmtwist -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c activity.c  -fPIC -DPIC -o .libs/activity.o
libtool: compile:  gcc-5 -DHAVE_CONFIG_H -I. -DFLICKCURL_INTERNAL=1 -DMTWIST_CONFIG -I../libmtwist -I/home/linuxbrew/.linuxbrew/Cellar/curl/7.69.1/include -I/usr/include/libxml2 -g -O2 -c category.c  -fPIC -DPIC -o .libs/category.o
In file included from args.c:33:0:
./flickcurl.h:31:25: fatal error: libxml/tree.h: No such file or directory
compilation terminated.
In file included from blog.c:33:0:
./flickcurl.h:31:25: fatal error: libxml/tree.h: No such file or directory
compilation terminated.
make[1]: *** [Makefile:596: args.lo] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:596: blog.lo] Error 1
In file included from activity.c:33:0:
./flickcurl.h:31:25: fatal error: libxml/tree.h: No such file or directory
compilation terminated.
In file included from category.c:33:0:
./flickcurl.h:31:25: fatal error: libxml/tree.h: No such file or directory
compilation terminated.
make[1]: *** [Makefile:596: activity.lo] Error 1
make[1]: *** [Makefile:596: category.lo] Error 1
make[1]: Leaving directory '/tmp/flickcurl-20200326-20511-7qbmbl/flickcurl-1.26/src'
make: *** [Makefile:490: install-recursive] Error 1
```

Making libxml2 a build requirement in the formula fixes the problem. I added curl also, just to be safe. I've also tested the changes on macOS and they don't appear to affect the behavior there.