### PR TITLE
cvs: fix style

### DIFF
--- a/Formula/cvs.rb
+++ b/Formula/cvs.rb
@@ -33,18 +33,19 @@ class Cvs < Formula
   patch :p0 do
     url "https://opensource.apple.com/tarballs/cvs/cvs-45.tar.gz"
     sha256 "4d200dcf0c9d5044d85d850948c88a07de83aeded5e14fa1df332737d72dc9ce"
-    apply *["patches/PR5178707.diff",
-            "patches/ea.diff",
-            "patches/endian.diff",
-            "patches/fixtest-client-20.diff",
-            "patches/fixtest-recase.diff",
-            "patches/i18n.diff",
-            "patches/initgroups.diff",
-            ("patches/nopic.diff" if OS.mac?),
-            "patches/remove-libcrypto.diff",
-            "patches/remove-info.diff",
-            "patches/tag.diff",
-            "patches/zlib.diff"].compact
+    patches = ["patches/PR5178707.diff",
+               "patches/ea.diff",
+               "patches/endian.diff",
+               "patches/fixtest-client-20.diff",
+               "patches/fixtest-recase.diff",
+               "patches/i18n.diff",
+               "patches/initgroups.diff",
+               ("patches/nopic.diff" if OS.mac?),
+               "patches/remove-libcrypto.diff",
+               "patches/remove-info.diff",
+               "patches/tag.diff",
+               "patches/zlib.diff"]
+    apply(*patches.compact)
   end
 
   # Fixes error: 'Illegal instruction: 4'; '%n used in a non-immutable format string' on 10.13


### PR DESCRIPTION
Fixes:
W: 36: 11: Ambiguous splat operator. Parenthesize the method arguments if it's surely a splat operator, or add a whitespace to the right of the * if it should be a multiplication.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
