### PR TITLE
workflows: add merge workflow

### DIFF
--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -1,0 +1,44 @@
+name: Merge upstream.
+
+on:
+  schedule:
+    - cron: '0 08,14,20 * * *'
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    container:
+      image: homebrew/brew
+    env:
+      MESSAGE: Merge branch homebrew/master into linuxbrew/master
+      BRANCH: merge
+    steps:
+      - name: Merge upstream
+        env:
+          GIT_COMMITTER_NAME: BrewTestBot
+          GIT_COMMITTER_EMAIL: homebrew-test-bot@lists.sfconservancy.org
+          TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+        run: |
+          cd $(brew --repo $GITHUB_REPOSITORY)
+          git pull origin master
+          git remote add homebrew https://github.com/Homebrew/homebrew-core
+          git fetch homebrew master
+          git merge -m "$MESSAGE" homebrew/master || true
+          git checkout --theirs .
+          git add .
+          git commit --no-edit
+          git push https://$TOKEN@github.com/$GITHUB_REPOSITORY HEAD:$BRANCH
+      - name: Create PR
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          script: |
+            github.pulls.create({
+              ...context.repo,
+              base: "master",
+              head: process.env.BRANCH,
+              title: process.env.MESSAGE,
+              body: "Automated upstream merge."
+            })
+
+


### PR DESCRIPTION
The process proposed here would be as follows:
- CI:
    - pull master
    - add homebrew remote
    - fetch homebrew/master
    - perform the merge
    - accept all upstream changes
    - push to new branch
    - create a pull request
- maintainer:
    - check the proposed changes
    - correct any mistakes if needed
        - commit changes
        - push branch
    - click merge button

In best case, there will be nothing to correct after the merge.

Workflow is configured to be running 3 times a day for now.

What do you think?

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----