### PR TITLE
ucg: Don't depend on argp-standalone on Linux

### DIFF
--- a/Formula/ucg.rb
+++ b/Formula/ucg.rb
@@ -15,7 +15,7 @@ class Ucg < Formula
     sha256 "e4699a681ae9d2e9d68ce7da85fc050907070bc9650fad0c4f76faf991f3a422" => :el_capitan
   end
 
-  depends_on "argp-standalone" => :build
+  depends_on "argp-standalone" => :build if OS.mac?
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
argp-standalone currently fails to compile on Linux,
but it's not necessary anyways because argp is part of
Glibc

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
No, it doesn't, but this was already an issue so I fixed it in homebrew-core: https://github.com/Homebrew/homebrew-core/pull/52498
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. *Not applicable*

-----
