### PR TITLE
workflows: remove one API call when posting issues

### DIFF
--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -72,34 +72,23 @@ jobs:
           exit 1
       - name: Post comment on failure
         if: failure()
-        uses: actions/github-script@0.8.0
+        uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           script: |
             const run_id = process.env.GITHUB_RUN_ID
             const actor = process.env.GITHUB_ACTOR
+            const pr = ${{steps.pr.outputs.number}}
+
             console.log("run_id=" + run_id)
             console.log("actor=" + actor)
-
-            const prs = await github.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.payload.head_commit.id
-            })
-            console.log(prs.data.length + " prs")
-            if (prs.data.length === 0) {
-              console.log("No pull requests are associated with this merge commit.")
-              return 0
-            }
-            const pr = prs.data[0]
-
-            console.log("pr=" + pr.number)
+            console.log("pr=" + pr)
 
             const repository = context.repo.owner + '/' + context.repo.repo
             const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
 
             github.issues.createComment({
-              issue_number: pr.number,
+              issue_number: pr,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: '@' + actor + ' upload bottles job failed: ' + url


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----