### PR TITLE
wifi-password: Depends on macOS

### DIFF
--- a/Formula/wifi-password.rb
+++ b/Formula/wifi-password.rb
@@ -6,6 +6,8 @@ class WifiPassword < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "wifi-password.sh" => "wifi-password"
   end


### PR DESCRIPTION
Requires the airport CLI command only for macOS

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? *Not applicable*
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? *Not applicable*
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Fails at runtime with `ERROR: Can't find `airport` CLI program at "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport".`