### PR TITLE
aws-keychain: Depends on macOS

### DIFF
--- a/Formula/aws-keychain.rb
+++ b/Formula/aws-keychain.rb
@@ -6,6 +6,8 @@ class AwsKeychain < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "aws-keychain"
   end


### PR DESCRIPTION
Uses the Mac-only security command and macOS keychain.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **Not applicable**

-----

Fails at runtime with:

```
% aws-keychain add test
/home/linuxbrew/.linuxbrew/bin/aws-keychain: line 38: security: command not found
```
