### PR TITLE
pkg-config: fix formula

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -17,7 +17,7 @@ class PkgConfig < Formula
     pc_path = %W[
       #{HOMEBREW_PREFIX}/lib/pkgconfig
       #{HOMEBREW_PREFIX}/share/pkgconfig
-    ].uniq.join(File::PATH_SEPARATOR)
+    ]
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
Closes https://github.com/Homebrew/linuxbrew-core/issues/20018

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
