### PR TITLE
k3d: default to latest k3s

### DIFF
--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -3,6 +3,7 @@ class K3d < Formula
   homepage "https://github.com/rancher/k3d"
   url "https://github.com/rancher/k3d/archive/v1.7.0.tar.gz"
   sha256 "e741809eb27f707c0f22c19a41ebbd6be7c20ec275285bb12bbf437a675aafb7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -17,8 +18,7 @@ class K3d < Formula
   def install
     system "go", "build",
            "-mod", "vendor",
-           "-ldflags", "-s -w -X github.com/rancher/k3d/version.Version=v#{version} " \
-                       "-X github.com/rancher/k3d/version.K3sVersion=v1.0.1",
+           "-ldflags", "-s -w -X github.com/rancher/k3d/version.Version=v#{version}",
            "-trimpath", "-o", bin/"k3d"
     prefix.install_metafiles
   end


### PR DESCRIPTION
Reverts a hack from f59d6da9293 to use a more modern version of k3s, now we can just refer to the `latest` tag on docker hub, which is the default in the application source code.

See also Homebrew/homebrew-core#53142

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.