### PR TITLE
gobject-introspection: fix libdir on fedora

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -44,6 +44,8 @@ class GobjectIntrospection < Formula
       -Dpython=#{Formula["python@3.8"].opt_bin}/python3
     ]
 
+    args << "--libdir=#{lib}" unless OS.mac?
+
     mkdir "build" do
       system "meson", *args, ".."
       Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")


### PR DESCRIPTION
else the path defaults to lib64, which we do not use.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
