### PR TITLE
bento4: fix build on Linux

### DIFF
--- a/Formula/bento4.rb
+++ b/Formula/bento4.rb
@@ -12,7 +12,7 @@ class Bento4 < Formula
     sha256 "d874fe1f7f65ff3a48c09b63f0dcbe5eb9a77d182165370772861d219cdbd0d2" => :high_sierra
   end
 
-  depends_on "cmake" => :build if OS.linux?
+  depends_on "cmake" => :build unless OS.mac?
   depends_on :xcode => :build if OS.mac?
   depends_on "python"
 
@@ -32,7 +32,7 @@ class Bento4 < Formula
         end
         bin.install programs
       end
-    elsif OS.linux?
+    else
       mkdir "cmakebuild" do
         system "cmake", "..", *std_cmake_args
         system "make"

--- a/Formula/bento4.rb
+++ b/Formula/bento4.rb
@@ -12,6 +12,7 @@ class Bento4 < Formula
     sha256 "d874fe1f7f65ff3a48c09b63f0dcbe5eb9a77d182165370772861d219cdbd0d2" => :high_sierra
   end
 
+  depends_on "cmake" => :build if OS.linux?
   depends_on :xcode => :build if OS.mac?
   depends_on "python"
 
@@ -20,15 +21,26 @@ class Bento4 < Formula
     :because => "both install `mp4extract` and `mp4info` binaries"
 
   def install
-    cd "Build/Targets/universal-apple-macosx" do
-      xcodebuild "-target", "All", "-configuration", "Release", "SYMROOT=build"
-      programs = Dir["build/Release/*"].select do |f|
-        next if f.end_with? ".dylib"
-        next if f.end_with? "Test"
+    if OS.mac?
+      cd "Build/Targets/universal-apple-macosx" do
+        xcodebuild "-target", "All", "-configuration", "Release", "SYMROOT=build"
+        programs = Dir["build/Release/*"].select do |f|
+          next if f.end_with? ".dylib"
+          next if f.end_with? "Test"
 
-        File.file?(f) && File.executable?(f)
+          File.file?(f) && File.executable?(f)
+        end
+        bin.install programs
       end
-      bin.install programs
+    elsif OS.linux?
+      mkdir "cmakebuild" do
+        system "cmake", "..", *std_cmake_args
+        system "make"
+        programs = Dir["./*"].select do |f|
+          File.file?(f) && File.executable?(f)
+        end
+        bin.install programs
+      end
     end
 
     rm Dir["Source/Python/wrappers/*.bat"]


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Bento4 doesn't install on Linux because the formula [uses xcodebuild](https://gist.github.com/clpo13/5eef21a2af2086d99d04316e31548415#file-01-xcodebuild). I've added cmake commands to allow building on Linux. This is my first time adding different install commands for macOS versus Linux, so please let me know if there's a better way to do it.