### PR TITLE
python@3.8: fix python3-config --ldflags

### DIFF
--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -3,14 +3,13 @@ class PythonAT38 < Formula
   homepage "https://www.python.org/"
   url "https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz"
   sha256 "2646e7dc233362f59714c6193017bb2d6f7b38d6ab4a0cb5fbac5c36c4d845df"
-  revision 1 unless OS.mac?
+  revision 2 unless OS.mac?
 
   bottle do
     rebuild 1
     sha256 "4bd9406b5d69313fcef3e572f85398ff9d7e2ab34eaf40c087bd0b4e87439ea8" => :catalina
     sha256 "511b4f2c3993f000516938ed0700936c8a7d8c054b5171fa733ac7d344291c30" => :mojave
     sha256 "86652428afa471b42ddba7028de02767d933f35f55e538b362c9cc219e972405" => :high_sierra
-    sha256 "c212d4f98cccb10812464f049af81a8f46eddba71520e8928bd5287bc6dafa3d" => :x86_64_linux
   end
 
   # setuptools remembers the build flags python is built with and uses them to
@@ -185,8 +184,9 @@ class PythonAT38 < Formula
       rm prefix/"Frameworks/Python.framework/Versions/Current"
     else
       # Prevent third-party packages from building against fragile Cellar paths
-      inreplace Dir[lib_cellar/"**/_sysconfigdata_m_linux_x86_64-*.py",
+      inreplace Dir[lib_cellar/"**/_sysconfigdata_*linux_x86_64-*.py",
                     lib_cellar/"config*/Makefile",
+                    bin/"python#{xy}-config",
                     lib/"pkgconfig/python-3.?.pc"],
                 prefix, opt_prefix
     end


### PR DESCRIPTION
We want to use the opt prefix instead of hardcoding Cellar paths,
to make version bumps portable.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
