### PR TITLE
workflows: try up to 20 times, with backoff

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -61,13 +61,14 @@ jobs:
           cd $(brew --repo ${{github.repository}})
           git commit --amend --no-edit
           git show --pretty=fuller
-          for try in $(seq 5); do
+          for try in $(seq 20); do
             git fetch
             git rebase origin/master
             if git push https://x-access-token:${{secrets.HOMEBREW_GITHUB_API_TOKEN}}@github.com/${{github.repository}} master; then
               exit 0
             else
-              sleep $(shuf -i 3-10 -n 1)
+              max=$(( $try + 10 ))
+              sleep $(shuf -i 3-$max -n 1)
             fi
           done
           exit 1

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -60,13 +60,14 @@ jobs:
           cd $(brew --repo ${{github.repository}})
           git commit --amend --no-edit
           git show --pretty=fuller
-          for try in $(seq 5); do
+          for try in $(seq 20); do
             git fetch
             git rebase origin/master
             if git push https://x-access-token:${{secrets.HOMEBREW_GITHUB_API_TOKEN}}@github.com/${{github.repository}} master; then
               exit 0
             else
-              sleep $(shuf -i 3-10 -n 1)
+              max=$(( $try + 10 ))
+              sleep $(shuf -i 3-$max -n 1)
             fi
           done
           exit 1


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Try much harder to push bottles, and also expand the range of time to sleep to do some "arithmetic backoff" based on the try number.

If this works we should also upstream this to homebrew/core.