### PR TITLE
replaced gcc by gcc@9 in llvm formula #20216

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -114,7 +114,7 @@ class Llvm < Formula
 
   unless OS.mac?
     depends_on "pkg-config" => :build
-    depends_on "gcc" # needed for libstdc++
+    depends_on "gcc@9" # needed for libstdc++
     depends_on "glibc" if Formula["glibc"].installed? || OS::Linux::Glibc.system_version < Formula["glibc"].version
     depends_on "binutils" # needed for gold and strip
     depends_on "libelf" # openmp requires <gelf.h>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
```cmake: /home/developer/.linuxbrew/lib/libstdc++.so.6: version `GLIBCXX_3.4.22' not found (required by cmake)```
-----
