### PR TITLE
tmx: Fix build for Linuxbrew

### DIFF
--- a/Formula/tmx.rb
+++ b/Formula/tmx.rb
@@ -13,6 +13,7 @@ class Tmx < Formula
   end
 
   depends_on "cmake" => :build
+  uses_from_macos "libxml2"
 
   def install
     system "cmake", ".", "-DBUILD_SHARED_LIBS=on", *std_cmake_args
@@ -50,7 +51,7 @@ class Tmx < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "#{lib}/libtmx.dylib", "-lz", "-lxml2", "-o", "test"
+    system ENV.cc, "test.c", "#{lib}/libtmx.#{OS.mac? ? "dylib" : "so"}", "-lz", "-lxml2", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/tmx.rb
+++ b/Formula/tmx.rb
@@ -13,6 +13,7 @@ class Tmx < Formula
   end
 
   depends_on "cmake" => :build
+
   uses_from_macos "libxml2"
 
   def install


### PR DESCRIPTION
Needs libxml2 (also zlib, handled indirectly)

Also needs a test fix

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
```
Already downloaded: /home/me/.cache/Homebrew/downloads/98e46850dbd76ac2339f2a6a4a72b9fd7816f80ab3a16381737209c7744424cf--tmx-tmx_1.0.0.tar.gz
==> cmake . -DBUILD_SHARED_LIBS=on
==> make install
Last 15 lines from /home/me/.cache/Homebrew/Logs/tmx/02.make:
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/gcc-5 -DWANT_ZLIB -I/home/linuxbrew/.linuxbrew/include/libxml2  -DNDEBUG   -o CMakeFiles/tmx.dir/src/tmx_mem.c.o   -c /tmp/tmx-20200425-50319-1anznf3/tmx-tmx_1.0.0/src/tmx_mem.c
/tmp/tmx-20200425-50319-1anznf3/tmx-tmx_1.0.0/src/tmx_xml.c:11:30: fatal error: libxml/xmlreader.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/tmx.dir/build.make:138: CMakeFiles/tmx.dir/src/tmx_xml.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/tmp/tmx-20200425-50319-1anznf3/tmx-tmx_1.0.0/src/tmx_mem.c:7:30: fatal error: libxml/xmlmemory.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/tmx.dir/build.make:151: CMakeFiles/tmx.dir/src/tmx_mem.c.o] Error 1
make[2]: Leaving directory '/tmp/tmx-20200425-50319-1anznf3/tmx-tmx_1.0.0'
make[1]: *** [CMakeFiles/Makefile2:128: CMakeFiles/tmx_shared.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/tmp/tmx-20200425-50319-1anznf3/tmx-tmx_1.0.0'
make[1]: *** [CMakeFiles/Makefile2:101: CMakeFiles/tmx.dir/all] Error 2
make[1]: Leaving directory '/tmp/tmx-20200425-50319-1anznf3/tmx-tmx_1.0.0'
make: *** [Makefile:153: all] Error 2
```
See https://gist.github.com/dfd72a75462434925c65897c89bfac89 for more details.

**Question for the current maintainers**: should patches involving `uses_from_macos` go upstream or here? Because of the `dylib` changes this was going to need a Linux change either way, but the `uses_from_macos` could arguably apply upstream.