### PR TITLE
rhash: Fix build for Linuxbrew

### DIFF
--- a/Formula/rhash.rb
+++ b/Formula/rhash.rb
@@ -15,7 +15,7 @@ class Rhash < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
-    lib.install "librhash/librhash.dylib"
+    lib.install "librhash/librhash.#{OS.mac? ? "dylib" : "so"}"
     system "make", "-C", "librhash", "install-lib-headers"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

```
==> Downloading https://downloads.sourceforge.net/project/rhash/rhash/1.3.9/rhash-1.3.9-src.tar.gz
Already downloaded: /home/me/.cache/Homebrew/downloads/bbac6b0fe4139b5baa91ca365dd1f267dd3f1c08320092b360da4a48ca056b46--rhash-1.3.9-src.tar.gz
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/rhash/1.3.9
==> make
==> make install
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - librhash/librhash.dylib
```

gist-logs [here](https://gist.github.com/rwhogg/a86e1e3e0867161f74f96f0d11cf0664) but they're not particularly illuminating