### PR TITLE
mruby-cli: Fix build for Linuxbrew

### DIFF
--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -16,6 +16,7 @@ class MrubyCli < Formula
   end
 
   uses_from_macos "bison" => :build
+  uses_from_macos "ruby" => :build
 
   def install
     ENV["MRUBY_CLI_LOCAL"] = "true"

--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -15,6 +15,8 @@ class MrubyCli < Formula
     sha256 "a06806ca6a22d3b015e073a984e832013f2efe729870e2aa6d0b17e91a4b9855" => :yosemite
   end
 
+  uses_from_macos "bison" => :build
+
   def install
     ENV["MRUBY_CLI_LOCAL"] = "true"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/7b92045e499e476098b6eccbeba3c665**

-----

Needs `bison` to build:

```
==> Reinstalling mruby-cli 
==> Downloading https://github.com/hone/mruby-cli/archive/v0.0.4.tar.gz
Already downloaded: /home/me/.cache/Homebrew/downloads/187de8cee9fd0752397543ca0c830956601e57212065cffeb36e4aaee41de5bc--mruby-cli-0.0.4.tar.gz
==> rake compile
Last 15 lines from /home/me/.cache/Homebrew/Logs/mruby-cli/01.rake:
rake aborted!
Command failed with status (127): [bison -o "/tmp/mruby-cli-20200426-65116-1s...]
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/tasks/mruby_build_commands.rake:31:in `_run'
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/tasks/mruby_build_commands.rake:36:in `rescue in _run'
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/tasks/mruby_build_commands.rake:32:in `_run'
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/tasks/mruby_build_commands.rake:223:in `run'
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/mrbgems/mruby-compiler/mrbgem.rake:30:in `block (2 levels) in <top (required)>'

Caused by:
Command failed with status (127): ["bison" -o "/tmp/mruby-cli-20200426-65116-...]
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/tasks/mruby_build_commands.rake:33:in `_run'
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/tasks/mruby_build_commands.rake:223:in `run'
/tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/mrbgems/mruby-compiler/mrbgem.rake:30:in `block (2 levels) in <top (required)>'
Tasks: TOP => compile => all => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/lib/libmruby.flags.mak => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/lib/libmruby.a => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/mrblib/mrblib.o => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/mrblib/mrblib.c => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/bin/mrbc => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/lib/libmruby_core.a => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/mrbgems/mruby-compiler/core/y.tab.o => /tmp/mruby-cli-20200426-65116-1swbh4z/mruby-cli-0.0.4/mruby/build/host/mrbgems/mruby-compiler/core/y.tab.c
(See full trace by running task with --trace)

READ THIS: https://docs.brew.sh/Troubleshooting
```