### PR TITLE
openssl: Add Test::More Perl package

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -64,7 +64,7 @@ class OpensslAT11 < Formula
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
         system "make", "PERL5LIB=#{ENV["PERL5LIB"]}", "CC=#{ENV.cc}"
         system "make", "install"
-      end    
+      end
     end
 
     # This could interfere with how we expect OpenSSL to build.

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -28,6 +28,11 @@ class OpensslAT11 < Formula
       url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz"
       sha256 "0fd90d4efea82d6e262e6933759e85d27cbcfa4091b14bf4042ae20bab528e53"
     end
+
+    resource "Test::More" do
+      url "https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302175.tar.gz"
+      sha256 "c8c8f5c51ad6d7a858c3b61b8b658d8e789d3da5d300065df0633875b0075e49"
+    end
   end
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
@@ -54,6 +59,12 @@ class OpensslAT11 < Formula
         system "make", "PERL5LIB=#{ENV["PERL5LIB"]}", "CC=#{ENV.cc}"
         system "make", "install"
       end
+
+      resource("Test::More").stage do
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+        system "make", "PERL5LIB=#{ENV["PERL5LIB"]}", "CC=#{ENV.cc}"
+        system "make", "install"
+      end    
     end
 
     # This could interfere with how we expect OpenSSL to build.


### PR DESCRIPTION
This commit address issue #20267

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

CentOS 7 fail to compile the openssl formula due to missing `Test::More` perl package which is required by `make test` step.