### PR TITLE
rgbds: Depends on bison to build

### DIFF
--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -15,6 +15,8 @@ class Rgbds < Formula
   depends_on "pkg-config" => :build
   depends_on "libpng"
 
+  uses_from_macos "bison" => :build
+
   def install
     system "make", "install", "PREFIX=#{prefix}", "mandir=#{man}"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/887240f66f163924fd7e00ffb5b38098**

-----
```
==> make install PREFIX=/home/linuxbrew/.linuxbrew/Cellar/rgbds/0.4.0 mandir=/home/linuxbrew/.linuxbrew/Cellar/rgbds/0.4.0/share/man
Last 15 lines from /home/me/.cache/Homebrew/Logs/rgbds/01.make:
2020-05-05 09:22:56 -0400

make
install
PREFIX=/home/linuxbrew/.linuxbrew/Cellar/rgbds/0.4.0
mandir=/home/linuxbrew/.linuxbrew/Cellar/rgbds/0.4.0/share/man

make: yacc: Command not found
make: *** [Makefile:125: src/asm/asmy.c] Error 127

READ THIS: https://docs.brew.sh/Troubleshooting
```