### PR TITLE
ruby: use HOMEBREW_FORCE_VENDOR_RUBY

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -73,6 +73,10 @@ class Ruby < Formula
     else
       "MJIT_CC=/usr/bin/gcc"
     end
+  
+    args << if ENV["HOMEBREW_FORCE_VENDOR_RUBY"].present? and ENV["HOMEBREW_RUBY_PATH"].present?
+      "--with-baseruby=#{ENV["HOMEBREW_RUBY_PATH"]}"
+    end
 
     system "./configure", *args
 

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -3,7 +3,7 @@ class Ruby < Formula
   homepage "https://www.ruby-lang.org/"
   url "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.xz"
   sha256 "b224f9844646cc92765df8288a46838511c1cec5b550d8874bd4686a904fcee7"
-  revision OS.mac? ? 2 : 3
+  revision OS.mac? ? 2 : 4
 
   bottle do
     sha256 "7f5ed2afb15b25f9616b617ecca2ee376eb67cf6c105790df22221b7be9c1ef9" => :catalina

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -73,8 +73,8 @@ class Ruby < Formula
     else
       "MJIT_CC=/usr/bin/gcc"
     end
-  
-    args << if ENV["HOMEBREW_FORCE_VENDOR_RUBY"].present? and ENV["HOMEBREW_RUBY_PATH"].present?
+
+    args << if ENV["HOMEBREW_FORCE_VENDOR_RUBY"].present? && ENV["HOMEBREW_RUBY_PATH"].present?
       "--with-baseruby=#{ENV["HOMEBREW_RUBY_PATH"]}"
     end
 


### PR DESCRIPTION
This would allow the user to set `HOMEBREW_FORCE_VENDOR_RUBY=1` to solve an upstream issue with compiling Ruby on Linux systems that have a version of Ruby already installed that is older than 2.2.

See:
https://bugs.ruby-lang.org/issues/16845
https://bugs.ruby-lang.org/issues/16668
https://bugs.ruby-lang.org/issues/16671

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
