### PR TITLE
code-server: Depends on libsecret for Linux

### DIFF
--- a/Formula/code-server.rb
+++ b/Formula/code-server.rb
@@ -15,6 +15,13 @@ class CodeServer < Formula
   depends_on "yarn" => :build
   depends_on "node"
 
+  unless OS.mac?
+    depends_on "pkg-config" => :build
+    depends_on "libsecret"
+    depends_on "linuxbrew/xorg/libxkbfile"
+    depends_on "linuxbrew/xorg/libx11"
+  end
+
   def install
     system "yarn", "--production", "--frozen-lockfile"
     libexec.install Dir["*"]


### PR DESCRIPTION
It's not spelled out explicitly in the dependencies, but
it's mentioned as a step here: https://github.com/cdr/code-server/issues/735#issuecomment-498929565

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/5a235ba487ec020d7b66eabd44e1d4c2**

```
Package libsecret-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsecret-1.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsecret-1' found
gyp: Call to 'pkg-config --libs-only-l libsecret-1' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
```