### PR TITLE
update sha256 for gzipped patchelf.

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -6,11 +6,12 @@ class Patchelf < Formula
 
   bottle do
     cellar :any_skip_relocation
+    rebuild 1
     sha256 "a808a7b52e286a6710c079a7e8be08f977554868da6b0fd69032032031900243" => :catalina
     sha256 "8f57b65d6a11bfe332e7663b144c0e4e9842291c2b0a4055bd10794b2911dac4" => :mojave
     sha256 "98e221be1ce346f4c33bee1fc87b7dba33aafcc88c98ac061e04a69c9c9e9584" => :high_sierra
     sha256 "2504614537c2837d9668389349586730c38b93a632175e1cf80568b0650eb5aa" => :sierra
-    sha256 "988b224305ff3fecadf9bbf5fbe1b18061077be6c896935b2cef29298526f5b8" => :x86_64_linux # glibc 2.13
+    sha256 "7f19eacef4e3d18d9c82a4f4060bd86abeb912a4a76fa37c29f0bb104a38b2a2" => :x86_64_linux # glibc 2.13
   end
 
   resource "hellworld" do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Patchelf bottle was earlier compressed as `tar`,  @sjackman gzipped and reuploaded.
The sha was updated to reflect this change.
