### PR TITLE
Add tcltk capability for R.

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -5,13 +5,6 @@ class R < Formula
   sha256 "06beb0291b569978484eb0dcb5d2339665ec745737bdfb4e873e7a5a75492940"
   revision 1
 
-  bottle do
-    sha256 "5905c138df0ad32f3bd822bb0913da1afb28a2b037ff466e8003065d94978414" => :catalina
-    sha256 "fa57206731acfdb0418e84e5bf1c7ef1fbbab8b15597b569039f71ee3337750a" => :mojave
-    sha256 "5e534f3435aa4a48b7874c3a65e1a12ba28fa71d726cc82fdbaa44e3973fb9e6" => :high_sierra
-    sha256 "ebeed59162de9ede2a3f96af02cc63c937d759a036de3f2922c86d90d51e8c04" => :x86_64_linux
-  end
-
   depends_on "pkg-config" => :build
   depends_on "gcc" # for gfortran
   depends_on "gettext"
@@ -66,8 +59,9 @@ class R < Formula
     else
       args << "--with-x"
       args << "--with-tcltk"
-      args << "--with-tcl-config=#{HOMEBREW_PREFIX}/lib/tclConfig.sh"
-      args << "--with-tk-config=#{HOMEBREW_PREFIX}/lib/tkConfig.sh"
+      tcl_lib = Formula["tcl-tk"].opt_lib
+      args << "--with-tcl-config=#{tcl_lib}/tclConfig.sh"
+      args << "--with-tk-config=#{tcl_lib}/tkConfig.sh"
     end
 
     unless OS.mac?

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -5,6 +5,12 @@ class R < Formula
   sha256 "06beb0291b569978484eb0dcb5d2339665ec745737bdfb4e873e7a5a75492940"
   revision 1
 
+  bottle do
+    sha256 "5905c138df0ad32f3bd822bb0913da1afb28a2b037ff466e8003065d94978414" => :catalina
+    sha256 "fa57206731acfdb0418e84e5bf1c7ef1fbbab8b15597b569039f71ee3337750a" => :mojave
+    sha256 "5e534f3435aa4a48b7874c3a65e1a12ba28fa71d726cc82fdbaa44e3973fb9e6" => :high_sierra
+  end
+
   depends_on "pkg-config" => :build
   depends_on "gcc" # for gfortran
   depends_on "gettext"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -27,6 +27,7 @@ class R < Formula
     depends_on "curl"
     depends_on "pango"
     depends_on "linuxbrew/xorg/xorg"
+    depends_on "tcl-tk"
   end
 
   # needed to preserve executable permissions on files without shebangs
@@ -62,6 +63,11 @@ class R < Formula
       args << "--without-tcltk"
       args << "--without-x"
       args << "--with-aqua"
+    else
+      args << "--with-x"
+      args << "--with-tcltk"
+      args << "--with-tcl-config=#{HOMEBREW_PREFIX}/lib/tclConfig.sh"
+      args << "--with-tk-config=#{HOMEBREW_PREFIX}/lib/tkConfig.sh"
     end
 
     unless OS.mac?


### PR DESCRIPTION
Enable `tcltk` for R.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

`brew audit --strict r.rb` says:
```
r:
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      lib/R/bin/libtool
Error: 1 problem in 1 formula detected
```