### PR TITLE
.github: Use image homebrew/ubuntu16.04:master

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -6,7 +6,7 @@ jobs:
   bottling:
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04:master
     steps:
         # Printing these details should always be the first step listed.
       - name: ${{github.event.client_payload.formula}}

--- a/.github/workflows/request-bottle-after-merge.yml
+++ b/.github/workflows/request-bottle-after-merge.yml
@@ -12,7 +12,7 @@ jobs:
     if: startsWith(github.event.head_commit.message, 'Merge') == true && contains(github.event.head_commit.message, 'Conflicts') == true
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04:master
     steps:
       - name: Tap linux-dev
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   tap_syntax:
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04:master
     steps:
       - name: Check out tap
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'Merge') == false
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04:master
     steps:
       - name: Check out tap
         uses: actions/checkout@v2

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -12,7 +12,7 @@ jobs:
     if: startsWith(github.event.head_commit.message, 'Merge') == false && github.event.pusher.name != 'BrewTestBot'
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04:master
     steps:
       - name: Determine associated pull request
         uses: actions/github-script@0.9.0


### PR DESCRIPTION
Use Docker image `homebrew/ubuntu16.04:master ` rather than `homebrew/brew:latest`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Depends on PR https://github.com/Homebrew/brew/pull/7617