### PR TITLE
util-linux: rebuild bottle for Linux

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -3,12 +3,12 @@ class UtilLinux < Formula
   homepage "https://github.com/karelzak/util-linux"
   url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.35/util-linux-2.35.2.tar.xz"
   sha256 "21b7431e82f6bcd9441a01beeec3d57ed33ee948f8a5b41da577073c372eb58a"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "8f9f0592f1135621eb61133f986c9372e6fa718d4137dfdaa63f2c212d729564" => :catalina
     sha256 "10530ca9de44cb341b50114f3c740b58b7daaf030568662ac2a174feb1c25e49" => :mojave
     sha256 "458ece9b1190f761a6fc42bf66484eec1e67cafb5ef44d6ccd40ee9a0b05cc7c" => :high_sierra
-    sha256 "3d66f456d95f150a0f1671c6ef807039820af261bc69ae11b4f45eb9762bb719" => :x86_64_linux
   end
 
   keg_only "macOS provides the uuid.h header" if OS.mac?


### PR DESCRIPTION
Because the previous bottle contains:

$ strings /home/linuxbrew/.linuxbrew/lib/libmount.so.1 | grep getrandom
getrandom() function
getrandom@@GLIBC_2.25
getrandom

and it should not reference a glibc specific version.
Not sure why that bottle build was botched, probably some upstrema homebrew
tweaks with depdencies that went wrong lately.
