### PR TITLE
llvm: rebuild

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -3,7 +3,7 @@ require "os/linux/glibc"
 class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
-  revision OS.mac? ? 3 : 6
+  revision OS.mac? ? 3 : 7
 
   stable do
     url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz"
@@ -79,7 +79,6 @@ class Llvm < Formula
     sha256 "ea9b9f579df49499d9ab0084e10edecc5350298d6c5db399a1dabc8694dab7db" => :catalina
     sha256 "14f59a25e73e3a00fd36632f2106b41eda1b54aa1039b4b979bd957a8c041bf4" => :mojave
     sha256 "6e09ca233790a58edae55bba453fd50179369b5514acb5f8b86156401227a75e" => :high_sierra
-    sha256 "399f96b59f680fe144c25a4096ca6f36bab84a311c78b6ef4ff67338dbe150d4" => :x86_64_linux
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

```
==> make deps
Makefile:54: *** Could not locate llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG.  Stop.
/home/linuxbrew/.linuxbrew/bin/clang: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /home/linuxbrew/.linuxbrew/lib/libLLVM-10.so)
/home/linuxbrew/.linuxbrew/bin/clang: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /home/linuxbrew/.linuxbrew/lib/libLLVM-10.so)
```

The bottle was probably built accidentaly in the container based off ubuntu 20.04 during transition of images.