### PR TITLE
texlive 20200522

### DIFF
--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -3,7 +3,7 @@ class Texlive < Formula
   homepage "https://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
   version "20200522"
-  #sha256 "3438a18c53ecf3d13e212ad8f76f73e728a67134772857adf54f02aaefac033e"
+  # sha256 "3438a18c53ecf3d13e212ad8f76f73e728a67134772857adf54f02aaefac033e"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -25,7 +25,8 @@ class Texlive < Formula
   def install
     ohai "Downloading and installing TeX Live. This will take a few minutes."
     ENV["TEXLIVE_INSTALL_PREFIX"] = libexec
-    system "./install-tl", "-scheme", "small", "-portable", "-profile", "/dev/null"
+    system "touch","zero.profile"
+    system "./install-tl", "-scheme", "small", "-portable", "-profile", "zero.profile"
 
     man1.install Dir[libexec/"texmf-dist/doc/man/man1/*"]
     man5.install Dir[libexec/"texmf-dist/doc/man/man5/*"]

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -3,7 +3,7 @@ class Texlive < Formula
   homepage "https://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
   version "20200522"
-  sha256 "02381aeaea5f3de06197104242bb12f5fdc6c82641364057de34dbb6509fadef"
+  #sha256 "3438a18c53ecf3d13e212ad8f76f73e728a67134772857adf54f02aaefac033e"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -2,12 +2,11 @@ class Texlive < Formula
   desc "TeX Live is a free software distribution for the TeX typesetting system"
   homepage "https://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
-  version "20190406"
-  sha256 "c7742ea5b0bc22fe2742e9fa2bf9aeb8ff88175722fcfb2b72c00a29c06e2fc9"
+  version "20200522"
+  sha256 "02381aeaea5f3de06197104242bb12f5fdc6c82641364057de34dbb6509fadef"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "4e24715e406a78243cc4391aabc6dc7776390b43fd57d21315a002776ea8994a" => :x86_64_linux
   end
 
   depends_on "wget" => :build

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -25,7 +25,7 @@ class Texlive < Formula
   def install
     ohai "Downloading and installing TeX Live. This will take a few minutes."
     ENV["TEXLIVE_INSTALL_PREFIX"] = libexec
-    system "touch","zero.profile"
+    touch("zero.profile")
     system "./install-tl", "-scheme", "small", "-portable", "-profile", "zero.profile"
 
     man1.install Dir[libexec/"texmf-dist/doc/man/man1/*"]


### PR DESCRIPTION
Update to TeXLive 2020.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The TeXLive installer is going to download huge mount of files, which is unlikely to be done with Chinese network where all oversea sites are extremely slow. Thus I cannot finish building on my own PC.
I have raised a issue as <https://github.com/Homebrew/linuxbrew-core/issues/20374>, and been suggested to open a pull request without a successfully build.
This is a minor update, thus should be working.

BTW, the official `install-tl-unx.tar.gz` just updated from 20200517 to 20200522. I wonder whether we have some other way to follow this.