### PR TITLE
chrome-cli: requires macOS

### DIFF
--- a/Formula/chrome-cli.rb
+++ b/Formula/chrome-cli.rb
@@ -15,6 +15,7 @@ class ChromeCli < Formula
   end
 
   depends_on :xcode => :build if OS.mac?
+  depends_on :macos
 
   def install
     # Release builds


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **N/A**
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? **N/A**
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. See https://gist.github.com/15e4d17c6ec61c81de2431b0c1393b6e

-----

https://github.com/prasmussen/chrome-cli specifically mentions that it's for macOS, it needs XCode to build, and depends on Scripting Bridge.

```
==> xcodebuild SDKROOT= SYMROOT=build
Last 15 lines from /home/me/.cache/Homebrew/Logs/chrome-cli/01.xcodebuild:
2020-05-29 08:48:35 -0400

xcodebuild
SDKROOT=
SYMROOT=build


READ THIS: https://docs.brew.sh/Troubleshooting
```