### PR TITLE
pipenv: fix build for Linuxbrew

### DIFF
--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -68,10 +68,14 @@ class Pipenv < Formula
     }
     (bin/"pipenv").write_env_script(libexec/"bin/pipenv", env)
 
-    output = Utils.safe_popen_read({ "SHELL" => "bash" }, libexec/"bin/pipenv", "--completion", { :err => :err })
+    output = Utils.safe_popen_read(
+      { "PIPENV_SHELL" => "bash" }, libexec/"bin/pipenv", "--completion", { :err => :err }
+    )
     (bash_completion/"pipenv").write output
 
-    output = Utils.safe_popen_read({ "SHELL" => "zsh" }, libexec/"bin/pipenv", "--completion", { :err => :err })
+    output = Utils.safe_popen_read(
+      { "PIPENV_SHELL" => "zsh" }, libexec/"bin/pipenv", "--completion", { :err => :err }
+    )
     (zsh_completion/"_pipenv").write output
   end
 


### PR DESCRIPTION
Fixes:
```
2020-06-03T18:52:32.2368814Z Traceback (most recent call last):
2020-06-03T18:52:32.2368954Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/bin/pipenv", line 8, in <module>
2020-06-03T18:52:32.2369078Z     sys.exit(cli())
2020-06-03T18:52:32.2369464Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 829, in __call__
2020-06-03T18:52:32.2369615Z     return self.main(*args, **kwargs)
2020-06-03T18:52:32.2369992Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 782, in main
2020-06-03T18:52:32.2370137Z     rv = self.invoke(ctx)
2020-06-03T18:52:32.2370528Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 1236, in invoke
2020-06-03T18:52:32.2370669Z     return Command.invoke(self, ctx)
2020-06-03T18:52:32.2371049Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
2020-06-03T18:52:32.2371298Z     return ctx.invoke(self.callback, **ctx.params)
2020-06-03T18:52:32.2371693Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
2020-06-03T18:52:32.2371832Z     return callback(*args, **kwargs)
2020-06-03T18:52:32.2372233Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/decorators.py", line 73, in new_func
2020-06-03T18:52:32.2372380Z     return ctx.invoke(f, obj, *args, **kwargs)
2020-06-03T18:52:32.2372754Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
2020-06-03T18:52:32.2372898Z     return callback(*args, **kwargs)
2020-06-03T18:52:32.2373288Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click/decorators.py", line 21, in new_func
2020-06-03T18:52:32.2373444Z     return f(get_current_context(), *args, **kwargs)
2020-06-03T18:52:32.2373822Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/cli/command.py", line 87, in cli
2020-06-03T18:52:32.2373971Z     print(click_completion.get_code(shell=shell, prog_name="pipenv"))
2020-06-03T18:52:32.2374384Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/site-packages/pipenv/vendor/click_completion/core.py", line 308, in get_code
2020-06-03T18:52:32.2374524Z     shell = Shell[shell]
2020-06-03T18:52:32.2374663Z   File "/home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/lib/python3.8/enum.py", line 344, in __getitem__
2020-06-03T18:52:32.2374801Z     return cls._member_map_[name]
2020-06-03T18:52:32.2375037Z KeyError: 'sh'
2020-06-03T18:52:32.2375463Z [31mError:[0m Failure while executing; `\{\"SHELL\"=\>\"bash\"\} /home/linuxbrew/.linuxbrew/Cellar/pipenv/2020.5.28_2/libexec/bin/pipenv --completion` exited with 1. Here's the output:
2020-06-03T18:52:32.2375564Z
```
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
