### PR TITLE
subversion: Fix merge conflict

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -120,12 +120,8 @@ class Subversion < Formula
       --without-gpg-agent
       --enable-javahl
       --without-jikes
-      <<<<<<< HEAD
-      RUBY=#{ruby}
-      =======
       PYTHON=#{Formula["python@3.8"].opt_bin}/python3
-      RUBY=/usr/bin/ruby
-      >>>>>>> 1935bc45ce
+      RUBY=#{ruby}
     ]
 
     inreplace "Makefile.in",

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -95,6 +95,9 @@ class Subversion < Formula
       system "scons", "install"
     end
 
+    # svn can't find libserf-1.so.1 at runtime without this
+    ENV.append "LDFLAGS", "-Wl,-rpath=#{serf_prefix}/lib" unless OS.mac?
+
     # Use existing system zlib
     # Use dep-provided other libraries
     # Don't mess with Apache modules (since we're not sudo)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/rwhogg/9e7e21da07ab3305396f180f0c7f2928**

```
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/subversion/1.14.0_1 --enable-optimize --disable-mod-activation --disable-plaintext-password-storage --with-apr-util
Last 15 lines from /home/me/.cache/Homebrew/Logs/subversion/03.configure:
--enable-javahl
--without-jikes
<<<<<<<
HEAD
RUBY=/home/linuxbrew/.linuxbrew/opt/ruby/bin/ruby
=======
PYTHON=/home/linuxbrew/.linuxbrew/opt/python@3.8/bin/python3
RUBY=/usr/bin/ruby
>>>>>>>
1935bc45ce

configure: WARNING: you should use --build, --host, --target
configure: WARNING: invalid host type: <<<<<<<
configure: WARNING: you should use --build, --host, --target
configure: error: invalid variable name: `'

READ THIS: https://docs.brew.sh/Troubleshooting
```
-----

A bit of a caveat about this one: I haven't really used subversion in years and I've never used the Python bindings (see https://github.com/Homebrew/homebrew-core/issues/53193#issue-600482673 and https://github.com/Homebrew/homebrew-core/pull/55398). So I can't really vouch for them working correctly. But it compiles again at least!