### PR TITLE
qt-5.15.0: Fix build on linux

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,7 +1,6 @@
 class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
-  revision 1 unless OS.mac?
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/0.35.0.tar.gz"
@@ -60,7 +59,7 @@ class Crystal < Formula
     else
       url "https://github.com/crystal-lang/crystal/releases/download/0.34.0/crystal-0.34.0-1-linux-x86_64.tar.gz"
       version "0.34.0-1"
-      sha256 "f1235f92d65140edd4a51c198f3c221379af8188b06ae96b7377e0a80c99181a"
+      sha256 "268ace9073ad073b56c07ac10e3f29927423a8b170d91420b0ca393fb02acfb1"
     end
   end
 

--- a/Formula/flake8.rb
+++ b/Formula/flake8.rb
@@ -3,16 +3,15 @@ class Flake8 < Formula
 
   desc "Lint your Python code for style and logical errors"
   homepage "https://flake8.pycqa.org/"
-  url "https://gitlab.com/pycqa/flake8/-/archive/3.8.2/flake8-3.8.2.tar.bz2"
-  sha256 "6185d7b5754dc3672f0ca5b380c5654b7511d4a6ae1439525608e0c3b2321d24"
+  url "https://gitlab.com/pycqa/flake8/-/archive/3.8.3/flake8-3.8.3.tar.bz2"
+  sha256 "eb8beddb4a94caa8284c8ac4370219f3887c67d1cf9ac722b4a03306fe03e2bc"
   head "https://gitlab.com/PyCQA/flake8.git", :shallow => false
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "38a01e872bef609a26d213c04e17175b9538ca51fb88b80e53f99ed900cf24dd" => :catalina
-    sha256 "5960ac5f10ae4d51310b4c6b4596872e7ba9ed921507988602439c1fa710325b" => :mojave
-    sha256 "59b2d53c686beac8c075e467a92a2245956939767f47b17edca81a5d5ae13c3b" => :high_sierra
-    sha256 "0d3993520e43f197c3146b0b5146c10a99faaaafd777913251cc49a4a9136fc3" => :x86_64_linux
+    sha256 "c69d45f5fc4c8d4626968bb9df56ee0f3bdfe746b61e527f373952ee8225992e" => :catalina
+    sha256 "eb9d1de4ade2c8ba850b44bd8a3d8d02c04aa51b021737c61d8498a0d41c404f" => :mojave
+    sha256 "d6c5a8a1a2ea74a8d296777d4adb4d916bae7e5ce75852b22690fe3a7c14b894" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/lazydocker.rb
+++ b/Formula/lazydocker.rb
@@ -2,15 +2,14 @@ class Lazydocker < Formula
   desc "The lazier way to manage everything docker"
   homepage "https://github.com/jesseduffield/lazydocker"
   url "https://github.com/jesseduffield/lazydocker.git",
-      :tag      => "v0.9",
+      :tag      => "v0.9.1",
       :revision => "10617da5608990bf4911142745d31566bac6964a"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "51a269c04bf156039e05ebb721c34da808973aaa6b52f014d07af3e441e6ebe7" => :catalina
-    sha256 "fc34436a43b43fb69c3f98e5c4a2dd26653b47a993f802eeac443ea1cfd2134d" => :mojave
-    sha256 "2186290d630c746995a06f2e37e1f77d9bd6e77becee66d59f1e5fdeb5fc4703" => :high_sierra
-    sha256 "33ffca6161b34f758916a0c604d1bd8a6e991757a7b6ff7b1219f73bdd203ccd" => :x86_64_linux
+    sha256 "0a32a3111697ccba3b9f1d959f206c23a6b2fdc2fdb968f5eed12575c67e56b4" => :catalina
+    sha256 "efe1cebae9966e4cbe0b55cfd28f6625d37b821827c7954168e80fc932ec57e2" => :mojave
+    sha256 "79c56a22d891d09ce3b08ef1c400768dc68f2c5244b9a33070aae6f33e3d1e7b" => :high_sierra
   end
 
   depends_on "go" => :build

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -10,6 +10,7 @@ class Mesa < Formula
     sha256 "92b3b0c3029fdb92a51c3aa9eec2f5dd494dd273ac003f261e16fd94e4950c24" => :catalina
     sha256 "149023dfcb0698bb772eb7f20fb349441f47963f13e0bca4c15c03ce6ed765d9" => :mojave
     sha256 "e5b85e7ff8624d311d2b6d1f5b069241b3193862b508011908f9a2b1c87d0e99" => :high_sierra
+    sha256 "0484846a5462c96c5764bbe01d3d8406cb0abad7421e79d941997c629d666c0d" => :x86_64_linux
   end
 
   depends_on "meson-internal" => :build

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -4,13 +4,14 @@
 class Mu < Formula
   desc "Tool for searching e-mail messages stored in the maildir-format"
   homepage "https://www.djcbsoftware.nl/code/mu/"
-  url "https://github.com/djcb/mu/archive/1.4.9.tar.gz"
-  sha256 "1d025e75ee3a0fc8b680963a4e61b8644cb89d98f4155ac0ef55f4b99cbbe6f7"
+  url "https://github.com/djcb/mu/archive/1.4.10.tar.gz"
+  sha256 "a3fd3b56fb0872892427909888d55bae2c3f0d574494cb27853ae4907b2c8af9"
 
   bottle do
-    sha256 "41480ee322e1a4ea3d583eadfda89ee098f5e50d53bdf68c5e3f6e8b814ff6c4" => :catalina
-    sha256 "978344c4dfdd9540cf20693c5a61bba050d9344c3c67c890c9f1de69c5e79eda" => :mojave
-    sha256 "e95b223119c049200c76003e487d4401a4f896753de754947809442544609533" => :high_sierra
+    cellar :any
+    sha256 "ff8820080a32067627c8b8ea26a2a80e94d24833d33ffd5c130a251f36243dce" => :catalina
+    sha256 "ae98cf1ff0fdbae8771d01a22078478cfb4b4248c3f664c135a7be6735194d4f" => :mojave
+    sha256 "a9ef200573c8092384f30fcec9cd7b9ecf3e34b29a72fb17a72aadef86772c51" => :high_sierra
   end
 
   head do

--- a/Formula/ncdu.rb
+++ b/Formula/ncdu.rb
@@ -1,15 +1,14 @@
 class Ncdu < Formula
   desc "NCurses Disk Usage"
   homepage "https://dev.yorhel.nl/ncdu"
-  url "https://dev.yorhel.nl/download/ncdu-1.15.tar.gz"
-  sha256 "4a593dc5cceb2492a9669f5f5d69d0e517de457a11036788ea4591f33c5297fb"
+  url "https://dev.yorhel.nl/download/ncdu-1.15.1.tar.gz"
+  sha256 "b02ddc4dbf1db139cc6fbbe2f54a282770380f0ca5c17089855eab52a9ea3fb0"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "df4662de39f18d84000aaea85626da50d6076281e8823b093cff48111aadf2ec" => :catalina
-    sha256 "f84f3f172a6949aff0a2a70f06a5b6e8fd05bd0a2ae18e1d6da7baf22378f0c6" => :mojave
-    sha256 "f5aced7c926a8523011d5e4f503721fcf2b67287fa4df0af4357b72211581f43" => :high_sierra
-    sha256 "f5d85e68f0a96952c45b5c9999bbbecb96377cc4f403bed7b31d2564ee97a6b9" => :x86_64_linux
+    sha256 "994f7f4e9624a0984ec7c37b5b15b9ae5c24663ebffaba19b0979f4e99919fee" => :catalina
+    sha256 "f7908eaf47c7842b15e56e17279583f4c938a9c920e1bae41f05d3e5506a99fb" => :mojave
+    sha256 "d094385dbfd71831c5f2b03f0817a06df9471a44f5437aaf577676d2723bc865" => :high_sierra
   end
 
   head do
@@ -25,8 +24,6 @@ class Ncdu < Formula
     system "autoreconf", "-i" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    # Older linuxes does not have this constant in /usr/include/linux/magic.h
-    inreplace "src/dir_scan.c", "CGROUP2_SUPER_MAGIC", "0x63677270" unless OS.mac?
     system "make", "install"
   end
 

--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -1,13 +1,13 @@
 class PetscComplex < Formula
   desc "Portable, Extensible Toolkit for Scientific Computation (complex)"
   homepage "https://www.mcs.anl.gov/petsc/"
-  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.13.1.tar.gz"
-  sha256 "74a895e44e2ff1146838aaccb7613e7626d99e0eed64ca032c87c72d084efac3"
+  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.13.2.tar.gz"
+  sha256 "6083422a7c5b8e89e5e4ccf64acade9bf8ab70245e25bca3a3da03caf74602f1"
 
   bottle do
-    sha256 "75672649113401ed21eb80a19a829b977df1e9b1b05010361bf3bbf37d5a704d" => :catalina
-    sha256 "a50c8af491f2a80e2ce4bd9610948b08b323d4d1a8611dcfe68a31b5f92b2b6c" => :mojave
-    sha256 "b77131eb96756447df8393bd9052199c5439ba6f31ea02bea069f4ce29391e15" => :high_sierra
+    sha256 "8b78b8e3d57d3bc52b4e694bc40f625218fc9bbe70ef6eba72bb32afedcc67be" => :catalina
+    sha256 "4d280fd2c80fd858a0614d439617215965474e42a3b234ccfd8e68cb39051254" => :mojave
+    sha256 "4215da5f0c9b824ed1ee4ba8d0652bd9175ce807b6c38e0d81c6465e2bd4e3b0" => :high_sierra
   end
 
   depends_on "hdf5"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -1,13 +1,13 @@
 class Petsc < Formula
   desc "Portable, Extensible Toolkit for Scientific Computation (real)"
   homepage "https://www.mcs.anl.gov/petsc/"
-  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.13.1.tar.gz"
-  sha256 "74a895e44e2ff1146838aaccb7613e7626d99e0eed64ca032c87c72d084efac3"
+  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.13.2.tar.gz"
+  sha256 "6083422a7c5b8e89e5e4ccf64acade9bf8ab70245e25bca3a3da03caf74602f1"
 
   bottle do
-    sha256 "108acd68bb4ace327eee14ba47293b2ab6dba5f616638b690633e3989012ad43" => :catalina
-    sha256 "09230fa80044053a8c6a909c5c0951c21fba10d9a1c216674259870de08358f7" => :mojave
-    sha256 "0db88d5dbb6a68c2102cd9aeceaced75a10d68609439455f294257811dd98501" => :high_sierra
+    sha256 "6c88b6cb034859246488751b06e6c68ed812cb7bf8c4cc1279d19f1d5c06c0ea" => :catalina
+    sha256 "57506f743d8f180cb961c210d9060691d9eb55424b5b326ab176deb2aa441811" => :mojave
+    sha256 "4a626437fe96be52852eeaa1d5c97cb665809336694820fb59d1efa97d5a930a" => :high_sierra
   end
 
   depends_on "hdf5"

--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -3,15 +3,14 @@ class Pnpm < Formula
 
   desc "📦🚀 Fast, disk space efficient package manager"
   homepage "https://pnpm.js.org"
-  url "https://registry.npmjs.org/pnpm/-/pnpm-5.1.4.tgz"
-  sha256 "9898b1afaef9b84fb7216b7b4d59825167057fe87edbe83c2e310b17c64e56a8"
+  url "https://registry.npmjs.org/pnpm/-/pnpm-5.1.6.tgz"
+  sha256 "acc7eb2ae79b31d7e0af7511e87d5129a58ec3b65e6dbcb3c01b9928a2d67d28"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "734306e3927b3c3cad8833a55462fe0644d3647a3080fbf14d71a2af0ca661dc" => :catalina
-    sha256 "61a5fffde2dce6aefa678d51796de5cf0bad68437bb41037b594f357dd02f082" => :mojave
-    sha256 "d74d061885b64635d177ae077e3ca4fe04b9ad74594596eaa6842d3224a91425" => :high_sierra
-    sha256 "e093b4a7c5669cd9957ac3fac1bccebcc1f39250a55eae671a1b3c8060eae4ef" => :x86_64_linux
+    sha256 "d83c4bae1fe16b46e903408da309f28d17f5425a6a112382caf4f7d7550cee17" => :catalina
+    sha256 "ec80df6f3b9ecbdc9362a1acc71e2f34dd1082585a16211de1ff96cd2551e8b0" => :mojave
+    sha256 "53b86216af2b1427ccca25f9ec0fa041fe831cd7edc2e64167e91501116ef66e" => :high_sierra
   end
 
   depends_on "node"

--- a/Formula/polynote.rb
+++ b/Formula/polynote.rb
@@ -1,8 +1,8 @@
 class Polynote < Formula
   desc "The polyglot notebook with first-class Scala support"
   homepage "https://polynote.org/"
-  url "https://github.com/polynote/polynote/releases/download/0.3.10/polynote-dist.tar.gz"
-  sha256 "6bec63cda20ab8f9b253be6c37ccd82e3464ab2b6f9d33e149e3b34eefe80d62"
+  url "https://github.com/polynote/polynote/releases/download/0.3.11/polynote-dist.tar.gz"
+  sha256 "3a35a828554709d61b29ded87af4214d1bbc2eb0ff9609b291559bb2f729dfc0"
 
   bottle :unneeded
 

--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -1,15 +1,14 @@
 class Prometheus < Formula
   desc "Service monitoring system and time series database"
   homepage "https://prometheus.io/"
-  url "https://github.com/prometheus/prometheus/archive/v2.18.1.tar.gz"
-  sha256 "fffb2e7f1f112b91d5ea7330cf6b5c5270374ea2c7c51beab464c10b9886a699"
+  url "https://github.com/prometheus/prometheus/archive/v2.19.0.tar.gz"
+  sha256 "72fc19722deb0d9f11df1dce58e2ee31fd8f3d1a584848166c2a2bc2aaf8ce74"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5610fa21f66cdd3b4dcc5f033b5d7901b40bb9595440fa00c3a5adbb7dc20a95" => :catalina
-    sha256 "24b913bad385759bd3db593ce2bb260089acab92f92433f3e6ca853b0653642a" => :mojave
-    sha256 "3ed2210c442f43f7c4c4c8ec1ccc075c66be94847bc4f6ae11467d997c22c2c6" => :high_sierra
-    sha256 "bfb0cf655f107bfc13dde01dfa734abd01ad04155cc553cab63726d64cfaa279" => :x86_64_linux
+    sha256 "d4c7c8450d44414b67a4e3001f71c365a43738f9a9443def9280d83c7e1443f5" => :catalina
+    sha256 "e014754fcc0b0f6581f4e2bfd2a4182c81a03266946f75fa829a545d4453bb41" => :mojave
+    sha256 "380aa76abbf8c03dd0a2b2050c12831185e9c98e50e7542711dcf3ffefd53a02" => :high_sierra
   end
 
   depends_on "go" => :build

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -1,15 +1,14 @@
 class Qscintilla2 < Formula
   desc "Port to Qt of the Scintilla editing component"
   homepage "https://www.riverbankcomputing.com/software/qscintilla/intro"
-  url "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.4/QScintilla-2.11.4.tar.gz"
-  sha256 "723f8f1d1686d9fc8f204cd855347e984322dd5cd727891d324d0d7d187bee20"
-  revision 1
+  url "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.5/QScintilla-2.11.5.tar.gz"
+  sha256 "9361e26fd7fb7b5819a7eb92c5c1880a18de9bd3ed9dd2eb008e57388696716b"
 
   bottle do
     cellar :any
-    sha256 "d6bae2002c7d20b9db3b9d22411db1d2ea5a7391baeb4231ccecb71e8f983b3c" => :catalina
-    sha256 "7ae90f4af154cdd22237db4f6679bf62165de120ca488594afd09902ff86bf38" => :mojave
-    sha256 "2ba039eea909559f93920e34719f176e3cbaf5a7456dd5d816c86dcbc6333f9f" => :high_sierra
+    sha256 "ad21b9c248d85d8c76c34c504d5c6e8a3cf0091034c50f916cb8c50e1ca83c28" => :catalina
+    sha256 "67b316a64f594a424c77ba50f31fc4724856fb8c8f247de60de98e5a311170ad" => :mojave
+    sha256 "ce35dfa9a500a78cd89bf7bade336304434c99e4de972af80ed4fbed1f6d7318" => :high_sierra
   end
 
   depends_on "pyqt"

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -53,6 +53,14 @@ class Qt < Formula
   uses_from_macos "flex"
   uses_from_macos "sqlite"
 
+  # Fix build on Linux when the build system has AVX2
+  # Patch submitted at https://codereview.qt-project.org/c/qt/qt3d/+/303993
+  patch do
+    url "https://codereview.qt-project.org/gitweb?p=qt/qt3d.git;a=patch;h=b456a7d47a36dc3429a5e7bac7665b12d257efea"
+    sha256 "e47071f5feb6f24958b3670d83071502fe87243456b29fdc731c6eba677d9a59"
+    directory "qt3d"
+  end
+
   def install
     # Workaround for disk space issues on github actions
     # https://github.com/Homebrew/linuxbrew-core/pull/19595

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -86,7 +86,6 @@ class Qt < Formula
       args << "-no-rpath"
       args << "-system-zlib"
     elsif OS.linux?
-      args << "-system-xcb"
       args << "-R#{lib}"
       # https://bugreports.qt.io/browse/QTBUG-71564
       args << "-no-avx2"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -1,16 +1,13 @@
 class R < Formula
   desc "Software environment for statistical computing"
   homepage "https://www.r-project.org/"
-  url "https://cran.r-project.org/src/base/R-4/R-4.0.0.tar.gz"
-  sha256 "06beb0291b569978484eb0dcb5d2339665ec745737bdfb4e873e7a5a75492940"
-  revision OS.mac? ? 1 : 2
+  url "https://cran.r-project.org/src/base/R-4/R-4.0.1.tar.gz"
+  sha256 "95fe24a4d8d8f8f888460c8f5fe4311cec656e7a1722d233218bc03861bc6f32"
 
   bottle do
-    rebuild 1
-    sha256 "cff148724950c35ef1f42450259ea2775e82101af114fd306dc20df04a9d13c0" => :catalina
-    sha256 "55bf4a20c65107934cad232c4e031d88920bb7e57d4b044350c0109899f53fcc" => :mojave
-    sha256 "1ebe182e8e6dde809cbb181a63a395d906ee0ea326bb80b432ecebacbea8b889" => :high_sierra
-    sha256 "b1b5f60b80a59e85610b8a81e522246046aa97c7c6e00c5b5cd9d557c3882122" => :x86_64_linux
+    sha256 "7a7230c6b8be3f8c3d530612f79b386629696d6432876ab28a90a8b45e60afd9" => :catalina
+    sha256 "20cfa704a7ef6392fcc412edb3b5246a666921e30bfd8a17cbe1fed2922d47c5" => :mojave
+    sha256 "aa6393071b0e29c4e16cb4496ec9e9d6edcc264776bb3ad96a0b633d0842b56a" => :high_sierra
   end
 
   depends_on "pkg-config" => :build
@@ -22,13 +19,6 @@ class R < Formula
   depends_on "pcre2"
   depends_on "readline"
   depends_on "xz"
-
-  unless OS.mac?
-    depends_on "cairo"
-    depends_on "curl"
-    depends_on "pango"
-    depends_on "linuxbrew/xorg/xorg"
-  end
 
   # needed to preserve executable permissions on files without shebangs
   skip_clean "lib/R/bin", "lib/R/doc"
@@ -43,39 +33,22 @@ class R < Formula
     args = [
       "--prefix=#{prefix}",
       "--enable-memory-profiling",
+      "--without-cairo",
+      "--without-tcltk",
+      "--without-x",
+      "--with-aqua",
       "--with-lapack",
       "--enable-R-shlib",
+      "SED=/usr/bin/sed", # don't remember Homebrew's sed shim
       "--disable-java",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
     ]
-
-    # don't remember Homebrew's sed shim
-    args << "SED=/usr/bin/sed" if File.exist?("/usr/bin/sed")
-
-    if OS.mac?
-      args << "--without-cairo"
-      args << "--without-tcltk"
-      args << "--without-x"
-      args << "--with-aqua"
-    end
-
-    unless OS.mac?
-      args << "--libdir=#{lib}" # avoid using lib64 on CentOS
-      args << "--with-cairo"
-
-      # If LDFLAGS contains any -L options, configure sets LD_LIBRARY_PATH to
-      # search those directories. Remove -LHOMEBREW_PREFIX/lib from LDFLAGS.
-      ENV.remove "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
-    end
 
     # Help CRAN packages find gettext and readline
     ["gettext", "readline"].each do |f|
       ENV.append "CPPFLAGS", "-I#{Formula[f].opt_include}"
       ENV.append "LDFLAGS", "-L#{Formula[f].opt_lib}"
     end
-
-    # Avoid references to homebrew shims
-    args << "LD=ld" unless OS.mac?
 
     system "./configure", *args
     system "make"
@@ -103,10 +76,8 @@ class R < Formula
     lib.install_symlink Dir[r_home/"lib/*"]
 
     # avoid triggering mandatory rebuilds of r when gcc is upgraded
-    inreplace lib/"R/etc/Makeconf",
-      Formula["gcc"].prefix.realpath,
-      Formula["gcc"].opt_prefix,
-      OS.mac?
+    inreplace lib/"R/etc/Makeconf", Formula["gcc"].prefix.realpath,
+                                    Formula["gcc"].opt_prefix
   end
 
   def post_install
@@ -118,9 +89,8 @@ class R < Formula
   end
 
   test do
-    dylib_ext = OS.mac? ? ".dylib" : ".so"
     assert_equal "[1] 2", shell_output("#{bin}/Rscript -e 'print(1+1)'").chomp
-    assert_equal dylib_ext, shell_output("#{bin}/R CMD config DYLIB_EXT").chomp
+    assert_equal ".dylib", shell_output("#{bin}/R CMD config DYLIB_EXT").chomp
 
     system bin/"Rscript -e \'install.packages(\"gss\", \".\", \"https://cloud.r-project.org\")\'"
     assert_predicate testpath/"gss/libs/gss.so", :exist?,

--- a/Formula/rst-lint.rb
+++ b/Formula/rst-lint.rb
@@ -3,23 +3,21 @@ class RstLint < Formula
 
   desc "ReStructuredText linter"
   homepage "https://github.com/twolfson/restructuredtext-lint"
-  url "https://github.com/twolfson/restructuredtext-lint/archive/1.3.0.tar.gz"
-  sha256 "4bf9d4724f59bc05ebe1cd5192c03d4597ee95c4bbf60bd5644422e1a2558da3"
-  revision OS.mac? ? 2 : 3
+  url "https://github.com/twolfson/restructuredtext-lint/archive/1.3.1.tar.gz"
+  sha256 "469fcc0dae4f511da5a28f5d0f9b5d0f477dabca4a44cd8c84e20b8a99791b89"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "f2e1f46bf019b4f7d1b7b5e749fe729ea070539c211626d5a0e69f059c39c30a" => :catalina
-    sha256 "a4c02982ae36f5ae3d2ac2b961e0f20d77bbf5135fe789fdc64196d8f307bc92" => :mojave
-    sha256 "791c788f3bf1f97cf11513fa8c2c775268c382c8d41bd406b6d45bd4dfabdac5" => :high_sierra
-    sha256 "6cd8ed5b33d01d21cafab442cc2cf29c6fb79268cdf4f65c9cb01c6a037cfbc3" => :x86_64_linux
+    sha256 "45b5248c1e791f738f6cf2b645cec9d94d9992caa3a7d00594ad9ed2b12a11e6" => :catalina
+    sha256 "e77f597dd712f47fe96b8b83130f9a85b51a1ce9113622443d36077b020bcd01" => :mojave
+    sha256 "18c09b7c8bad5976c12dd900e827f2a036929a853707b2dd139c258278ccf548" => :high_sierra
   end
 
   depends_on "python@3.8"
 
   resource "docutils" do
-    url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
-    sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+    url "https://files.pythonhosted.org/packages/2f/e0/3d435b34abd2d62e8206171892f174b180cd37b09d57b924ca5c2ef2219d/docutils-0.16.tar.gz"
+    sha256 "c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
   end
 
   def install

--- a/Formula/shadowenv.rb
+++ b/Formula/shadowenv.rb
@@ -1,16 +1,14 @@
 class Shadowenv < Formula
   desc "Reversible directory-local environment variable manipulations"
   homepage "https://shopify.github.io/shadowenv/"
-  url "https://github.com/Shopify/shadowenv/archive/2.0.2.tar.gz"
-  sha256 "cd84eae312073b7ff3d799b9f095d16c8d97edc4700a2af0c359a1db744714e6"
-  revision 1
+  url "https://github.com/Shopify/shadowenv/archive/2.0.3.tar.gz"
+  sha256 "9d86db156b84e8df9cdc3c6084af4e538a5928fb6817567778464b10fe12a095"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "8392eac6bf8d09067b6688d6bc713d6ef36bbdf16111253f6da7f355164a6e24" => :catalina
-    sha256 "65aa5ddb76b7ebb453f4aa138847d237616d5c36a41376e5349bb9b87e5f656c" => :mojave
-    sha256 "000b9f2d6fb73be7d466fce5cf948eeba3df27261bc410f6d0064cd3a4d09e92" => :high_sierra
-    sha256 "38f91e4e7a2e5144121eced7fea1e01df5601ac01c48c094cc6505da64889697" => :x86_64_linux
+    sha256 "a8e73028069e37003f2e019230e48947913b164ebb9cdb50ea088b6398fc352c" => :catalina
+    sha256 "5022c65cf81ba99f8be31fdd879201e566f203f357e5ca88d14daaa0d9a83325" => :mojave
+    sha256 "fe0a543dc0a0ce7adba2eebc9f8f224aa55a4f63b49a4474d576d6467d604065" => :high_sierra
   end
 
   depends_on "rust" => :build

--- a/Formula/squid.rb
+++ b/Formula/squid.rb
@@ -1,15 +1,13 @@
 class Squid < Formula
   desc "Advanced proxy caching server for HTTP, HTTPS, FTP, and Gopher"
   homepage "http://www.squid-cache.org/"
-  url "http://www.squid-cache.org/Versions/v4/squid-4.11.tar.xz"
-  sha256 "4ed947612410263f57ad0e39bfd087e60fb714f028d7d3b0e469943efd34287d"
+  url "http://www.squid-cache.org/Versions/v4/squid-4.12.tar.xz"
+  sha256 "f42a03c8b3dc020722c88bf1a87da8cb0c087b2f66b41d8256c77ee1b527e317"
 
   bottle do
-    rebuild 1
-    sha256 "85f41e55245e7641f5b4f9db82f68f124073e00df97757495becfd546309fe25" => :catalina
-    sha256 "da5b02e845e3e4c74838e55a07ceae271a63a2f37c05899c63023ff130982d7b" => :mojave
-    sha256 "e0a011336aa1cadadbf932912d5835457688b7379f995466a4bc8513d2745e60" => :high_sierra
-    sha256 "6ce74d937d65f35664a500b3435b6be2ca5009b776257adb0b361e8e3057d1f5" => :x86_64_linux
+    sha256 "9910eea9598125a80e3282a09781dda3bb73b5edc9b3a155e2e41361b672c9b3" => :catalina
+    sha256 "afb188d816e0ca55a082d5dfc79cb48c0dbd879be1835bf8f774e4949cd71817" => :mojave
+    sha256 "65900a2c2ba2f9fcef8b294ec2dc26c76157e972796458fffd20b07c69e64150" => :high_sierra
   end
 
   head do

--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -1,18 +1,17 @@
 class StressNg < Formula
   desc "Stress test a computer system in various selectable ways"
   homepage "https://kernel.ubuntu.com/~cking/stress-ng/"
-  url "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.11.12.tar.xz"
-  sha256 "0ccf437ca1876a3e8a55986c6481697045203a17f5994cb2f5096cd461d18031"
+  url "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.11.13.tar.xz"
+  sha256 "adca2b21dc897e4193f3c358d459d2ef2254418a0e3dd0c208e2c94d20371be3"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "e4c93f3d965ce97cdf1111507dd8d50cc3c0e23d6d3667f11a0c3afaa4cb9cae" => :catalina
-    sha256 "d5866ef496fa55bc0dd4d89d1ae97bc4a44004a312df231cb36819f32fcc5515" => :mojave
-    sha256 "ad2ee58899ecf1a20a46f4e9f6e03d6fccdfc83505e2d68655b528e924744be4" => :high_sierra
-    sha256 "afaa7eb894d6aa01c1808a6d7e64c4fe18646aaba6a11b7b9d1df8deba5ac420" => :x86_64_linux
+    sha256 "ec9c912a17f21cfb6f060f228fc834cbfa47536725f2a6d01b3e4c85696c7bcf" => :catalina
+    sha256 "085fc372c87a3aeb8374cc9cca894eb37675c3e3d0a2a93e7e4b6f1a20531935" => :mojave
+    sha256 "5b3b204b15f649f47273aadc697915ab91b90751043f52adeeb78974700a4083" => :high_sierra
   end
 
-  depends_on :macos => :sierra if OS.mac?
+  depends_on :macos => :sierra
 
   uses_from_macos "zlib"
 

--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -1,15 +1,13 @@
 class Swig < Formula
   desc "Generate scripting interfaces to C/C++ code"
   homepage "http://www.swig.org/"
-  url "https://downloads.sourceforge.net/project/swig/swig/swig-4.0.1/swig-4.0.1.tar.gz"
-  sha256 "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
+  url "https://downloads.sourceforge.net/project/swig/swig/swig-4.0.2/swig-4.0.2.tar.gz"
+  sha256 "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
 
   bottle do
-    sha256 "d44eb5e2ae81970d131618c4ddd508d3d798e9465979a125454db75c3b9125e1" => :catalina
-    sha256 "3bc985b393a1f9979185a2b18341c6d1114532baf5447000d94247a01c224ed6" => :mojave
-    sha256 "f1df176e92ad7c3a7da641eb67dda3b4e65ed9ec8de76e3b51e366e40cc9662b" => :high_sierra
-    sha256 "26a33bc67766b89d55731ab3102b3c5808192b0d66f2d805d209cc933789d238" => :sierra
-    sha256 "91627f8411cf628a3cdd7d9f97d2118b67c340062a8d2ecc16fd27ebb93656e6" => :x86_64_linux
+    sha256 "530e80b7e7dcd28469b52fc3b668683a97b72642ebf2b6d4e6708d14f05e7286" => :catalina
+    sha256 "50afb5930cb37af2e400f0369f6da15b1d4922c1f72f45d13e7e3f8bd9d6d27b" => :mojave
+    sha256 "8bab440005b048ce454a3dd50ba608e1f85391edd73e9e40510269e923cad238" => :high_sierra
   end
 
   head do
@@ -49,19 +47,9 @@ class Swig < Formula
       puts Test.add(1, 1)
     EOS
     system "#{bin}/swig", "-ruby", "test.i"
-    if OS.mac?
-      system ENV.cc, "-c", "test.c"
-      system ENV.cc, "-c", "test_wrap.c",
-             "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
-      system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
-      assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
-    else
-      system ENV.cc, "-c", "-fPIC", "test.c"
-      system ENV.cc, "-c", "-fPIC", "test_wrap.c",
-             "-I#{RbConfig::CONFIG["rubyhdrdir"]}", "-I#{RbConfig::CONFIG["rubyarchhdrdir"]}"
-      system ENV.cc, "-shared", "test.o", "test_wrap.o", "-o", "test.so",
-             *RbConfig::CONFIG["LIBRUBYARG"].delete("'").split
-      assert_equal "2", shell_output("ruby run.rb").strip
-    end
+    system ENV.cc, "-c", "test.c"
+    system ENV.cc, "-c", "test_wrap.c", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
+    system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
+    assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
   end
 end

--- a/Formula/tengo.rb
+++ b/Formula/tengo.rb
@@ -1,14 +1,14 @@
 class Tengo < Formula
   desc "Fast script language for Go"
   homepage "https://tengolang.com"
-  url "https://github.com/d5/tengo/archive/v2.5.0.tar.gz"
-  sha256 "9e459e89d91a87eebd0398bdf22d1141d6c30359ddaf6308e3eb8bb2ce4aeaaa"
+  url "https://github.com/d5/tengo/archive/v2.6.0.tar.gz"
+  sha256 "3a1c4c53b9791da67b261929fd742d24cbd678832fdc896de382f0c4e97bc5c2"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "ff22f2b77ebc837ca71b1159a1737cb55209318fb3154f41aa98b390e2940926" => :catalina
-    sha256 "ff22f2b77ebc837ca71b1159a1737cb55209318fb3154f41aa98b390e2940926" => :mojave
-    sha256 "ff22f2b77ebc837ca71b1159a1737cb55209318fb3154f41aa98b390e2940926" => :high_sierra
+    sha256 "c2c5d13206abe7acff924d0b1d4a93b8c34ed4487e5e26d203579aa4326227b0" => :catalina
+    sha256 "c2c5d13206abe7acff924d0b1d4a93b8c34ed4487e5e26d203579aa4326227b0" => :mojave
+    sha256 "c2c5d13206abe7acff924d0b1d4a93b8c34ed4487e5e26d203579aa4326227b0" => :high_sierra
   end
 
   depends_on "go" => :build

--- a/Formula/twoping.rb
+++ b/Formula/twoping.rb
@@ -1,16 +1,15 @@
 class Twoping < Formula
   desc "Ping utility to determine directional packet loss"
   homepage "https://www.finnie.org/software/2ping/"
-  url "https://www.finnie.org/software/2ping/2ping-4.4.tar.gz"
-  sha256 "b4392abda19c9982127cbd7f21b9ed88aabec4cdda66d4789ce644c7fca084c7"
+  url "https://www.finnie.org/software/2ping/2ping-4.4.1.tar.gz"
+  sha256 "0aa52cba661abdbf51f2f344c93ec116ca2e1e4ba2e82519b8a65ae5b08b0316"
   head "https://github.com/rfinnie/2ping.git"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "35d34d2b20db56adaa08728de0346a419822efec1cf343118fef9ec777929f7f" => :catalina
-    sha256 "35d34d2b20db56adaa08728de0346a419822efec1cf343118fef9ec777929f7f" => :mojave
-    sha256 "35d34d2b20db56adaa08728de0346a419822efec1cf343118fef9ec777929f7f" => :high_sierra
-    sha256 "a0cb50c7e09c9fb3f8e730aea54528840e23d9b592bb599d3feb176df1688a6d" => :x86_64_linux
+    sha256 "c072b4dccf205261e7a5fedcbee5a3968e1a58a42772ba235a4e710652886c52" => :catalina
+    sha256 "c072b4dccf205261e7a5fedcbee5a3968e1a58a42772ba235a4e710652886c52" => :mojave
+    sha256 "c072b4dccf205261e7a5fedcbee5a3968e1a58a42772ba235a4e710652886c52" => :high_sierra
   end
 
   depends_on "python@3.8"

--- a/Formula/vulkan-headers.rb
+++ b/Formula/vulkan-headers.rb
@@ -1,15 +1,14 @@
 class VulkanHeaders < Formula
   desc "Vulkan Header files and API registry"
   homepage "https://github.com/KhronosGroup/Vulkan-Headers"
-  url "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.142.tar.gz"
-  sha256 "6770503b0e06bd45e8cb1dba1e40ad37097d1100c2de7cd45c07de3b2d383a3e"
+  url "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.143.tar.gz"
+  sha256 "8965ae2c64033576690ded2f315bef67fb8b7d49a5ad27a5b7bb41816936a618"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "51115062fdbcac4f2edd1c65cba09a19994fe32a3f6bb7dba1601833cb96ead5" => :catalina
-    sha256 "51115062fdbcac4f2edd1c65cba09a19994fe32a3f6bb7dba1601833cb96ead5" => :mojave
-    sha256 "51115062fdbcac4f2edd1c65cba09a19994fe32a3f6bb7dba1601833cb96ead5" => :high_sierra
-    sha256 "7efdfa5d89fd652672db93b975fbfd885cabd71146d784b69b28504faaa0a894" => :x86_64_linux
+    sha256 "034b6867a94b70fa754fd9f33ce67a419c054fe87be2291bbf4704ab6d052af1" => :catalina
+    sha256 "034b6867a94b70fa754fd9f33ce67a419c054fe87be2291bbf4704ab6d052af1" => :mojave
+    sha256 "034b6867a94b70fa754fd9f33ce67a419c054fe87be2291bbf4704ab6d052af1" => :high_sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -1,16 +1,15 @@
 class Wpscan < Formula
   desc "Black box WordPress vulnerability scanner"
   homepage "https://wpscan.org"
-  url "https://github.com/wpscanteam/wpscan/archive/v3.8.1.tar.gz"
-  sha256 "d2ba1e66a7c3421dfb756096cd048eacd78e4dcb5504e25153091dba2af047ee"
+  url "https://github.com/wpscanteam/wpscan/archive/v3.8.2.tar.gz"
+  sha256 "5aac100b95745bdb45031b6383b74453b209b965486197d8026a83a662412c3c"
   head "https://github.com/wpscanteam/wpscan.git"
 
   bottle do
     cellar :any
-    sha256 "6b52086c8d8dd9ad36a244bfbbaf1bc1018a193290e2fa05d16fdd353384bb3e" => :catalina
-    sha256 "39acc20f1a3e32e4894a37d61ebcdcc15231b555dc63a4933fa713328a049d66" => :mojave
-    sha256 "06ecabf210ad28c3f652b990e58c9772f487eccc0637b27a0d065a95448f52f3" => :high_sierra
-    sha256 "6530e37a288da3b46cb5fceff9ecc882ca855a4d2e4902cb7ad527cda1535876" => :x86_64_linux
+    sha256 "202f067c8019102a570f95ac29d60a5010498cedf047e3fb4cd7aab4636f0959" => :catalina
+    sha256 "d5cff4f5d3649adab8cd5195266f2e0634d2c8993714f7e59f9d8d8d0bc53dc2" => :mojave
+    sha256 "ce604ef3517c146a2922cb3d75ec18d5e740262e5c7b178565e25c07bb410f36" => :high_sierra
   end
 
   depends_on "pkg-config" => :build
@@ -18,7 +17,7 @@ class Wpscan < Formula
 
   uses_from_macos "curl"
   uses_from_macos "unzip"
-  uses_from_macos "xz" # for liblzma
+  uses_from_macos "xz" # for liblxma
   uses_from_macos "zlib"
 
   if MacOS.version < :catalina


### PR DESCRIPTION
This PR is a followup to https://github.com/Homebrew/homebrew-core/pull/55964, so that qt-5.15 can build on Linux:
  - commits 220cf6a to 8201f50 are those commits from homebrew-core and that PR,
  - commit 8201f50  fix the left-over: `-system-xcb` in no longer an option of `./configure` in qt-5.15.0. 

Here is the checklist:
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure: https://gist.github.com/e165097db929cc72d8d778c45a0ec05c.

Here is the exact error message before 8201f50:
> ERROR: Invalid value given for boolean command line option 'xcb'.

-----
