### PR TITLE
PATCHELF_RB env for test-bot

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: homebrew/ubuntu16.04:master
+    env:
+      HOMEBREW_PATCHELF_RB: 1
     steps:
         # Printing these details should always be the first step listed.
       - name: ${{github.event.client_payload.formula}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: homebrew/ubuntu16.04:master
+    env:
+      HOMEBREW_PATCHELF_RB: 1
     steps:
       - name: Update Homebrew
         run: brew update-reset


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----


`HOMEBREW_PATCHELF_RB` flag  asks the ELF reading and parsing to be done via `patchelf.rb `. 
As per @ MikeMcQuaid's request we  have decided to enable it only on linuxbrew-core CI before enabling it for all developers.
If things go well for the next 3 weeks, this commit can  be safely  reverted.

