### PR TITLE
autoconf: fix libtoolize link on Linux

### DIFF
--- a/Formula/autoconf.rb
+++ b/Formula/autoconf.rb
@@ -5,7 +5,7 @@ class Autoconf < Formula
   mirror "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz"
   sha256 "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969"
   license "GPL-2.0"
-  revision 1 unless OS.mac?
+  revision 2 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation
@@ -25,12 +25,14 @@ class Autoconf < Formula
   uses_from_macos "perl"
 
   def install
-    ENV["PERL"] = "/usr/bin/perl" if OS.mac?
+    if OS.mac?
+      ENV["PERL"] = "/usr/bin/perl"
 
-    # force autoreconf to look for and use our glibtoolize
-    inreplace "bin/autoreconf.in", "libtoolize", "glibtoolize"
-    # also touch the man page so that it isn't rebuilt
-    inreplace "man/autoreconf.1", "libtoolize", "glibtoolize"
+      # force autoreconf to look for and use our glibtoolize
+      inreplace "bin/autoreconf.in", "libtoolize", "glibtoolize"
+      # also touch the man page so that it isn't rebuilt
+      inreplace "man/autoreconf.1", "libtoolize", "glibtoolize"
+    end
 
     system "./configure", "--prefix=#{prefix}", "--with-lispdir=#{elisp}"
     system "make", "install"

--- a/Formula/autoconf.rb
+++ b/Formula/autoconf.rb
@@ -18,7 +18,6 @@ class Autoconf < Formula
     sha256 "daf70656aa9ff8b2fb612324222aa6b5e900e2705c9f555198bcd8cd798d7dd0" => :yosemite
     sha256 "d153b3318754731ff5e91b45b2518c75880993fa9d1f312a03696e2c1de0c9d5" => :mavericks
     sha256 "37e77a2e7ca6d479f0a471d5f5d828efff621bd051c1884ff1363d77c5c4675e" => :mountain_lion
-    sha256 "d8a7ca62ed0f84bbdb3c6206fc3d0b7b1222e28dcfffff2a0c7a91193204ccce" => :x86_64_linux
   end
 
   uses_from_macos "m4"


### PR DESCRIPTION
On linux, `libtoolize` is not installed as `glibtoolize`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
