### PR TITLE
wren: Fix build for Linux

### DIFF
--- a/Formula/wren.rb
+++ b/Formula/wren.rb
@@ -13,7 +13,7 @@ class Wren < Formula
   end
 
   def install
-    system "make", "-C", "projects/make.mac"
+    system "make", "-C", "projects/make#{".mac" if OS.mac?}"
     lib.install Dir["lib/*"]
     include.install Dir["src/include/*"]
     pkgshare.install "example"


### PR DESCRIPTION
make.mac omits some necessary compiler flags
(eg. -lm for using acos)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/rwhogg/78f8e5b840c11c51e60cc5c63c6c5d62**

Errors:

```
==> make -C projects/make.mac
Last 15 lines from /home/me/.cache/Homebrew/Logs/wren/01.make:
wren_core.c:(.text+0x14d9): undefined reference to `acos'
/home/linuxbrew/.linuxbrew/bin/ld: ../../lib/libwren.a(wren_core.o): in function `prim_num_mod':
wren_core.c:(.text+0x2438): undefined reference to `fmod'
/home/linuxbrew/.linuxbrew/bin/ld: ../../lib/libwren.a(wren_primitive.o): in function `validateIndexValue':
wren_primitive.c:(.text+0x37): undefined reference to `trunc'
/home/linuxbrew/.linuxbrew/bin/ld: ../../lib/libwren.a(wren_primitive.o): in function `validateIntValue':
wren_primitive.c:(.text+0x183): undefined reference to `trunc'
/home/linuxbrew/.linuxbrew/bin/ld: ../../lib/libwren.a(wren_primitive.o): in function `validateInt':
wren_primitive.c:(.text+0x1f3): undefined reference to `trunc'
/home/linuxbrew/.linuxbrew/bin/ld: ../../lib/libwren.a(wren_primitive.o): in function `calculateRange':
wren_primitive.c:(.text+0x45a): undefined reference to `trunc'
collect2: error: ld returned 1 exit status
make[1]: *** [wren_test.make:149: ../../bin/wren_test] Error 1
make: *** [Makefile:66: wren_test] Error 2
make: Leaving directory '/tmp/wren-20200701-9029-1q4e57r/wren-0.3.0/projects/make.mac'
```

-----

Note, `wren-cli` will probably need this exact same fix once it is merged into linuxbrew-core.
