### PR TITLE
wren-cli: Fix build for Linux

### DIFF
--- a/Formula/wren-cli.rb
+++ b/Formula/wren-cli.rb
@@ -12,7 +12,7 @@ class WrenCli < Formula
   end
 
   def install
-    system "make", "-C", "projects/make.mac"
+    system "make", "-C", "projects/make#{".mac" if OS.mac?}"
     bin.install "bin/wren_cli"
     pkgshare.install "example"
   end


### PR DESCRIPTION
Fix error:

make[1]: *** [wren_cli.make:257: obj/64bit/Release/darwin-proctitle.o] Error 1
../../deps/libuv/src/unix/bsd-ifaddrs.c:31:23: fatal error: net/if_dl.h: No such file or directory

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/rwhogg/6027e3d32a035b85c701721bb48ae9a9**

There's a variety of things that failed, but here's at least two:

```
Last 15 lines from /home/me/.cache/Homebrew/Logs/wren-cli/01.make:
compilation terminated.
make[1]: *** [wren_cli.make:248: obj/64bit/Release/async.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [wren_cli.make:257: obj/64bit/Release/darwin-proctitle.o] Error 1
../../deps/libuv/src/unix/bsd-ifaddrs.c:31:23: fatal error: net/if_dl.h: No such file or directory
compilation terminated.
make[1]: *** [wren_cli.make:251: obj/64bit/Release/bsd-ifaddrs.o] Error 1
../../deps/libuv/src/unix/core.c: In function 'uv__dup2_cloexec':
../../deps/libuv/src/unix/core.c:1051:34: error: 'O_CLOEXEC' undeclared (first use in this function)
       r = uv__dup3(oldfd, newfd, O_CLOEXEC);
                                  ^
../../deps/libuv/src/unix/core.c:1051:34: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [wren_cli.make:254: obj/64bit/Release/core.o] Error 1
make: *** [Makefile:42: wren_cli] Error 2
make: Leaving directory '/tmp/wren-cli-20200701-59476-bivyi8/wren-cli-0.3.0/projects/make.mac'
```

-----

Basically the same as https://github.com/Homebrew/linuxbrew-core/pull/20653