### PR TITLE
k9s 0.21.2 (new formula)

### DIFF
--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -1,5 +1,5 @@
 class K9s < Formula
-  desc "Kubernetes CLI To Manage Your Clusters In Style!"
+  desc "Kubernetes CLI to manage your clusters in style!"
   homepage "https://k9scli.io/"
   url "https://github.com/derailed/k9s.git",
       :tag      => "v0.21.2",

--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -1,0 +1,20 @@
+class K9s < Formula
+  desc "Kubernetes CLI To Manage Your Clusters In Style!"
+  homepage "https://k9scli.io/"
+  url "https://github.com/derailed/k9s.git",
+      :tag      => "v0.21.2",
+      :revision => "977791627860a0febb3c217a5322702da109ecbb"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-ldflags",
+             "-s -w -X github.com/derailed/k9s/cmd.version=#{version}
+             -X github.com/derailed/k9s/cmd.commit=#{stable.specs[:revision]}",
+             *std_go_args
+  end
+
+  test do
+    system "k9s", "version"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
k9s is an insanely handy and popular interactive CLI to deal with Kubernetes clusters. There is an official formula available here https://github.com/derailed/homebrew-k9s/blob/master/Formula/k9s.rb but I think it should be added to the core repo for more exposure.