### PR TITLE
kpcli: Fix build for Linuxbrew

### DIFF
--- a/Formula/kpcli.rb
+++ b/Formula/kpcli.rb
@@ -69,6 +69,11 @@ class Kpcli < Formula
     sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
   end
 
+  resource "Clone" do
+    url "https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/Clone-0.45.tar.gz"
+    sha256 "cbb6ee348afa95432e4878893b46752549e70dc68fe6d9e430d1d2e99079a9e6"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV.prepend_path "PERL5LIB", libexec/"lib"
@@ -82,7 +87,7 @@ class Kpcli < Formula
       "Clipboard",
       "Capture::Tiny",
     ]
-    resources << (OS.mac? ? "Mac::Pasteboard" : "Term::ReadKey")
+    resources += (OS.mac? ? ["Mac::Pasteboard"] : ["Term::ReadKey", "Clone"])
 
     resources.each do |r|
       resource(r).stage do

--- a/Formula/kpcli.rb
+++ b/Formula/kpcli.rb
@@ -64,6 +64,11 @@ class Kpcli < Formula
     sha256 "6c23113e87bad393308c90a207013e505f659274736638d8c79bac9c67cc3e19"
   end
 
+  resource "Term::ReadKey" do
+    url "https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz"
+    sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV.prepend_path "PERL5LIB", libexec/"lib"
@@ -75,9 +80,10 @@ class Kpcli < Formula
       "Term::ShellUI",
       "Data::Password",
       "Clipboard",
-      "Mac::Pasteboard",
       "Capture::Tiny",
     ]
+    resources << (OS.mac? ? "Mac::Pasteboard" : "Term::ReadKey")
+
     resources.each do |r|
       resource(r).stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"


### PR DESCRIPTION
Mac::Pasteboard fails to install on anything other than macOS.
Additionally, Homebrew-installed Perl does not come with Term::ReadKey.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. *See https://gist.github.com/rwhogg/220e235f5a111ffc51be61b64aab7dcc#file-13-perl-L7 *

-----

`Mac::Pasteboard` just refuses to install on Linux:

```
perl
Makefile.PL
INSTALL_BASE=/home/linuxbrew/.linuxbrew/Cellar/kpcli/3.4/libexec

OS unsupported
```

After removing it from the resources, `kpcli` fails at runtime for lack of `Term::ReadKey`:

```
Can't locate Term/ReadKey.pm in @INC (you may need to install the Term::ReadKey module) (@INC contains: /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.4/libexec/lib /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.4/libexec/lib/perl5/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.4/libexec/lib/perl5 /home/linuxbrew/.linuxbrew/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0 /home/linuxbrew/.linuxbrew/Cellar/perl/5.32.0/lib/perl5/5.32.0/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/Cellar/perl/5.32.0/lib/perl5/5.32.0 /home/linuxbrew/.linuxbrew/lib/perl5/site_perl/5.32.0) at /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.4/libexec/kpcli line 43.
BEGIN failed--compilation aborted at /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.4/libexec/kpcli line 43.
```

I've admittedly seen some inconsistent results with this one: one machine I tried it on also failed for lack of `Clone` but since that's listed as a "core" module in the `kpcli` source I'm not sure what to make of it.