### PR TITLE
pandoc: not relocateable on Linux

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -10,7 +10,6 @@ class Pandoc < Formula
   head "https://github.com/jgm/pandoc.git"
 
   bottle do
-    cellar :any_skip_relocation
     sha256 "be40069cb95d3de8fdf16e311998bb1e6315a635d7e93183ba771a12d3f548cd" => :catalina
     sha256 "b1f1dea0254517166a8575c5e2b2ee279ccbdb682578d62ba66a91011595fa78" => :mojave
     sha256 "98bc7e09e12d87d7c0cd372ab658bc767516c841d00502535e4dc05e0607565f" => :high_sierra


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----