### PR TITLE
meson: remove patch

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -16,9 +16,6 @@ class Meson < Formula
   depends_on "ninja"
   depends_on "python@3.8"
 
-  # https://github.com/mesonbuild/meson/issues/2567#issuecomment-504581379
-  patch :DATA
-
   def install
     version = Language::Python.major_minor_version Formula["python@3.8"].bin/"python3"
     ENV["PYTHONPATH"] = lib/"python#{version}/site-packages"
@@ -46,20 +43,3 @@ class Meson < Formula
     end
   end
 end
-__END__
---- meson-0.47.2.orig/mesonbuild/minstall.py
-+++ meson-0.47.2/mesonbuild/minstall.py
-@@ -486,8 +486,11 @@ class Installer:
-                         printed_symlink_error = True
-             if os.path.isfile(outname):
-                 try:
--                    depfixer.fix_rpath(outname, install_rpath, final_path,
--                                       install_name_mappings, verbose=False)
-+                    if install_rpath:
-+                        depfixer.fix_rpath(outname, install_rpath, final_path,
-+                                           install_name_mappings, verbose=False)
-+                    else:
-+                        print("RPATH changes at install time disabled")
-                 except SystemExit as e:
-                     if isinstance(e.code, int) and e.code == 0:
-                         pass


### PR DESCRIPTION
Supposedly fixed in v0.55.0

https://mesonbuild.com/Release-notes-for-0-55-0.html


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----