### PR TITLE
pandoc: fix installation to cabal-install v2.

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -23,9 +23,8 @@ class Pandoc < Formula
   uses_from_macos "zlib"
 
   def install
-    cabal_sandbox do
-      install_cabal_package :flags => ["embed_data_files"]
-    end
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
     (bash_completion/"pandoc").write `#{bin}/pandoc --bash-completion`
     man1.install "man/pandoc.1"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
-----

The `cabal-install` formula has been updated to `v2` however the `pandoc` formula was not updated to account for the new `cabal-install` API. This PR fixes `pandoc` installation.
