### PR TITLE
julia: new formula

### DIFF
--- a/Formula/julia.rb
+++ b/Formula/julia.rb
@@ -13,7 +13,7 @@ class Julia < Formula
   test do
     system "#{bin}/julia", "--help"
     File.write("test.jl", <<-END
-      1+1 
+      1+1
       println("Hello, brew!")
     END
     )

--- a/Formula/julia.rb
+++ b/Formula/julia.rb
@@ -1,0 +1,22 @@
+class Julia < Formula
+  desc "The Julia language"
+  homepage "https://julialang.org/"
+  url "https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+  version "1.4.2"
+  sha256 "d77311be23260710e89700d0b1113eecf421d6cf31a9cebad3f6bdd606165c28"
+  license "MIT"
+
+  def install
+    Dir["./*"].each { |f| mv f, prefix }
+  end
+
+  test do
+    system "#{bin}/julia", "--help"
+    File.write("test.jl", <<-END
+      1+1 
+      println("Hello, brew!")
+    END
+    )
+    system "#{bin}/julia", "test.jl"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This formula adds `julia` language to `linuxbrew` which is only available as Homebrew cask for Mac. The installation just downloads the generic Linux on x86 pre-built package from the [official website](https://julialang.org/downloads/). 

The language maintainers [recommend](https://github.com/JuliaLang/julia/tree/v1.4.2#binary-installation) that we use the official Julia binaries provided by them to ensure compatibility. For this reason, I have not build it from source in this PR. Julia comes with a set of patched libraries (eg. [LLVM](https://github.com/JuliaLang/julia/blob/master/doc/build/build.md#llvm)) which is the reason why the authors recommend to install the pre-built version.

On my machine `brew linkage --test julia` fails complaining that two libraries are missing:

```
  libLLVM-8jl.so
  libjulia.so.1
```

However these libraries are installed with `julia` so I am not sure how to proceed in this case to pass the test.