### PR TITLE
glibc: Fix: cannot open locale definition file `C'

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -143,7 +143,7 @@ class Glibc < Formula
 
     # Compile locale definition files
     mkdir_p lib/"locale"
-    locales = ENV.map { |k, v| v if k[/^LANG$|^LC_/] && v != "C" }.compact
+    locales = ENV.map { |k, v| v if k[/^LANG$|^LC_/] && v != "C" && !v.start_with?("C.") }.compact
     # en_US.UTF-8 is required by gawk make check
     locales = (locales + ["en_US.UTF-8"]).sort.uniq
     ohai "Installing locale data for #{locales.join(" ")}"


### PR DESCRIPTION
Fix the error:
```
brew postinstall glibc
Cellar/glibc/2.23/bin/localedef -i C -f UTF-8 C.UTF-8
cannot open locale definition file `C': No such file or directory
sh: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8)
Warning: The post-install step did not complete successfully
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This PR fixes https://github.com/Homebrew/brew/pull/8047#issuecomment-663215436

:warning: This PR is untested.