### PR TITLE
graphviz: Depend on ghostscript and groff to build

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -27,8 +27,10 @@ class Graphviz < Formula
   depends_on "libtool"
   depends_on "pango"
   depends_on "byacc" => :build unless OS.mac?
+  depends_on "ghostscript" => :build unless OS.mac? # for ps2pdf
 
   uses_from_macos "flex" => :build
+  uses_from_macos "groff" => :build
 
   on_linux do
     depends_on "byacc" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

One part of this PR is just to address the issue described [here](https://github.com/Homebrew/linuxbrew-core/pull/20730#issuecomment-658483079).

The other is for this: https://gist.githubusercontent.com/rwhogg/6d292e3006f0716e3b5af1ed3f1ad137/raw/55e6ed7aac67aa30b21cf71be4602d3f81d263d9/03.make

```
make[3]: Entering directory '/tmp/graphviz-20200722-44186-jb042m/graphviz-2.44.1/plugin/gdk'
  CC       gvplugin_gdk.lo
  CC       gvdevice_gdk.lo
  CC       gvloadimage_gdk.lo
gvdevice_gdk.c:19:35: fatal error: gdk-pixbuf/gdk-pixbuf.h: No such file or directory
compilation terminated.
gvloadimage_gdk.c:23:35: fatal error: gdk-pixbuf/gdk-pixbuf.h: No such file or directory
compilation terminated.
make[3]: *** [Makefile:758: gvdevice_gdk.lo] Error 1
```

and similar issues for GTK+, gdk-pixbuf, and librsvg.

-----
