### PR TITLE
sslscan: fix build on Linux

### DIFF
--- a/Formula/sslscan.rb
+++ b/Formula/sslscan.rb
@@ -16,9 +16,10 @@ class Sslscan < Formula
   depends_on "openssl@1.1"
 
   def install
-    # use `libcrypto.dylib` built from `openssl@1.1`
+    # use `libcrypto.dylib`/`libcrypto.a` built from `openssl@1.1`
+    libcrypto = OS.mac? ? "libcrypto.dylib" : "libcrypto.a"
     inreplace "Makefile", "static: openssl/libcrypto.a",
-                          "static: #{Formula["openssl@1.1"].opt_lib}/libcrypto.dylib"
+                          "static: #{Formula["openssl@1.1"].opt_lib}/#{libcrypto}"
 
     system "make", "static"
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Installing sslscan on Linux causes the following build error:

```
make
static

fatal: not a git repository (or any of the parent directories): .git
make: *** No rule to make target '/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib/libcrypto.dylib', needed by 'static'.  Stop.
```

The full logs are at https://gist.github.com/76e6e16ad7d91a477326a4b8a8c1c4c6. The error was introduced when sslscan was upgraded to 2.0.0 in 2036969 and openssl@1.1 was added as a dependency to prevent sslscan from building its own copy. The fix is to use `libcrypto.a` from openssl@1.1 instead of `libcrypto.dylib` when installed on Linux.