### PR TITLE
ipopt: fix for Linux

### DIFF
--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -48,7 +48,7 @@ class Ipopt < Formula
       inreplace "Makefile.inc", "@rpath/", "#{opt_lib}/" if OS.mac?
 
       # Fix for GCC 10
-      inreplace "Makefile.inc", "OPTF    = -fPIC", "OPTF    = -fPIC -fallow-argument-mismatch"
+      inreplace "Makefile.inc", "OPTF    = -fPIC", "OPTF    = -fPIC -fallow-argument-mismatch" if OS.mac?
 
       ENV.deparallelize { system "make", "d" }
 


### PR DESCRIPTION
Inreplace only need on macOS

https://github.com/Homebrew/linuxbrew-core/runs/937256467?check_suite_focus=true


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----