### PR TITLE
gcc: Depends on glibc if the host glibc is too old

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -40,6 +40,7 @@ class Gcc < Formula
   depends_on "mpfr"
   unless OS.mac?
     depends_on "binutils"
+    depends_on "glibc" if OS::Linux::Glibc.system_version < Formula["glibc"].version
     depends_on "isl@0.18"
   end
 


### PR DESCRIPTION
Reverts the change made in
https://github.com/Homebrew/linuxbrew-core/commit/88a60db8de0dabdcb8ea5ee18b562f63b1df98e7#diff-baf58e557d0debf0bd219be97ec02ab8

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

When the host's `glibc` is too old, `brew install hello` ought to install both `glibc` and `gcc`.