### PR TITLE
ocrmypdf: fix build on Linux

### DIFF
--- a/Formula/ocrmypdf.rb
+++ b/Formula/ocrmypdf.rb
@@ -32,6 +32,11 @@ class Ocrmypdf < Formula
   uses_from_macos "libxslt"
   uses_from_macos "zlib"
 
+  unless OS.mac?
+    fails_with gcc: "5"
+    depends_on "gcc@6" => :build
+  end
+
   resource "cffi" do
     url "https://files.pythonhosted.org/packages/54/1d/15eae71ab444bd88a1d69f19592dcf32b9e3166ecf427dd9243ef0d3b7bc/cffi-1.14.1.tar.gz"
     sha256 "b2a2b0d276a136146e012154baefaea2758ef1f56ae9f4e01c612b0831e0bd2f"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Full logs at https://gist.github.com/clpo13/d9bd3eb667d6e839530417cba9585bc8. The relevant error from `12.pip`:

```
gcc-5 -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -DVERSION_INFO="1.17.3" -I/tmp/pip-build-env-q4evs58_/overlay/lib/python3.8/site-packages/pybind11/include -I/home/linuxbrew/.linuxbrew/opt/python@3.8/include/python3.8 -c src/qpdf/object_convert.cpp -o build/temp.linux-x86_64-3.8/src/qpdf/object_convert.o -std=c++14 -fvisibility=hidden
src/qpdf/object_convert.cpp: In function 'QPDFObjectHandle objecthandle_encode(pybind11::handle)':
src/qpdf/object_convert.cpp:119:33: error: 'isfinite' was not declared in this scope
         if (! isfinite(as_double))
                                 ^
src/qpdf/object_convert.cpp:119:33: note: suggested alternative:
In file included from src/qpdf/object_convert.cpp:15:0:
/home/linuxbrew/.linuxbrew/Cellar/gcc/5.5.0_7/include/c++/5.5.0/cmath:604:5: note:   'std::isfinite'
     isfinite(_Tp __x)
     ^
error: command 'gcc-5' failed with exit status 1
Building wheel for pikepdf (PEP 517): finished with status 'error'
ERROR: Failed building wheel for pikepdf
```

Fixes #20908.