### PR TITLE
harfbuzz: fix build on Linux

### DIFF
--- a/Formula/harfbuzz.rb
+++ b/Formula/harfbuzz.rb
@@ -35,6 +35,10 @@ class Harfbuzz < Formula
     sha256 "4d60b681918c2b911da9a84e37386ed1fa48794d5c943ff9a7bd50eb3a255969"
   end
 
+  # Silence a warning that prevents building on Linux
+  # https://github.com/harfbuzz/harfbuzz/issues/2555
+  patch :DATA
+
   def install
     args = %w[
       --default-library=both
@@ -62,3 +66,29 @@ class Harfbuzz < Formula
     end
   end
 end
+
+__END__
+diff --git a/src/hb-gobject-enums.cc.tmpl b/src/hb-gobject-enums.cc.tmpl
+index 2ffd1c9d..26954ed2 100644
+--- a/src/hb-gobject-enums.cc.tmpl
++++ b/src/hb-gobject-enums.cc.tmpl
+@@ -30,6 +30,7 @@
+ #ifdef HAVE_GOBJECT
+
+ /* g++ didn't like older gtype.h gcc-only code path. */
++#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+ #include <glib.h>
+ #if !GLIB_CHECK_VERSION(2,29,16)
+ #undef __GNUC__
+diff --git a/src/hb-gobject-structs.cc b/src/hb-gobject-structs.cc
+index 7c46e264..a64913a9 100644
+--- a/src/hb-gobject-structs.cc
++++ b/src/hb-gobject-structs.cc
+@@ -50,6 +50,7 @@
+
+
+ /* g++ didn't like older gtype.h gcc-only code path. */
++#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+ #include <glib.h>
+ #if !GLIB_CHECK_VERSION(2,29,16)
+ #undef __GNUC__


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Full logs: https://gist.github.com/clpo13/2c3e8efd0a487623d9bd4b2bdcee3600

The patch silences a warning that harfbuzz treats as an error (see harfbuzz/harfbuzz#2555). It should fix #20888.
