### PR TITLE
httpd: Uses libxml2 from macOS

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -11,7 +11,6 @@ class Httpd < Formula
     sha256 "8c6b348427bd5c43d784dd5ae6261304e4218607cace3f264e016819c3118527" => :catalina
     sha256 "e561f825dc044083a10d85d0faa4f785d95466e827d20264702078c58fd900ac" => :mojave
     sha256 "aede7239a3d25119c493644cac072fc953f3b1d5a4c490558781ad9ac5000504" => :high_sierra
-    sha256 "ef942cdad790da41299041a08ae8a292256d0d65ce716ec9767d98494cbe3721" => :x86_64_linux
   end
 
   depends_on "apr"

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -20,6 +20,7 @@ class Httpd < Formula
   depends_on "openssl@1.1"
   depends_on "pcre"
 
+  uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -5,6 +5,7 @@ class Httpd < Formula
   mirror "https://archive.apache.org/dist/httpd/httpd-2.4.46.tar.bz2"
   sha256 "740eddf6e1c641992b22359cabc66e6325868c3c5e2e3f98faf349b61ecf41ea"
   license "Apache-2.0"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "8c6b348427bd5c43d784dd5ae6261304e4218607cace3f264e016819c3118527" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message. **See https://gist.github.com/rwhogg/146dcd522891df140b1da25ce7bd62b6**

-----

Fixes error:

```
mod_xml2enc.c:38:29: fatal error: libxml/encoding.h: No such file or directory
```

I checked the linkage, and it also claims that there's an undeclared dependency on `curl` as well. Waiting for if CI says that's a problem or not.