### PR TITLE
Remove adhoc compiler

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -70,18 +70,6 @@ class Neovim < Formula
     ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
     lua_path = "--lua-dir=#{Formula["luajit"].opt_prefix}"
 
-    cmake_compiler_args = if OS.mac?
-      %w[
-        -DCMAKE_C_COMPILER=/usr/bin/clang
-        -DCMAKE_CXX_COMPILER=/usr/bin/clang++
-      ]
-    else
-      %w[
-        -DCMAKE_C_COMPILER=/usr/bin/gcc
-        -DCMAKE_CXX_COMPILER=/usr/bin/g++
-      ]
-    end
-
     cd "deps-build" do
       %w[
         mpack/mpack-1.0.8-0.rockspec
@@ -100,7 +88,6 @@ class Neovim < Formula
 
       cd "build/src/luv" do
         cmake_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] }
-        cmake_args += cmake_compiler_args
         cmake_args += %W[
           -DCMAKE_INSTALL_PREFIX=#{buildpath}/deps-build
           -DLUA_BUILD_TYPE=System
@@ -116,7 +103,6 @@ class Neovim < Formula
 
     mkdir "build" do
       cmake_args = std_cmake_args
-      cmake_args += cmake_compiler_args
       cmake_args += %W[
         -DLIBLUV_INCLUDE_DIR=#{buildpath}/deps-build/include
         -DLIBLUV_LIBRARY=#{buildpath}/deps-build/lib/libluv.a


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

I don't see the need to force a specific compiler. It will fail if `/usr/bin/gcc` happens to be old while not specifying it will allow brew to choose its own compiler (if it happens to be installed, which was my case).