### PR TITLE
deheader: rewrite python shebang

### DIFF
--- a/Formula/deheader.rb
+++ b/Formula/deheader.rb
@@ -1,4 +1,6 @@
 class Deheader < Formula
+  include Language::Python::Shebang
+
   desc "Analyze C/C++ files for unnecessary headers"
   homepage "http://www.catb.org/~esr/deheader"
   url "http://www.catb.org/~esr/deheader/deheader-1.7.tar.gz"
@@ -14,6 +16,7 @@ class Deheader < Formula
   end
 
   depends_on "xmlto" => :build
+  depends_on "python@3.8"
 
   on_linux do
     depends_on "libarchive" => :build
@@ -25,6 +28,8 @@ class Deheader < Formula
     system "make"
     bin.install "deheader"
     man1.install "deheader.1"
+
+    rewrite_shebang detected_python_shebang, bin/"deheader"
   end
 
   test do


### PR DESCRIPTION
Fixes:

```
==> brew test --verbose deheader
==> FAILED
==> Testing deheader
==> /home/linuxbrew/.linuxbrew/Cellar/deheader/1.7/bin/deheader test.c | tr -cd 0-9
/usr/bin/env: ‘python’: No such file or directory
Error: deheader: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <"121"> expected but was
<"">.
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----