### PR TITLE
Disable the docs, they requires docbook2x which is broken.

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -68,7 +68,8 @@ class Fontconfig < Formula
                           "--with-add-fonts=#{font_dirs.join(",")}",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
-                          "--sysconfdir=#{etc}"
+                          "--sysconfdir=#{etc}",
+                          "--disable-docs"
     system "make", "install", "RUN_FC_CACHE_TEST=false"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Generating the doc requires `docbook2x`, however, it is not sufficient to add it as dependency because other error are brought up. Something about some missing library.

The audit and the style show:

```
fontconfig:
  * C: 7: col 21: Don't use OS.mac?; homebrew/core only supports macOS
  * C: 64: col 70: Don't use OS.mac?; homebrew/core only supports macOS
Error: 2 problems in 1 formula detected
```

But this was there before my PR, let me know if you would like me to delete them.