### PR TITLE
Add deprecate! and disable! reasons

### DIFF
--- a/Formula/fmdiff.rb
+++ b/Formula/fmdiff.rb
@@ -17,9 +17,6 @@ class Fmdiff < Formula
     sha256 "59d9c9d8a8759531a2f715619cfb2bce404fc7378235cf416ea5a426eb8d967f" => :yosemite
   end
 
-  # Does not have a valid open-source license
-  disable!
-
   depends_on :macos
   # Needs FileMerge.app, which is part of Xcode.
   depends_on :xcode

--- a/Formula/terraform-provisioner-ansible.rb
+++ b/Formula/terraform-provisioner-ansible.rb
@@ -18,9 +18,8 @@ class TerraformProvisionerAnsible < Formula
     sha256 "e63f913481d372db46d923d90b2b45553e015df1f6407610a5dd26b850d3ad5c" => :x86_64_linux
   end
 
-  # Does not have any license
   # https://github.com/jonmorehouse/terraform-provisioner-ansible/issues/41
-  disable!
+  disable! because: "has no license"
 
   depends_on "go" => :build
   depends_on "terraform"

--- a/Formula/tj.rb
+++ b/Formula/tj.rb
@@ -14,9 +14,8 @@ class Tj < Formula
     sha256 "c7486821bd35ae016c533c2b8a49839ede4754bf2405e5f192a431dc8b50fa99" => :x86_64_linux
   end
 
-  # Does not have any license
   # https://github.com/sgreben/tj/issues/5
-  disable!
+  disable! because: "has no license"
 
   depends_on "go" => :build
 

--- a/Formula/zinc.rb
+++ b/Formula/zinc.rb
@@ -6,7 +6,7 @@ class Zinc < Formula
 
   bottle :unneeded
 
-  deprecate!
+  deprecate! because: "has an archived upstream repository"
 
   def install
     rm_f Dir["bin/ng/{linux,win}*"]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Add `deprecate!` and `disable!` reasons for formulae. Needed for https://github.com/Homebrew/brew/pull/8530

Also removes the `disable!` line from `fmdiff` as its license is listed as `:public_domain` which is acceptable (this was likely my fault and leftover from some confusion there was in the past about licensing). Note that `fmdiff` isn't disabled in homebrew-core

CC: @MikeMcQuaid