### PR TITLE
device-mapper: add livecheck

### DIFF
--- a/Formula/device-mapper.rb
+++ b/Formula/device-mapper.rb
@@ -5,6 +5,12 @@ class DeviceMapper < Formula
     tag:      "v2_03_10",
     revision: "4d9f0606beb0acb329794909560433c08b50875d"
 
+  livecheck do
+    url :stable
+    strategy :page_match
+    regex(/href=.*?;a=tag;.*?>Release (\d+(?:\.\d+)+)</i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "152056e9f33c4d22f82a84c85d21a920d9f9a645be10f67644b8830a05fcff7e" => :x86_64_linux


### PR DESCRIPTION
<!-- - [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
-->

Currently, livecheck is getting the "latest" version from the tag `old-gdb-19990504`. This PR updates livecheck to instead check https://sourceware.org/git/lvm2.git which only lists the most recently tagged versions.

Before:

```
device-mapper : 2.03.10 ==> 19990504
```

After:

```
device-mapper : 2.03.10 ==> 2.03.10
```