### PR TITLE
adoptopenjdk@11: add livecheck

### DIFF
--- a/Formula/adoptopenjdk@11.rb
+++ b/Formula/adoptopenjdk@11.rb
@@ -5,6 +5,11 @@ class AdoptopenjdkAT11 < Formula
   version "11.0.3.7"
   sha256 "23cded2b43261016f0f246c85c8948d4a9b7f2d44988f75dad69723a7a526094"
 
+  livecheck do
+    url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/latest"
+    regex(%r{href=.*?/tag/.*?>jdk-(\d+(?:\.\d+)+\+\d*)[_<]}i)
+  end
+
   bottle :unneeded
 
   depends_on :linux


### PR DESCRIPTION
<!-- - [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
-->

Before:

```
adoptopenjdk@11 : 11.0.3.7 ==> 11-2018-11-09-05-58
```

After:

```
adoptopenjdk@11 : 11.0.3.7 ==> 11.0.8+10
```

`11.0.3.7` is equivalent to `11.0.3+7`:

```
irb(main):011:0> Version.new("11.0.3.7") == Version.new("11.0.3+7")
=> true
```

Regex ends with `[_<]` to support both `jdk-11.0.8+10_openj9-0.21.0` and `jdk-11.0.8+10`