### PR TITLE
perl: fix perl post_install on some linux systems

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -77,6 +77,8 @@ class Perl < Formula
       ENV.activate_extensions!
       ENV.setup_build_environment(formula: self)
       ENV["PERL_MM_USE_DEFAULT"] = "1"
+      # fix for https://github.com/Homebrew/linuxbrew-core/issues/4808
+      system bin/"sh", "-c", "test -f ln -s /usr/include/xlocale.h || ln -s /usr/include/locale.h /usr/include/xlocale.h"
       system bin/"cpan", "-i", "XML::Parser"
       system bin/"cpan", "-i", "XML::SAX"
     end

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -78,7 +78,7 @@ class Perl < Formula
       ENV.setup_build_environment(formula: self)
       ENV["PERL_MM_USE_DEFAULT"] = "1"
       # fix for https://github.com/Homebrew/linuxbrew-core/issues/4808
-      system bin/"sh", "-c", "test -f ln -s /usr/include/xlocale.h || ln -s /usr/include/locale.h /usr/include/xlocale.h"
+      system bin/"sh", "-c", "test -f /usr/include/xlocale.h || ln -s /usr/include/locale.h /usr/include/xlocale.h"
       system bin/"cpan", "-i", "XML::Parser"
       system bin/"cpan", "-i", "XML::SAX"
     end


### PR DESCRIPTION
On some systems, `xlocale.h` is absent (and is needed for the subsequent line `system bin/"cpan", "-i", "XML::Parser"`, which can be fixed by symlinking `locale.h`.

This error occurs for instance on GH Actions `ubuntu-latest`, when installing perl from bottle as downstream dependency of another formula that is being tested by `brew test-bot`.

refs
https://github.com/Homebrew/linuxbrew-core/issues/4808
https://github.com/Homebrew/homebrew-test-bot/issues/499
and a similar issue with `xlocale.h`
https://github.com/agracio/electron-edge-js/issues/16

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
