### PR TITLE
minikube: fix sha

### DIFF
--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -3,7 +3,7 @@ class Minikube < Formula
   homepage "https://minikube.sigs.k8s.io/"
   url "https://github.com/kubernetes/minikube.git",
       tag:      "v1.13.0",
-      revision: "eeb05350f8ba6ff3a12791fcce350c131cb2ff44"
+      revision: "0c5e9de4ca6f9c55147ae7f90af97eff5befef5f"
   license "Apache-2.0"
   head "https://github.com/kubernetes/minikube.git"
 


### PR DESCRIPTION
closes https://github.com/Homebrew/homebrew-core/issues/60746

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

It fixes the mismatch in minikube SHA commit:

```
==> Downloading https://linuxbrew.bintray.com/bottles/go-bindata-3.21.0.x86_64_linux.bottle.tar.gz
Already downloaded: /home/devhammed/.cache/Homebrew/downloads/55706724bcb823f0fb9fa2de4b02eada4fe361a0cd0cd57a5ae13172984cb57f--go-bindata-3.21.0.x86_64_linux.bottle.tar.gz
==> Cloning https://github.com/kubernetes/minikube.git
Updating /home/devhammed/.cache/Homebrew/minikube--git
==> Checking out tag v1.13.0
HEAD is now at 0c5e9de Merge pull request #9182 from sharifelgamal/fix-release-make
HEAD is now at 0c5e9de Merge pull request #9182 from sharifelgamal/fix-release-make
Entering 'site/themes/docsy'
Synchronizing submodule url for 'assets/vendor/Font-Awesome'
Synchronizing submodule url for 'assets/vendor/bootstrap'
Entering 'site/themes/docsy/assets/vendor/Font-Awesome'
Entering 'site/themes/docsy/assets/vendor/bootstrap'
/home/devhammed/.cache/Homebrew/minikube--git/site/themes/docsy
/home/devhammed/.cache/Homebrew/minikube--git/site/themes/docsy/assets/vendor/Font-Awesome
/home/devhammed/.cache/Homebrew/minikube--git/site/themes/docsy/assets/vendor/bootstrap
Error: v1.13.0 tag should be eeb05350f8ba6ff3a12791fcce350c131cb2ff44
but is actually 0c5e9de4ca6f9c55147ae7f90af97eff5befef5f
```

After fixing:

![Screenshot from 2020-09-14 16-18-06](https://user-images.githubusercontent.com/22827908/93104613-00675f00-f6a6-11ea-8b04-6de13ef7b6fc.png)
