### PR TITLE
.github/workflows/tests: Delete step for non-existent `tests-linux.yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,20 +31,6 @@ jobs:
 
     - run: brew test-bot --only-tap-syntax
 
-    - name: Check .github/workflows/tests-linux.yml formulae coverage
-      run: |
-        FILES=$(grep -oE 'Formula/[a-z0-9_\.\-]+' .github/workflows/tests-linux.yml)
-        for FILE in $FILES; do
-          if [ ! -f "$FILE" ]; then
-            echo ".github/workflows/tests-linux.yml is testing a non existing file: $FILE"
-            exit 1
-          fi
-          if [ ! grep -q "depends_on :linux" "$FILE"]; then
-            echo "$FILE is not a linux-only formula."
-            exit 1
-          fi
-        done
-
   tests:
     needs: tap_syntax
     if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'Merge') == false


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~
- [x] ~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~

-----

- The file that this `grep`s in was "deleted after merge" in 5cceb3e06cf1b65bf00df8bc8306bdbcfbab45df, so `tap-syntax` CI on PRs after that was [failing](https://github.com/Homebrew/linuxbrew-core/runs/1119195262#step:6:18):

```
Run FILES=$(grep -oE 'Formula/[a-z0-9_\.\-]+' .github/workflows/tests-linux.yml)
grep: .github/workflows/tests-linux.yml: No such file or directory
[error] Process completed with exit code 2.
```

----

It's been a while since I made a Linux contribution, and even longer since I touched CI, so if there's a better way of doing this - or if the `tests-linux.yml` file should still exist here - then let me know. But failing CI wasn't a good thing for contributors.
