### PR TITLE
systemd: Stop rewriting the Python shebang line

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -31,8 +31,6 @@ class Systemd < Formula
   uses_from_macos "expat"
 
   def install
-    Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")
-
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
     # Needed by intltool (xml::parser)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- `Language::Python.rewrite_python_shebang` is deprecated. I tried replacing it, then I did a `brew install -si systemd` and inspected what it was replacing to see if it was even still valid given the formula was updated recently anyway - `/usr/bin/env python3`.
- The install completes successfully without the rewriting, and the test passes. Let's see what test-bot says...
- Potentially fixes #21135. Failure logs are in that issue.
