### PR TITLE
qt: Remove failing `inreplace` for Python 3

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -102,10 +102,6 @@ class Qt < Formula
       args -= ["-proprietary-codecs"]
     end
 
-    inreplace %w[qtdeclarative/qtdeclarative.pro qtdeclarative/src/3rdparty/masm/masm.pri] do |s|
-      s.gsub! "python ", "python3 "
-    end
-
     system "./configure", *args
 
     # Remove reference to shims directory


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- This was reported as failing (confirmed by me) in #21130.
- I don't know if any more `inreplace`s are needed if files have moved - we'll see from CI as I don't have time right now to let a `qt` build run. 😭
