### PR TITLE
bazel: JAVA_HOME is set to MacOS style directory instead of Linux style directory

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -43,9 +43,9 @@ class Bazel < Formula
       system "./compile.sh"
       system "./output/bazel",
              "--output_user_root",
-             "--cxxopt=-std=c++11",
              buildpath/"output_user_root",
              "build",
+             "--cxxopt=-std=c++11",
              "scripts:bash_completion"
       bin.install "scripts/packages/bazel.sh" => "bazel"
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -14,6 +14,14 @@ class Bazel < Formula
 
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
+  
+  on_linux do
+    fails_with gcc: "5"
+    fails_with gcc: "6"
+    fails_with gcc: "7"
+    fails_with gcc: "8"
+    depends_on "gcc@9"
+  end
 
   uses_from_macos "zip"
 
@@ -22,15 +30,24 @@ class Bazel < Formula
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
     # Force Bazel to use openjdk@11
-    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix/"."
-    ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk"
+    
+    ENV["JAVA_HOME"] = if OS.mac?
+      Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home"
+    else
+      Formula["openjdk@11"].opt_prefix
+    end
+
+    ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk --verbose_failures"
+    ENV["VERBOSE"] = "yes"
 
     (buildpath/"sources").install buildpath.children
 
     cd "sources" do
-      system "./compile.sh"
+      system "./compile.sh",
+             "--env=std"
       system "./output/bazel",
              "--output_user_root",
+             *("--cxxopt=-std=c++11" unless OS.mac?),
              buildpath/"output_user_root",
              "build",
              "scripts:bash_completion"
@@ -38,8 +55,7 @@ class Bazel < Formula
       bin.install "scripts/packages/bazel.sh" => "bazel"
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
       (libexec/"bin").install "output/bazel" => "bazel-real"
-      bin.env_script_all_files(libexec/"bin",
-        JAVA_HOME: Formula["openjdk@11"].opt_prefix/".")
+      bin.env_script_all_files(libexec/"bin", JAVA_HOME: ENV["JAVA_HOME"])
 
       bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
       zsh_completion.install "scripts/zsh_completion/_bazel"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -14,37 +14,44 @@ class Bazel < Formula
 
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
-  uses_from_macos "zip"
+  
   on_linux do
+    fails_with gcc: "5"
+    fails_with gcc: "6"
+    fails_with gcc: "7"
+    fails_with gcc: "8"
     depends_on "gcc@9"
   end
-  fails_with gcc: "5"
-  fails_with gcc: "6"
-  fails_with gcc: "7"
-  fails_with gcc: "8"
+
+  uses_from_macos "zip"
 
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
     # Force Bazel to use openjdk@11
+    
     ENV["JAVA_HOME"] = if OS.mac?
       Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home"
     else
       Formula["openjdk@11"].opt_prefix
     end
+
     ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk --verbose_failures"
     ENV["VERBOSE"] = "yes"
+
     (buildpath/"sources").install buildpath.children
+
     cd "sources" do
       system "./compile.sh",
              "--env=std"
       system "./output/bazel",
              "--output_user_root",
-             "--cxxopt=-std=c++11",
+             *("--cxxopt=-std=c++11" unless OS.mac?),
              buildpath/"output_user_root",
-             "build",
+             "build --cxxopt=-std=c++11",
              "scripts:bash_completion"
+
       bin.install "scripts/packages/bazel.sh" => "bazel"
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
       (libexec/"bin").install "output/bazel" => "bazel-real"
@@ -77,7 +84,7 @@ class Bazel < Formula
     EOS
 
     system bin/"bazel",
-           "build",
+           "build --cxxopt=-std=c++11",
            "//:bazel-test"
     assert_equal "Hi!\n", pipe_output("bazel-bin/bazel-test")
 

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -14,14 +14,12 @@ class Bazel < Formula
 
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
- 
   uses_from_macos "zip"
-  
+  fails_with gcc: "5"
+  fails_with gcc: "6"
+  fails_with gcc: "7"
+  fails_with gcc: "8"
   on_linux do
-    fails_with gcc: "5"
-    fails_with gcc: "6"
-    fails_with gcc: "7"
-    fails_with gcc: "8"
     depends_on "gcc@9"
   end
 

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -38,12 +38,11 @@ class Bazel < Formula
     (buildpath/"sources").install buildpath.children
     cd "sources" do
       system "./compile.sh",
-             "--cxxopt=-std=c++11"
       system "./output/bazel",
              "--output_user_root",
              "--cxxopt=-std=c++11",
              buildpath/"output_user_root",
-             "build --cxxopt=-std=c++11",
+             "build",
              "scripts:bash_completion"
       bin.install "scripts/packages/bazel.sh" => "bazel"
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
@@ -77,7 +76,7 @@ class Bazel < Formula
     EOS
 
     system bin/"bazel",
-           "build --cxxopt=-std=c++11",
+           "build",
            "//:bazel-test"
     assert_equal "Hi!\n", pipe_output("bazel-bin/bazel-test")
 

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -14,6 +14,8 @@ class Bazel < Formula
 
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
+ 
+  uses_from_macos "zip"
   
   on_linux do
     fails_with gcc: "5"
@@ -22,8 +24,6 @@ class Bazel < Formula
     fails_with gcc: "8"
     depends_on "gcc@9"
   end
-
-  uses_from_macos "zip"
 
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -27,7 +27,7 @@ class Bazel < Formula
     ENV["EMBED_LABEL"] = "#{version}-homebrew"
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
-    # Force Bazel to use openjdk@11 
+    # Force Bazel to use openjdk@11
     ENV["JAVA_HOME"] = if OS.mac?
       Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home"
     else

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -41,7 +41,7 @@ class Bazel < Formula
              "--env=std"
       system "./output/bazel",
              "--output_user_root",
-             *("--cxxopt=-std=c++11" unless OS.mac?),
+             "--cxxopt=-std=c++11",
              buildpath/"output_user_root",
              "build",
              "scripts:bash_completion"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -14,10 +14,13 @@ class Bazel < Formula
 
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
+
   uses_from_macos "zip"
+
   on_linux do
     depends_on "gcc@9"
   end
+
   fails_with gcc: "5"
   fails_with gcc: "6"
   fails_with gcc: "7"
@@ -37,7 +40,7 @@ class Bazel < Formula
     ENV["VERBOSE"] = "yes"
     (buildpath/"sources").install buildpath.children
     cd "sources" do
-      system "./compile.sh",
+      system "./compile.sh"
       system "./output/bazel",
              "--output_user_root",
              "--cxxopt=-std=c++11",

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -14,44 +14,37 @@ class Bazel < Formula
 
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
-  
+  uses_from_macos "zip"
   on_linux do
-    fails_with gcc: "5"
-    fails_with gcc: "6"
-    fails_with gcc: "7"
-    fails_with gcc: "8"
     depends_on "gcc@9"
   end
-
-  uses_from_macos "zip"
+  fails_with gcc: "5"
+  fails_with gcc: "6"
+  fails_with gcc: "7"
+  fails_with gcc: "8"
 
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
     # Force Bazel to use openjdk@11
-    
     ENV["JAVA_HOME"] = if OS.mac?
       Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home"
     else
       Formula["openjdk@11"].opt_prefix
     end
-
     ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk --verbose_failures"
     ENV["VERBOSE"] = "yes"
-
     (buildpath/"sources").install buildpath.children
-
     cd "sources" do
       system "./compile.sh",
              "--env=std"
       system "./output/bazel",
              "--output_user_root",
-             *("--cxxopt=-std=c++11" unless OS.mac?),
+             "--cxxopt=-std=c++11",
              buildpath/"output_user_root",
              "build --cxxopt=-std=c++11",
              "scripts:bash_completion"
-
       bin.install "scripts/packages/bazel.sh" => "bazel"
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
       (libexec/"bin").install "output/bazel" => "bazel-real"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -27,19 +27,15 @@ class Bazel < Formula
     ENV["EMBED_LABEL"] = "#{version}-homebrew"
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
-    # Force Bazel to use openjdk@11
-    
+    # Force Bazel to use openjdk@11 
     ENV["JAVA_HOME"] = if OS.mac?
       Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home"
     else
       Formula["openjdk@11"].opt_prefix
     end
-
     ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk --verbose_failures"
     ENV["VERBOSE"] = "yes"
-
     (buildpath/"sources").install buildpath.children
-
     cd "sources" do
       system "./compile.sh",
              "--env=std"
@@ -49,7 +45,6 @@ class Bazel < Formula
              buildpath/"output_user_root",
              "build",
              "scripts:bash_completion"
-
       bin.install "scripts/packages/bazel.sh" => "bazel"
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
       (libexec/"bin").install "output/bazel" => "bazel-real"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -15,13 +15,13 @@ class Bazel < Formula
   depends_on "python@3.8" => :build
   depends_on "openjdk@11"
   uses_from_macos "zip"
+  on_linux do
+    depends_on "gcc@9"
+  end
   fails_with gcc: "5"
   fails_with gcc: "6"
   fails_with gcc: "7"
   fails_with gcc: "8"
-  on_linux do
-    depends_on "gcc@9"
-  end
 
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -38,7 +38,7 @@ class Bazel < Formula
     (buildpath/"sources").install buildpath.children
     cd "sources" do
       system "./compile.sh",
-             "--env=std"
+             "--cxxopt=-std=c++11"
       system "./output/bazel",
              "--output_user_root",
              "--cxxopt=-std=c++11",

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -81,6 +81,8 @@ class Bazel < Formula
 
     system bin/"bazel",
            "build",
+           "--action_env=#{std_cmake_args}",
+           "--cxxopt=-std=c++11",
            "//:bazel-test"
     assert_equal "Hi!\n", pipe_output("bazel-bin/bazel-test")
 

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -45,6 +45,7 @@ class Bazel < Formula
              "--output_user_root",
              buildpath/"output_user_root",
              "build",
+             "--action_env=#{std_cmake_args}",
              "--cxxopt=-std=c++11",
              "scripts:bash_completion"
       bin.install "scripts/packages/bazel.sh" => "bazel"

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -22,7 +22,7 @@ class Bazel < Formula
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
     # Force Bazel to use openjdk@11
-    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home"
+    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix/"."
     ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk"
 
     (buildpath/"sources").install buildpath.children
@@ -39,7 +39,7 @@ class Bazel < Formula
       ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
       (libexec/"bin").install "output/bazel" => "bazel-real"
       bin.env_script_all_files(libexec/"bin",
-        JAVA_HOME: Formula["openjdk@11"].opt_libexec/"openjdk.jdk/Contents/Home")
+        JAVA_HOME: Formula["openjdk@11"].opt_prefix/".")
 
       bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
       zsh_completion.install "scripts/zsh_completion/_bazel"


### PR DESCRIPTION
The directory for Java installations is not in "Contents/Home/". This directory structure exists in MacOS but not in Linux. This formula does not work on Linux due to the incorrect environment variable, because Java cannot be found correctly. Instead, the opt_prefix directory should be used.

Based on https://docs.oracle.com/javase/10/install/installed-directory-structure-jdk-and-jre.htm and testing on Ubuntu.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
