### PR TITLE
xctool: the formula does depend on xcode and macos

### DIFF
--- a/Formula/xctool.rb
+++ b/Formula/xctool.rb
@@ -14,7 +14,7 @@ class Xctool < Formula
   end
 
   depends_on :macos
-  depends_on xcode: "7.0" if OS.mac?
+  depends_on xcode: "7.0"
 
   def install
     xcodebuild "-workspace", "xctool.xcworkspace",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
