### PR TITLE
jasper: use freeglut on Linux

### DIFF
--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -16,21 +16,26 @@ class Jasper < Formula
 
   def install
     mkdir "build" do
-      # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
-      # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
-      glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework" if OS.mac?
+      if OS.mac?
+        # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
+        # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
+        glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework" if OS.mac?
+        os_cmake_args = ("-DGLUT_glut_LIBRARY=#{glut_lib}")
+      else
+        os_cmake_args = ("-DJAS_ENABLE_OPENGL=false")
+      end
 
       system "cmake", "..",
-        *("-DGLUT_glut_LIBRARY=#{glut_lib}" if OS.mac?),
         "-DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=false",
+        *os_cmake_args,
         *std_cmake_args
       system "make"
       system "make", "install"
       system "make", "clean"
 
       system "cmake", "..",
-        "-DGLUT_glut_LIBRARY=#{glut_lib}",
         "-DJAS_ENABLE_SHARED=OFF",
+        *os_cmake_args,
         *std_cmake_args
       system "make"
       lib.install "src/libjasper/libjasper.a"

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -20,9 +20,9 @@ class Jasper < Formula
         # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
         # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
         glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework" if OS.mac?
-        os_cmake_args = ("-DGLUT_glut_LIBRARY=#{glut_lib}")
+        os_cmake_args = ["-DGLUT_glut_LIBRARY=#{glut_lib}"]
       else
-        os_cmake_args = ("-DJAS_ENABLE_OPENGL=false")
+        os_cmake_args = ["-DJAS_ENABLE_OPENGL=false"]
       end
 
       system "cmake", "..",

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -12,17 +12,17 @@ class Jasper < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "freeglut" unless OS.mac?
   depends_on "jpeg"
 
   def install
     mkdir "build" do
+      os_cmake_args = []
       if OS.mac?
         # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
         # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
         glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework" if OS.mac?
-        os_cmake_args = ["-DGLUT_glut_LIBRARY=#{glut_lib}"]
-      else
-        os_cmake_args = ["-DJAS_ENABLE_OPENGL=false"]
+        os_cmake_args.push "-DGLUT_glut_LIBRARY=#{glut_lib}"
       end
 
       system "cmake", "..",

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -21,7 +21,7 @@ class Jasper < Formula
       if OS.mac?
         # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
         # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
-        glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework" if OS.mac?
+        glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"
         os_cmake_args.push "-DGLUT_glut_LIBRARY=#{glut_lib}"
       end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  *Sorry, wasn't able to confirm this locally.*
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
  *Here's the relevant part of the error log from running `brew install jasper`:*
  ```
  cmake
  ..
  -DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=false
  -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG
  -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
  -DCMAKE_INSTALL_PREFIX=/home/linuxbrew/.linuxbrew/Cellar/jasper/2.0.22
  -DCMAKE_BUILD_TYPE=Release
  -DCMAKE_FIND_FRAMEWORK=LAST
  -DCMAKE_VERBOSE_MAKEFILE=ON
  -Wno-dev

  -- The C compiler identification is GNU 5.5.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/gcc-5 - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  Software version: 2.0.22
  Shared library ABI version: 4
  Shared library build version: 4.0.0
  JAS_MULTICONFIGURATION_GENERATOR 0
  CMake Error at /home/linuxbrew/.linuxbrew/Cellar/cmake/3.18.4/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
    Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY
    OPENGL_INCLUDE_DIR)
  Call Stack (most recent call first):
    /home/linuxbrew/.linuxbrew/Cellar/cmake/3.18.4/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
    /home/linuxbrew/.linuxbrew/Cellar/cmake/3.18.4/share/cmake/Modules/FindOpenGL.cmake:433 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
    build/cmake/modules/JasOpenGL.cmake:7 (find_package)
    CMakeLists.txt:206 (include)
  ```

-----

https://github.com/jasper-software/jasper/pull/248 fixed a GLUT-related build issue, which seems to have exposed an issue with the Linux build of JasPer.

Since there doesn't appear to be an existing build dependency on a GLUT library on Linux, I simply disabled the OpenGL build flag.

Definitely feel free to make or suggest style tweaks -- not sure what's preferred by Linuxbrew maintainers.