### PR TITLE
pyenv: migrate to python@3.9

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -5,6 +5,7 @@ class Pyenv < Formula
   sha256 "a36f11a9e35bb3354e820fe2e9d258208624703506878fc6b7466d646b59d782"
   license "MIT"
   version_scheme 1
+  revision 1 unless OS.mac?
   head "https://github.com/pyenv/pyenv.git"
 
   livecheck do
@@ -17,14 +18,13 @@ class Pyenv < Formula
     sha256 "2f4c78fd8cce10de8e9fb48a43c7cd51003e7a87c3cba9e4c3942d72f331df58" => :catalina
     sha256 "a3f8395adbc0644940fa03f41807fac246b997d10ae990f549e016699a2b7e51" => :mojave
     sha256 "d4a573a9116ee1f474e4a77517af5c9dfaefe5ebb9cf7f26d2cc9ac872fe1155" => :high_sierra
-    sha256 "8d6415989eafa27a8c665534bb257ebeedd8adee8be4b8776bc7ecbec8fbfb43" => :x86_64_linux
   end
 
   depends_on "autoconf"
   depends_on "openssl@1.1"
   depends_on "pkg-config"
   depends_on "readline"
-  depends_on "python@3.8" unless OS.mac?
+  depends_on "python@3.9" unless OS.mac?
 
   uses_from_macos "bzip2"
   uses_from_macos "libffi"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

These 5 formulae have `bottle :unneeded`:
``` console
$ brew uses --include-build pyenv
pyenv-ccache
pyenv-pip-migrate
pyenv-virtualenv
pyenv-virtualenvwrapper
pyenv-which-ext
```

Current dependency:
``` console
$ brew deps --tree --include-build --include-test pyenv
pyenv
├── autoconf
│   ├── m4
│   └── perl
│       ├── expat
│       │   └── libbsd
│       ├── gdbm
│       └── berkeley-db
│           └── openssl@1.1
├── openssl@1.1
├── pkg-config
├── readline
│   └── ncurses
│       ├── pkg-config
│       └── gpatch
├── python@3.8
│   ├── pkg-config
│   ├── gdbm
│   ├── openssl@1.1
│   ├── readline
│   │   └── ncurses
│   │       ├── pkg-config
│   │       └── gpatch
│   ├── sqlite
│   │   ├── readline
│   │   │   └── ncurses
│   │   │       ├── pkg-config
│   │   │       └── gpatch
│   │   └── zlib
│   ├── xz
│   ├── bzip2
│   ├── libffi
│   ├── ncurses
│   │   ├── pkg-config
│   │   └── gpatch
│   ├── unzip
│   │   └── bzip2
│   ├── xz
│   └── zlib
├── bzip2
├── libffi
├── ncurses
│   ├── pkg-config
│   └── gpatch
├── xz
└── zlib
```