### PR TITLE
portmidi: fix build on Linux

### DIFF
--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -3,7 +3,7 @@ class Portmidi < Formula
   homepage "https://sourceforge.net/projects/portmedia/"
   url "https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip"
   sha256 "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
-  revision OS.mac? ? 2 : 3
+  revision 2
 
   livecheck do
     url :stable

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -20,22 +20,131 @@ class Portmidi < Formula
 
   depends_on "cmake" => :build
 
+  depends_on "openjdk" unless OS.mac?
+
+  # Fix incorrect use of CMAKE_CACHEFILE_DIR that results in output dir being set to /Release
+  # (see https://gitlab.kitware.com/cmake/cmake/-/issues/18168#note_432059).
+  # Also fixes https://stackoverflow.com/a/14226042/473909.
+  patch :DATA unless OS.mac?
+
   def install
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra || MacOS.version == :el_capitan
+    if OS.mac?
+      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra || MacOS.version == :el_capitan
 
-    inreplace "pm_mac/Makefile.osx", "PF=/usr/local", "PF=#{prefix}"
+      inreplace "pm_mac/Makefile.osx", "PF=/usr/local", "PF=#{prefix}"
 
-    # need to create include/lib directories since make won't create them itself
-    include.mkpath
-    lib.mkpath
+      # need to create include/lib directories since make won't create them itself
+      include.mkpath
+      lib.mkpath
 
-    # Fix outdated SYSROOT to avoid:
-    # No rule to make target `/Developer/SDKs/MacOSX10.5.sdk/...'
-    inreplace "pm_common/CMakeLists.txt",
-              "set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.5.sdk CACHE",
-              "set(CMAKE_OSX_SYSROOT /#{MacOS.sdk_path} CACHE"
+      # Fix outdated SYSROOT to avoid:
+      # No rule to make target `/Developer/SDKs/MacOSX10.5.sdk/...'
+      inreplace "pm_common/CMakeLists.txt",
+                "set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.5.sdk CACHE",
+                "set(CMAKE_OSX_SYSROOT /#{MacOS.sdk_path} CACHE"
 
-    system "make", "-f", "pm_mac/Makefile.osx"
-    system "make", "-f", "pm_mac/Makefile.osx", "install"
+      system "make", "-f", "pm_mac/Makefile.osx"
+      system "make", "-f", "pm_mac/Makefile.osx", "install"
+    else
+      ENV.deparallelize
+      ENV["JAVA_HOME"] = Formula["openjdk"].libexec
+
+      # replace hard-coded prefixes
+      dirs = ["pm_common", "pm_dylib", "pm_java"]
+      dirs.each do |d|
+        inreplace "#{d}/CMakeLists.txt", "/usr/local", prefix
+      end
+      inreplace "pm_java/CMakeLists.txt", "/usr/share/java", libexec
+
+      system "cmake", ".", *std_cmake_args
+
+      system "make"
+      system "make", "install"
+
+      rm bin/"pmdefaults"
+      bin.write_jar_script libexec/"pmdefaults.jar", "pmdefaults", "-Djava.library.path=#{lib}"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include "portmidi.h"
+
+      int main() {
+      Pm_Initialize();
+      Pm_Terminate();
+      }
+    EOS
+
+    system ENV.cc, testpath/"test.c", "-I#{include}", "-L#{lib}", "-lportmidi", "-o", "test"
+    system "./test"
   end
 end
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4919b78..ad0ba09 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,12 +9,12 @@ if(UNIX)
+   set(CMAKE_BUILD_TYPE Release CACHE STRING 
+       "Semicolon-separate list of supported configuration types")
+   # set default directories but don't override cached values...
+-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CACHEFILE_DIR}/${CMAKE_BUILD_TYPE}
++  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+       CACHE STRING "libraries go here")
+-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CACHEFILE_DIR}/${CMAKE_BUILD_TYPE}
++  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+       CACHE STRING "libraries go here")
+   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY 
+-      ${CMAKE_CACHEFILE_DIR}/${CMAKE_BUILD_TYPE}
++      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+       CACHE STRING "executables go here")
+ 
+ else(UNIX)
+@@ -54,13 +54,13 @@ if(UNIX)
+   # then every other path is left alone
+   if(CMAKE_LIBRARY_OUTPUT_DIRECTORY MATCHES ${BAD_DIR})
+     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY 
+-        ${CMAKE_CACHEFILE_DIR}/${CMAKE_BUILD_TYPE}
++        ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+         CACHE STRING "executables go here" FORCE)
+     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY 
+-        ${CMAKE_CACHEFILE_DIR}/${CMAKE_BUILD_TYPE}
++        ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+         CACHE STRING "libraries go here" FORCE)
+     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY 
+-        ${CMAKE_CACHEFILE_DIR}/${CMAKE_BUILD_TYPE}
++        ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+         CACHE STRING "libraries go here" FORCE)
+   endif(CMAKE_LIBRARY_OUTPUT_DIRECTORY MATCHES ${BAD_DIR})
+ endif(UNIX)
+diff --git a/pm_java/CMakeLists.txt b/pm_java/CMakeLists.txt
+index a350620..02720bb 100644
+--- a/pm_java/CMakeLists.txt
++++ b/pm_java/CMakeLists.txt
+@@ -16,12 +16,12 @@ if(UNIX)
+         COMMAND javac -classpath . pmdefaults/PmDefaultsFrame.java
+ 	MAIN_DEPENDENCY pmdefaults/PmDefaultsFrame.java
+ 	DEPENDS pmdefaults/PmDefaults.java
+-	WORKING_DIRECTORY pm_java)
++	WORKING_DIRECTORY .)
+     add_custom_command(OUTPUT pmdefaults/PmDefaults.class
+         COMMAND javac -classpath . pmdefaults/PmDefaults.java
+ 	MAIN_DEPENDENCY pmdefaults/PmDefaults.java
+ 	DEPENDS pmdefaults/PmDefaultsFrame.java
+-	WORKING_DIRECTORY pm_java)
++	WORKING_DIRECTORY .)
+     add_custom_command(OUTPUT ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/pmdefaults.jar
+         COMMAND	cp pmdefaults/portmusic_logo.png .
+         COMMAND	jar cmf pmdefaults/manifest.txt pmdefaults.jar
+@@ -32,8 +32,8 @@ if(UNIX)
+ 	COMMAND rm portmusic_logo.png
+ 	MAIN_DEPENDENCY pmdefaults/PmDefaults.class
+ 	DEPENDS ${PMDEFAULTS_ALL_CLASSES}
+-	WORKING_DIRECTORY pm_java)
+-    add_custom_target(pmdefaults_target ALL 
++	WORKING_DIRECTORY .)
++    add_custom_target(pmdefaults_target ALL
+         DEPENDS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/pmdefaults.jar)
+     # message(STATUS "add_custom_target: pmdefaults.jar")
+ 

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -3,7 +3,7 @@ class Portmidi < Formula
   homepage "https://sourceforge.net/projects/portmedia/"
   url "https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip"
   sha256 "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
-  revision 2
+  revision OS.mac? ? 2 : 3
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Build failure logs: https://gist.github.com/5d3a50b178eb30c23598ca6af55306ac. Java is a requirement of the build, so I included openjdk as a dependency on Linux. The patch at the end ensures built files are put in the right place in the build directory, and the `inreplace` calls ensure everything gets installed into the right Homebrew directories instead of `/usr/local` or `/usr/share`, which are hardcoded in multiple places.