### PR TITLE
Update youtube-dl links and disable HEAD for now

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -5,12 +5,6 @@ class YoutubeDl < Formula
   sha256 "67fb9bfa30f5b8f06227c478a8a6ed04af1f97ad4e81dd7e2ce518df3e275391"
   license "Unlicense"
 
-  #HEAD is disabled as https://github.com/ytdl-org/youtube-dl/ is taken down due to DMCA takedown notice by RIAA (https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md).
-  #head do
-  #  url "https://github.com/ytdl-org/youtube-dl.git"
-  #  depends_on "pandoc" => :build
-  #end
-
   bottle :unneeded
 
   def install

--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -1,14 +1,15 @@
 class YoutubeDl < Formula
   desc "Download YouTube videos from the command-line"
-  homepage "https://ytdl-org.github.io/youtube-dl/"
-  url "https://github.com/ytdl-org/youtube-dl/releases/download/2020.09.20/youtube-dl-2020.09.20.tar.gz"
-  sha256 "ac1a799cf968345bf29089ed2e5c5d4f4a32031625d808369e61b6362d1c7cde"
+  homepage "https://yt-dl.org"
+  url "http://abf-downloads.openmandriva.org/ytdl/youtube-dl-2020.09.20.tar.gz"
+  sha256 "ead79e9248aaf7667f015da2ccd4bde44a8948fa980f82965609cdca88ad285e"
   license "Unlicense"
 
-  head do
-    url "https://github.com/ytdl-org/youtube-dl.git"
-    depends_on "pandoc" => :build
-  end
+  #HEAD is disabled as https://github.com/ytdl-org/youtube-dl/ is taken down due to DMCA takedown notice by RIAA (https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md).
+  #head do
+  #  url "https://github.com/ytdl-org/youtube-dl.git"
+  #  depends_on "pandoc" => :build
+  #end
 
   bottle :unneeded
 

--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -1,8 +1,8 @@
 class YoutubeDl < Formula
   desc "Download YouTube videos from the command-line"
   homepage "https://yt-dl.org"
-  url "http://abf-downloads.openmandriva.org/ytdl/youtube-dl-2020.09.20.tar.gz"
-  sha256 "ead79e9248aaf7667f015da2ccd4bde44a8948fa980f82965609cdca88ad285e"
+  url "https://files.pythonhosted.org/packages/12/8b/51cae2929739d637fdfbc706b2d5f8925b5710d8f408b5319a07ea45fe99/youtube_dl-2020.9.20.tar.gz"
+  sha256 "67fb9bfa30f5b8f06227c478a8a6ed04af1f97ad4e81dd7e2ce518df3e275391"
   license "Unlicense"
 
   #HEAD is disabled as https://github.com/ytdl-org/youtube-dl/ is taken down due to DMCA takedown notice by RIAA (https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md).


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

As noted in their [main website](https://yt-dl.org) and [Hacker News](https://news.ycombinator.com/item?id=24872911), youtube-dl [dev repository](https://github.com/ytdl-org/youtube-dl/) is taken down due to [DMCA takedown notice by RIAA](https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md).

This pull request updates links so they point to the mirror they set up.