### PR TITLE
zookeeper: fix build on Linux

### DIFF
--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -25,7 +25,7 @@ class Zookeeper < Formula
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
 
-  unless OS.mac?
+  on_linux do
     depends_on "openjdk"
     depends_on "openssl@1.1"
   end

--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -24,6 +24,7 @@ class Zookeeper < Formula
   depends_on "libtool" => :build
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
+  depends_on "openjdk"
 
   def shim_script(target)
     <<~EOS
@@ -37,6 +38,7 @@ class Zookeeper < Formula
   def default_zk_env
     <<~EOS
       [ -z "$ZOOCFGDIR" ] && export ZOOCFGDIR="#{etc}/zookeeper"
+      [ -z "$JAVA_HOME" ] && export JAVA_HOME=#{Formula["openjdk"].opt_libexec}
     EOS
   end
 

--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -24,7 +24,11 @@ class Zookeeper < Formula
   depends_on "libtool" => :build
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
-  depends_on "openjdk"
+
+  unless OS.mac?
+    depends_on "openjdk"
+    depends_on "openssl@1.1"
+  end
 
   def shim_script(target)
     <<~EOS
@@ -38,7 +42,6 @@ class Zookeeper < Formula
   def default_zk_env
     <<~EOS
       [ -z "$ZOOCFGDIR" ] && export ZOOCFGDIR="#{etc}/zookeeper"
-      [ -z "$JAVA_HOME" ] && export JAVA_HOME=#{Formula["openjdk"].opt_libexec}
     EOS
   end
 
@@ -81,6 +84,12 @@ class Zookeeper < Formula
 
     defaults = etc/"zookeeper/defaults"
     defaults.write(default_zk_env) unless defaults.exist?
+    # set default JAVA_HOME for scripts on Linux so they can find the right java binary
+    unless OS.mac?
+      defaults.append_lines <<~EOS
+        [ -z "$JAVA_HOME" ] && export JAVA_HOME="#{Formula["openjdk"].opt_libexec}"
+      EOS
+    end
 
     log4j_properties = etc/"zookeeper/log4j.properties"
     log4j_properties.write(default_log4j_properties) unless log4j_properties.exist?


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Build failure logs: https://gist.github.com/clpo13/1419a96b86cc1e471bca5f6d4a5018a1

This fixes #21108 by including OpenJDK as a direct dependency and setting a default `JAVA_HOME` for the scripts so they'll run after installation. OpenJDK is already included as an indirect dependency via Maven but the build needs to run `java` and [can't find it](https://gist.github.com/clpo13/1419a96b86cc1e471bca5f6d4a5018a1#file-01-mvn-L189), even if `JAVA_HOME` is set in the build environment (double-checked by running `brew install -d zookeeper` and running `which java` after dropping to a debug shell).
