### PR TITLE
tcl-tk: fix build on Linux

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -17,7 +17,6 @@ class TclTk < Formula
     sha256 "4740b30b97f0308ecc59c1308945c38ddca5d3da528d779f38199a2dad905fa1" => :catalina
     sha256 "1851fee12a3ee44648845d8663a192712ce6827ef8fe167301d2638ac9ddb96c" => :mojave
     sha256 "d1d689cc3e9cf08b2a42d487db3c4142e7ee4ff322bef22d6187fc67a5b776b7" => :high_sierra
-    sha256 "4e9e5e6b2833a549a7866b8235570c62e99386af69a5ac69f823375c6c767e06" => :x86_64_linux
   end
 
   keg_only :provided_by_macos
@@ -26,6 +25,7 @@ class TclTk < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "freetype"   => :build
   end
 
   unless OS.mac?
@@ -61,6 +61,13 @@ class TclTk < Formula
   end
 
   def install
+    unless OS.mac?
+      ENV.prepend_path "CPATH", [
+        "#{Formula["freetype"].opt_include}/freetype2",
+        "#{Formula["freetype"].opt_include}/freetype2/freetype/config",
+      ].join(":")
+    end
+
     args = %W[
       --prefix=#{prefix}
       --mandir=#{man}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The error message from the [build log](https://gist.github.com/jnooree/34f5aadcc24de42deec521b940252fa1) was:
> In file included from /tmp/tcl-tk--tk-20201029-27542-13yq7wn/tk8.6.10/unix/../unix/tkUnixRFont.c:14:
> /home/jnooree/.linuxbrew/include/X11/Xft/Xft.h:39:10: fatal error: ft2build.h: No such file or directory

Fixed build error by adding `freetype` dependency and prepending the header path to `$CPATH` environment variable.