### PR TITLE
picat: fix build on linux

### DIFF
--- a/Formula/picat.rb
+++ b/Formula/picat.rb
@@ -13,7 +13,8 @@ class Picat < Formula
   end
 
   def install
-    system "make", "-C", "emu", "-f", "Makefile.mac64"
+    makefile = OS.mac? ? "Makefile.mac64" : "Makefile.linux64"
+    system "make", "-C", "emu", "-f", makefile
     bin.install "emu/picat" => "picat"
     prefix.install "lib" => "pi_lib"
     doc.install Dir["doc/*"]

--- a/Formula/picat.rb
+++ b/Formula/picat.rb
@@ -13,6 +13,7 @@ class Picat < Formula
   end
 
   def install
+    ENV.cxx11 unless OS.mac?
     makefile = OS.mac? ? "Makefile.mac64" : "Makefile.linux64"
     system "make", "-C", "emu", "-f", makefile
     bin.install "emu/picat" => "picat"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This PR fixes the building of the `picat` formula for linux. Currently the formula tries to build according to the MacOS specific Makefile, which results in the following error: https://gist.github.com/Dekker1/97226546cea3e780a5be734f973b1bc4

The only required fix is to correctly select which makefile to use based on the operating system.
