### PR TITLE
tiger-vnc: fix hardcoded mac-specific library name

### DIFF
--- a/Formula/tiger-vnc.rb
+++ b/Formula/tiger-vnc.rb
@@ -23,7 +23,7 @@ class TigerVnc < Formula
     turbo = Formula["jpeg-turbo"]
     args = std_cmake_args + %W[
       -DJPEG_INCLUDE_DIR=#{turbo.include}
-      -DJPEG_LIBRARY=#{turbo.lib}/libjpeg.dylib
+      -DJPEG_LIBRARY=#{turbo.lib}/#{shared_library("libjpeg")}
       .
     ]
     system "cmake", *args


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Fixes error:

```
make[2]: *** No rule to make target '/home/linuxbrew/.linuxbrew/opt/jpeg-turbo/lib/libjpeg.dylib', needed by 'vncviewer/vncviewer'.  Stop.
```

Full gist: https://git.io/JkLdz
