### PR TITLE
formulae: depend on xinput from core

### DIFF
--- a/Formula/freeglut.rb
+++ b/Formula/freeglut.rb
@@ -4,7 +4,7 @@ class Freeglut < Formula
   url "https://downloads.sourceforge.net/project/freeglut/freeglut/3.2.1/freeglut-3.2.1.tar.gz"
   sha256 "d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68"
   license "MIT"
-  revision OS.mac? ? 1 : 4
+  revision OS.mac? ? 1 : 5
 
   livecheck do
     url :stable
@@ -16,7 +16,6 @@ class Freeglut < Formula
     sha256 "21e92d3aa8a1615937c6776292dd823912220d272a4a437f66917d1e6dd0b655" => :catalina
     sha256 "8d71afe59334afe060d513d68e8c76b3fc0927cf05d61b146dd1444c66d5db35" => :mojave
     sha256 "0a30955c90e594481f1ebf4dd218065768386704e2fdcdc0aae45055171dfd2d" => :high_sierra
-    sha256 "77feb14967d7943422202ee72f244dc6290984788996e3c96a49a011fac9e7a0" => :x86_64_linux
   end
 
   depends_on "cmake" => :build
@@ -29,7 +28,7 @@ class Freeglut < Formula
 
   unless OS.mac?
     depends_on "mesa-glu"
-    depends_on "linuxbrew/xorg/xinput"
+    depends_on "xinput"
   end
 
   resource "init_error_func.c" do

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -4,7 +4,7 @@ class Mupdf < Formula
   url "https://mupdf.com/downloads/archive/mupdf-1.18.0-source.tar.xz"
   sha256 "592d4f6c0fba41bb954eb1a41616661b62b134d5b383e33bd45a081af5d4a59a"
   license "AGPL-3.0-or-later"
-  revision OS.mac? ? 1 : 3
+  revision OS.mac? ? 1 : 4
   head "https://git.ghostscript.com/mupdf.git"
 
   livecheck do
@@ -18,7 +18,6 @@ class Mupdf < Formula
     sha256 "b656ec4a7c2cbb3b55b52678e5129bbeb27215c793cd6e3876d40a51d293bd84" => :catalina
     sha256 "5b06c1203b68608f64d082b83db659a46d98a849d79530bfa83f28adb970e17e" => :mojave
     sha256 "32dc7277f5dce0762c695ecf15f3ec745ec7767afec09f6acefc4aea86386873" => :high_sierra
-    sha256 "a12207d117fd782a4af784f5863af70c39633cab54a964332c4111cfab2c775a" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build
@@ -28,7 +27,7 @@ class Mupdf < Formula
 
   unless OS.mac?
     depends_on "mesa-glu"
-    depends_on "linuxbrew/xorg/xinput"
+    depends_on "xinput"
   end
 
   conflicts_with "mupdf-tools",

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -2,7 +2,7 @@ class Sdl2 < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
   homepage "https://www.libsdl.org/"
   license "Zlib"
-  revision OS.mac? ? 1 : 2
+  revision OS.mac? ? 1 : 3
 
   stable do
     url "https://libsdl.org/release/SDL2-2.0.12.tar.gz"
@@ -28,7 +28,6 @@ class Sdl2 < Formula
     sha256 "4a074d422e597b6f68c61cff5ee7d212264f3392b1c40a185a01cf180fe34516" => :catalina
     sha256 "7d757169bb95da1477e01a4704e8ad204fccfb1cabb3292cee3449885e14e6b8" => :mojave
     sha256 "5c7aa312b1a5d7fb8fe3fcd2112a8a74250bb84954024794333b465acafbee4f" => :high_sierra
-    sha256 "a00ff5d341355661fdacf093e140f52288f64d2d7781aa86b4ae91680729f1fd" => :x86_64_linux
   end
 
   head do
@@ -48,7 +47,7 @@ class Sdl2 < Formula
     depends_on "libxcursor"
     depends_on "libxscrnsaver"
     depends_on "libxxf86vm"
-    depends_on "linuxbrew/xorg/xinput"
+    depends_on "xinput"
     depends_on "pulseaudio"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
