### PR TITLE
coreutils: disable SELinux, add attr as Linux dependency

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -55,8 +55,9 @@ class Coreutils < Formula
       --prefix=#{prefix}
       --program-prefix=g
       --without-gmp
-      --without-selinux
     ]
+
+    args << "--without-selinux" unless OS.mac?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -32,6 +32,10 @@ class Coreutils < Formula
     depends_on "gperf" => :build unless OS.mac?
   end
 
+  on_linux do
+    depends_on "attr"
+  end
+
   conflicts_with "aardvark_shell_utils", because: "both install `realpath` binaries"
   conflicts_with "b2sum", because: "both install `b2sum` binaries"
   conflicts_with "ganglia", because: "both install `gstat` binaries"
@@ -51,6 +55,7 @@ class Coreutils < Formula
       --prefix=#{prefix}
       --program-prefix=g
       --without-gmp
+      --without-selinux
     ]
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

SELinux was disabled to fix build failure on RHEL/CentOS - SELinux is available as a system library but not a Homebrew package.  Additionally, coreutils will try to link to `attr` if it is installed as a system library, so it was added as a dependency to fix build failure.