### PR TITLE
cups: use lib instead of lib64

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -22,6 +22,7 @@ class Cups < Formula
                           "--with-components=core",
                           "--without-bundledir",
                           "--prefix=#{prefix}",
+                          "--libdir=#{lib}",
                           *("--disable-gssapi" unless OS.mac?)
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Force CUPS to use `lib` as libdir on systems where it chooses `lib64` by default. 