### PR TITLE
ilmbase: use lib instead of lib64

### DIFF
--- a/Formula/ilmbase.rb
+++ b/Formula/ilmbase.rb
@@ -17,7 +17,7 @@ class Ilmbase < Formula
 
   def install
     cd "IlmBase" do
-      system "cmake", ".", *std_cmake_args, "-DBUILD_TESTING=OFF"
+      system "cmake", ".", *std_cmake_args, "-DBUILD_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
