### PR TITLE
linux-pam: disable SELinux and add missing dependency libtirpc

### DIFF
--- a/Formula/linux-pam.rb
+++ b/Formula/linux-pam.rb
@@ -12,6 +12,7 @@ class LinuxPam < Formula
   depends_on "pkg-config" => :build
   depends_on "berkeley-db"
   depends_on "libprelude"
+  depends_on "libtirpc"
   depends_on :linux
 
   skip_clean :la, "etc"
@@ -21,6 +22,7 @@ class LinuxPam < Formula
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
+      --disable-selinux
       --prefix=#{prefix}
       --includedir=#{include}/security
       --oldincludedir=#{include}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
