### PR TITLE
mariadb: disable dtrace and JDBC on Linux

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -72,13 +72,12 @@ class Mariadb < Formula
       -DCOMPILATION_COMMENT=Homebrew
     ]
 
-    args << "-DENABLE_DTRACE=NO" unless OS.mac?
-    args << "-DCONNECT_WITH_JDBC=OFF" unless OS.mac?
-
     unless OS.mac?
       args << "-DWITH_NUMA=OFF"
       args << "-DPLUGIN_ROCKSDB=NO"
       args << "-DPLUGIN_MROONGA=NO"
+      args << "-DENABLE_DTRACE=NO"
+      args << "-DCONNECT_WITH_JDBC=OFF"
     end
 
     # disable TokuDB, which is currently not supported on macOS

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -21,6 +21,7 @@ class Mariadb < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "groonga"
+  depends_on "openjdk"
   depends_on "openssl@1.1"
   unless OS.mac?
     depends_on "gcc@7" => :build
@@ -57,6 +58,7 @@ class Mariadb < Formula
     # -DINSTALL_* are relative to prefix
     args = %W[
       -DMYSQL_DATADIR=#{var}/mysql
+      -DENABLE_DTRACE=NO
       -DINSTALL_INCLUDEDIR=include/mysql
       -DINSTALL_MANDIR=share/man
       -DINSTALL_DOCDIR=share/doc/#{name}

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -58,7 +58,6 @@ class Mariadb < Formula
     # -DINSTALL_* are relative to prefix
     args = %W[
       -DMYSQL_DATADIR=#{var}/mysql
-      -DENABLE_DTRACE=NO
       -DINSTALL_INCLUDEDIR=include/mysql
       -DINSTALL_MANDIR=share/man
       -DINSTALL_DOCDIR=share/doc/#{name}
@@ -73,6 +72,8 @@ class Mariadb < Formula
       -DINSTALL_SYSCONFDIR=#{etc}
       -DCOMPILATION_COMMENT=Homebrew
     ]
+
+    args << "-DENABLE_DTRACE=NO" unless OS.mac?
 
     unless OS.mac?
       args << "-DWITH_NUMA=OFF"

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -21,7 +21,6 @@ class Mariadb < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "groonga"
-  depends_on "openjdk"
   depends_on "openssl@1.1"
   unless OS.mac?
     depends_on "gcc@7" => :build
@@ -74,6 +73,7 @@ class Mariadb < Formula
     ]
 
     args << "-DENABLE_DTRACE=NO" unless OS.mac?
+    args << "-DCONNECT_WITH_JDBC=OFF" unless OS.mac?
 
     unless OS.mac?
       args << "-DWITH_NUMA=OFF"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
