### PR TITLE
systemd: use lib instead of lib64

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -41,6 +41,7 @@ class Systemd < Formula
 
     args = %W[
       --prefix=#{prefix}
+      --libdir=lib
       --sysconfdir=#{etc}
       --localstatedir=#{var}
       -Drootprefix=#{prefix}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
