### PR TITLE
opencv: use brewed libraries, fix dependencies

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -35,7 +35,8 @@ class Opencv < Formula
   depends_on "tbb"
   depends_on "vtk"
   depends_on "webp"
-  depends_on "openblas" unless OS.mac?
+
+  uses_from_macos "zlib"
 
   resource "contrib" do
     url "https://github.com/opencv/opencv_contrib/archive/4.5.0.tar.gz"
@@ -88,7 +89,20 @@ class Opencv < Formula
       -DBUILD_opencv_python3=ON
       -DPYTHON3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
     ]
-    args << "-DENABLE_PRECOMPILED_HEADERS=OFF" unless OS.mac?
+
+    # Disable precompiled headers and force opencv to use brewed libraries on Linux
+    unless OS.mac?
+      args << "-DENABLE_PRECOMPILED_HEADERS=OFF"
+      args << "-DJPEG_LIBRARY=#{Formula["libjpeg"].opt_lib}/libjpeg.so"
+      args << "-DOpenBLAS_LIB=#{Formula["openblas"].opt_lib}/libopenblas.so"
+      args << "-DOPENEXR_ILMIMF_LIBRARY=#{Formula["openexr"].opt_lib}/libIlmImf.so"
+      args << "-DOPENEXR_ILMTHREAD_LIBRARY=#{Formula["ilmbase"].opt_lib}/libIlmThread.so"
+      args << "-DPNG_LIBRARY=#{Formula["libpng"].opt_lib}/libpng.so"
+      args << "-DPROTOBUF_LIBRARY=#{Formula["protobuf"].opt_lib}/libprotobuf.so"
+      args << "-DTIFF_LIBRARY=#{Formula["libtiff"].opt_lib}/libtiff.so"
+      args << "-DWITH_V4L=OFF"
+      args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.so"
+    end
 
     args << "-DENABLE_AVX=OFF" << "-DENABLE_AVX2=OFF"
     args << "-DENABLE_SSE41=OFF" << "-DENABLE_SSE42=OFF" unless MacOS.version.requires_sse42?

--- a/Formula/pugixml.rb
+++ b/Formula/pugixml.rb
@@ -4,6 +4,7 @@ class Pugixml < Formula
   url "https://github.com/zeux/pugixml/releases/download/v1.11.3/pugixml-1.11.3.tar.gz"
   sha256 "aa2a4b8a8907c01c914da06f3a8630d838275c75d1d5ea03ab48307fd1913a6d"
   license "MIT"
+  revision 1 unless OS.mac?
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class Pugixml < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", "-DBUILD_SHARED_LIBS=OFF",
+    system "cmake", ".", "-DBUILD_SHARED_LIBS=ON",
                          "-DBUILD_PKGCONFIG=ON", *std_cmake_args
     system "make", "install"
   end

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -47,6 +47,7 @@ class Vtk < Formula
     depends_on "zlib"
     depends_on "tcl-tk"
     depends_on "mesa"
+    depends_on "mesa-glu"
   end
 
   def install
@@ -89,6 +90,7 @@ class Vtk < Formula
       -DVTK_GROUP_ENABLE_Qt:STRING=YES
     ]
     args << "-DVTK_USE_COCOA=" + (OS.mac? ? "ON" : "OFF")
+    args << "-DOpenGL_GL_PREFERENCE=LEGACY" unless OS.mac?
 
     mkdir "build" do
       system "cmake", "..", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This PR should resolve this issue: #21141. As I explained in the issue, build failures occur for OpenCV because CMake stubbornly insists on using system libraries for certain dependencies even though the brewed libraries are visible in the search path. By explicitly specifying the location of these libraries, this forces CMake to use the brewed libraries and resolves the problem.

I also found 3 missing dependencies, two of which (zlib and libglvnd) are available as formula, and one (video4linux) which I could not find and had to disable in order to build. If someone is aware of a formula which provides video4linux, please let me know and I will add it as a dependency instead of disabling it.