### PR TITLE
tcl-tk: fix build on Linux

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -27,6 +27,7 @@ class TclTk < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "freetype"   => :build
   end
 
   unless OS.mac?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The original PR, #21342, was accidentally deleted, so another one is opened. Sorry for my mistake.
This version reflects the changes proposed by @iMichka 

>The error message from the [build log](https://gist.github.com/jnooree/34f5aadcc24de42deec521b940252fa1) was:
>> In file included from /tmp/tcl-tk--tk-20201029-27542-13yq7wn/tk8.6.10/unix/../unix/tkUnixRFont.c:14:
>> /home/jnooree/.linuxbrew/include/X11/Xft/Xft.h:39:10: fatal error: ft2build.h: No such file or directory
>
>Fixed build error by adding `freetype` dependency and prepending the header path to `$CPATH` environment variable.