### PR TITLE
mesa: fix

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -82,7 +82,7 @@ class Mesa < Formula
       ]
 
       unless OS.mac?
-        args << "-Dplatforms=x11,wayland,drm,surfaceless"
+        args << "-Dplatforms=x11,wayland"
         args << "-Dglx=auto"
         args << "-Ddri3=true"
         args << "-Ddri-drivers=auto"


### PR DESCRIPTION
- remove drm and surfaceless options

```
../meson.build:21:0: ERROR: Options "drm, surfaceless" are not in allowed choices: "auto, x11, wayland, haiku, android, windows"
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----