### PR TITLE
imagemagick: Add support for X server

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -29,6 +29,7 @@ class Imagemagick < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"
+  depends_on "libx11"
   depends_on "little-cms2"
   depends_on "openexr"
   depends_on "openjpeg"
@@ -64,7 +65,6 @@ class Imagemagick < Formula
       --with-lqr
       --without-fftw
       --without-pango
-      --without-x
       --without-wmf
       --enable-openmp
       ac_cv_prog_c_openmp=-Xpreprocessor\ -fopenmp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

- Add dependency `libx11`
- Remove `--without-x` option

This repository is for linux, so no need to remove support for x11. (See Homebrew/homebrew-core#49082 for the discussion about macOS)