### PR TITLE
ffmpeg: fix build for Linuxbrew

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -71,13 +71,6 @@ class Ffmpeg < Formula
 
   depends_on "libxv" unless OS.mac?
 
-  # https://trac.ffmpeg.org/ticket/8760
-  # Remove in next release
-  patch do
-    url "https://github.com/FFmpeg/FFmpeg/commit/7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch?full_index=1"
-    sha256 "1cbe1b68d70eadd49080a6e512a35f3e230de26b6e1b1c859d9119906417737f"
-  end
-
   def install
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
resolve double application of patch by removing the duplicate
unconditional patch, leaving the stable spec patch intact

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
gist-logs produces no output, but this is the error:
```
==> Downloading https://github.com/FFmpeg/FFmpeg/commit/7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch?full_index=1
Already downloaded: /home/jcount/.cache/Homebrew/downloads/c585557298843eab846c569ff84eb7623db209cd15cfd74b2d736a1e7d86a55c--7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch
==> Downloading https://github.com/FFmpeg/FFmpeg/commit/7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch?full_index=1
Already downloaded: /home/jcount/.cache/Homebrew/downloads/c585557298843eab846c569ff84eb7623db209cd15cfd74b2d736a1e7d86a55c--7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch
==> Downloading https://ffmpeg.org/releases/ffmpeg-4.3.1.tar.xz
Already downloaded: /home/jcount/.cache/Homebrew/downloads/907d44c10ce0824ba8d0acb013a260cf4114a463a371b204afae8e3588f76792--ffmpeg-4.3.1.tar.xz
==> Patching
==> Applying 7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch
patching file libavformat/libsrt.c
==> Applying 7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315.patch
patching file libavformat/libsrt.c
Hunk #1 FAILED at 313.
Hunk #2 FAILED at 333.
2 out of 2 hunks FAILED -- saving rejects to file libavformat/libsrt.c.rej
```