### PR TITLE
gettext: use included gettext

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -26,7 +26,7 @@ class Gettext < Formula
                           "--disable-silent-rules",
                           "--disable-debug",
                           "--prefix=#{prefix}",
-                          ("--with-included-gettext" if OS.mac?),
+                          "--with-included-gettext",
                           "--with-included-glib",
                           "--with-included-libcroco",
                           "--with-included-libunistring",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Workaround for formulae that depend on `gettext` and give `undefined reference to libintl_*` errors:

```rb
ENV.append "LDFLAGS", "-lintl"
```

(Discovered in https://github.com/Homebrew/homebrew-core/pull/63558)