### PR TITLE
pulseaudio: add dbus as a Linux dependency and specify brewed udev rules dir 

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -34,6 +34,7 @@ class Pulseaudio < Formula
   depends_on "openssl@1.1"
   depends_on "speexdsp"
   unless OS.mac?
+    depends_on "dbus"
     depends_on "glib"
     depends_on "libcap"
   end
@@ -73,6 +74,8 @@ class Pulseaudio < Formula
       --disable-nls
       --disable-x11
     ]
+
+    args << "--with-udev-rules-dir=#{lib}/udev/rules.d" if OS.linux?
 
     if OS.mac?
       args << "--with-mac-sysroot=#{MacOS.sdk_path})"

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -75,21 +75,25 @@ class Pulseaudio < Formula
       --disable-x11
     ]
 
-    args << "--with-udev-rules-dir=#{lib}/udev/rules.d" if OS.linux?
-
     if OS.mac?
       args << "--with-mac-sysroot=#{MacOS.sdk_path})"
       args << "--with-mac-version-min=#{MacOS.version}"
     end
 
-    # Perl depends on gdbm.
-    # If the dependency of pulseaudio on perl is build-time only,
-    # pulseaudio detects and links gdbm at build-time, but cannot locate it at run-time.
-    # Thus, we have to
-    #  - specify not to use gdbm, or
-    #  - add a dependency on gdbm if gdbm is wanted (not implemented).
-    # See Linuxbrew/homebrew-core#8148
-    args << "--with-database=simple" unless OS.mac?
+    unless OS.mac?
+      # Perl depends on gdbm.
+      # If the dependency of pulseaudio on perl is build-time only,
+      # pulseaudio detects and links gdbm at build-time, but cannot locate it at run-time.
+      # Thus, we have to
+      #  - specify not to use gdbm, or
+      #  - add a dependency on gdbm if gdbm is wanted (not implemented).
+      # See Linuxbrew/homebrew-core#8148
+      args << "--with-database=simple"
+
+      # Tell pulseaudio to use the brewed udev rules dir instead of the system one,
+      # which it does not have permission to modify
+      args << "--with-udev-rules-dir=#{lib}/udev/rules.d"
+    end
 
     if build.head?
       # autogen.sh runs bootstrap.sh then ./configure


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The udev rules dir must be specified or the build will fail because it tries to modify the system udev rules dir.