### PR TITLE
libprelude: explicitly disable Python 2 bindings and depend on ruby@2.6 for ruby bindings

### DIFF
--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -1,18 +1,17 @@
 class Libprelude < Formula
   desc "Universal Security Information & Event Management (SIEM) system"
   homepage "https://www.prelude-siem.org/"
-  url "https://www.prelude-siem.org/attachments/download/1172/libprelude-5.1.0.tar.gz"
-  sha256 "a5fa3ca1e428291afe4bb5095f01c05fd0d9ebd517a0ce3d07ca9977abcf41fa"
+  url "https://www.prelude-siem.org/attachments/download/1395/libprelude-5.2.0.tar.gz"
+  sha256 "187e025a5d51219810123575b32aa0b40037709a073a775bc3e5a65aa6d6a66e"
 
   bottle do
-    sha256 "1ba7de08e4e1bae22f2df8dac21cb6d6966e6f9f32962940c70655582fcd3f6b" => :x86_64_linux
   end
 
   depends_on "libtool" => :build
   depends_on "perl" => :build
   depends_on "pkg-config" => :build
   depends_on "python" => :build
-  depends_on "ruby" => :build
+  depends_on "ruby@2.6" => :build
   depends_on "swig" => :build
   depends_on "valgrind" => :build
   depends_on "gnutls"
@@ -29,6 +28,7 @@ class Libprelude < Formula
       --disable-rpath
       --with-pic
       --with-python3
+      --without-python2
       --with-valgrind
       --with-lua
       --with-ruby


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The libprelude bindings are not compatible with the ruby 2.7 API so ruby 2.6 must be used instead.