### PR TITLE
pre-commit: avoid executable links with relative paths

### DIFF
--- a/Formula/pre-commit.rb
+++ b/Formula/pre-commit.rb
@@ -93,6 +93,17 @@ class PreCommit < Formula
       rm f
       ln_s realpath, f
     end
+
+    unless OS.mac?
+      bin_python_path = Pathname(libexec/"bin")
+      bin_python_path.each_child do |f|
+        next unless f.symlink?
+
+        realpath = f.realpath
+        rm f
+        ln_s realpath, f
+      end
+    end
   end
 
   test do


### PR DESCRIPTION
This fixes #21288 based on the [comment by Mikko Salmi](https://github.com/Homebrew/linuxbrew-core/issues/21288#issuecomment-727049016), namely, by pointing executable links that having relative paths to those full paths.

There are other workarounds in comments on the issue, but they require to change `.git/hooks/pre-commit` or `.pre-commit-config.yaml` in users' repositories.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
