### PR TITLE
jasper: explicitly enable shared lib and disable document generation

### DIFF
--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -27,8 +27,11 @@ class Jasper < Formula
         os_cmake_args.push "-DGLUT_glut_LIBRARY=#{glut_lib}"
       end
 
+      os_cmake_args << "-DJAS_ENABLE_DOC=OFF"
+
       system "cmake", "..",
         "-DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=false",
+        "-DJAS_ENABLE_SHARED=ON",
         *os_cmake_args,
         *std_cmake_args
       system "make"

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -11,7 +11,6 @@ class Jasper < Formula
     sha256 "638641e641f36d5c48fe361bb5f1096506fb3ce9337c4f15174faf593d8d4a14" => :arm64_big_sur
     sha256 "d1c76e642247f71829a1bfafbff0ddb4f46a11b918299bec64175287033ac90f" => :catalina
     sha256 "1c1317a1ef7c31f8586e98d3fb1604220d7c15a5fd3ccedd5c2cd3bbe0304769" => :mojave
-    sha256 "5e8e162ed72d7755aa4b5bec5e1b552385f9c286ba257ca7690c574232792be0" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -4,6 +4,7 @@ class Jasper < Formula
   url "https://github.com/jasper-software/jasper/archive/version-2.0.24.tar.gz"
   sha256 "d2d28e115968d38499163cf8086179503668ce0d71b90dd33855b3de96a1ca1d"
   license "JasPer-2.0"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "d3ec3a84be1bd061d7c64ef8434f126d1e6d6f086d177405b2e8e9c7651dcc79" => :big_sur


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

It seems that on Linux `-DJAS_ENABLE_SHARED=ON` must explicitly be called to build the shared library.  I'm not entirely sure why the static library is also being built, but some effort appears to have been made to make it work, so I've left that part of the formula unchanged.  If we don't need the static library, I can remove that part of the formula.  