### PR TITLE
libxslt: remove unneeded flag

### DIFF
--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -37,7 +37,6 @@ class Libxslt < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          ("--without-crypto" unless OS.mac?),
                           "--without-python",
                           "--with-libxml-prefix=#{Formula["libxml2"].opt_prefix}"
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Removes `--without-crypto` flag added in https://github.com/Linuxbrew/legacy-linuxbrew/pull/147

From `configure` log:

```
checking for libgcrypt-config... no
Crypto extensions will not be available. Install libgcrypt and reconfigure to make available.
```