### PR TITLE
Fix/m4/patch

### DIFF
--- a/Formula/m4.rb
+++ b/Formula/m4.rb
@@ -5,6 +5,7 @@ class M4 < Formula
   mirror "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.xz"
   sha256 "f2c1e86ca0a404ff281631bdc8377638992744b175afb806e25871a24a934e07"
   license "GPL-3.0-or-later"
+  revision 1 unless OS.mac?
 
   livecheck do
     url :stable
@@ -17,7 +18,6 @@ class M4 < Formula
     sha256 "1db2471add366dde3b52f8d2d32e6d118584f91d1390d8efd6c10c41c9d6a45c" => :arm64_big_sur
     sha256 "2fdf452c94c6b63ea0a45608c19a4477acaf79853a298d337360971c5d51413b" => :catalina
     sha256 "2c0f28d612ba588cd6bf8380c6e286c9d3e585dcd8c4ad198b955c9e8cd1d817" => :mojave
-    sha256 "1552dd0379252680e0c32085df6b6ab59aa32f45be389ff18620a073a8f3c78c" => :x86_64_linux
   end
 
   keg_only :provided_by_macos
@@ -28,6 +28,22 @@ class M4 < Formula
     patch :p0 do
       url "https://raw.githubusercontent.com/macports/macports-ports/edf0ee1e2cf/devel/m4/files/secure_snprintf.patch"
       sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
+  on_linux do
+    if OS::Linux::Glibc.system_version >= "2.28" ||
+       (Formula["glibc"].any_version_installed? && Formula["glibc"].version >= "2.28")
+      # Glibc no longer provides several required symbols since version 2.28.
+      # Gnulib, bundled into m4, and the dependent of those removed symbols
+      # would no longer compile without an upstream fix applied.
+      # - https://github.com/coreutils/gnulib/commit/4af4a4a71827c0bc5e0ec67af23edef4f15cee8e#diff-5bcce8ce55246264586c4aed2a45ff89
+      # Patch the copy of gnulib bundled with the m4 1.4.18 distribution.
+      # - https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
+      patch do
+        url "https://raw.githubusercontent.com/archlinux/svntogit-packages/19e203625ecdf223400d523f3f8344f6ce96e0c2/trunk/m4-1.4.18-glibc-change-work-around.patch"
+        sha256 "fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8"
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

```bash
$ brew audit --strict m4

m4:
* 1: col 1: Incorrect file permissions (660): chmod +r /home/hutson/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/m4.rb
Error: 1 problem in 1 formula detected
```

Original build failure (Copied from - https://github.com/Homebrew/discussions/discussions/263):

```bash
$ brew update
Already up-to-date.


$ brew update
Already up-to-date.


$ brew install m4
Warning: Building m4 from source as the bottle needs:
- HOMEBREW_CELLAR: any_skip_relocation (yours is /home/hutson/.linuxbrew/Cellar)
- HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew (yours is /home/hutson/.linuxbrew)
- HOMEBREW_REPOSITORY: /home/linuxbrew/.linuxbrew/Homebrew (yours is /home/hutson/.linuxbrew/Homebrew)
==> Downloading https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz
######################################################################## 100.0%
==> ./configure --prefix=/home/hutson/.linuxbrew/Cellar/m4/1.4.18
==> make
Last 15 lines from /home/hutson/.cache/Homebrew/Logs/m4/02.make:
      |   ^~~~~
make[3]: *** [Makefile:1915: freadahead.o] Error 1
make[3]: *** Waiting for unfinished jobs....
  CC       obstack.o
fseeko.c: In function 'rpl_fseeko':
fseeko.c:110:4: error: #error "Please port gnulib fseeko.c to your platform! Look at the code in fseeko.c, then report this to bug-gnulib."
  110 |   #error "Please port gnulib fseeko.c to your platform! Look at the code in fseeko.c, then report this to bug-gnulib."
      |    ^~~~~
make[3]: *** [Makefile:1915: fseeko.o] Error 1
make[3]: Leaving directory '/tmp/m4-20201210-737477-6wlgue/m4-1.4.18/lib'
make[2]: *** [Makefile:1674: all] Error 2
make[2]: Leaving directory '/tmp/m4-20201210-737477-6wlgue/m4-1.4.18/lib'
make[1]: *** [Makefile:1572: all-recursive] Error 1
make[1]: Leaving directory '/tmp/m4-20201210-737477-6wlgue/m4-1.4.18'
make: *** [Makefile:1528: all] Error 2

READ THIS: https://docs.brew.sh/Troubleshooting


$ brew config
HOMEBREW_VERSION: 2.6.1-27-g06c60b9
ORIGIN: https://github.com/Homebrew/brew
HEAD: 06c60b98924610b9c6707ff857b4f99039eb6266
Last commit: 2 hours ago
Core tap ORIGIN: https://github.com/Homebrew/linuxbrew-core
Core tap HEAD: 07337e40aba8dedfe81f095a6dff2d0f9933df05
Core tap last commit: 7 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /home/hutson/.linuxbrew
HOMEBREW_REPOSITORY: /home/hutson/.linuxbrew/Homebrew
HOMEBREW_CELLAR: /home/hutson/.linuxbrew/Cellar
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: :0
HOMEBREW_EDITOR: nano
HOMEBREW_MAKE_JOBS: 8
HOMEBREW_NO_ANALYTICS: set
Homebrew Ruby: 2.6.3 => /home/hutson/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/bin/ruby
CPU: octa-core 64-bit skylake
Clang: N/A
Git: 2.25.1 => /bin/git
Curl: 7.68.0 => /usr/bin/curl
Kernel: Linux 5.4.0-56-generic x86_64 GNU/Linux
OS: Ubuntu 20.04.1 LTS (focal)
Host glibc: 2.31
/usr/bin/gcc: 9.3.0
/usr/bin/ruby: N/A
glibc: N/A
gcc: N/A
xorg: N/A


$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Your Homebrew's prefix is not /home/linuxbrew/.linuxbrew.
Some of Homebrew's bottles (binary packages) can only be used with the default
prefix (/home/linuxbrew/.linuxbrew).
You will encounter build failures with some formulae.
Please create pull requests instead of asking for help on Homebrew's GitHub,
Twitter or any other official channels. You are responsible for resolving
any issues you experience while you are running this
unsupported configuration.


$ cat /home/hutson/.cache/Homebrew/Logs/m4/02.make
2020-12-10 19:14:36 -0600

make

/usr/bin/make  all-recursive
make[1]: Entering directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18'
Making all in .
make[2]: Entering directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18'
make[2]: Nothing to be done for 'all-am'.
make[2]: Leaving directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18'
Making all in examples
make[2]: Entering directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18/examples'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18/examples'
Making all in lib
make[2]: Entering directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18/lib'
  GEN      alloca.h
  GEN      configmake.h
  GEN      c++defs.h
  GEN      arg-nonnull.h
  GEN      warn-on-use.h
  GEN      limits.h
  GEN      unused-parameter.h
  GEN      fcntl.h
  GEN      sys/types.h
  GEN      langinfo.h
  GEN      locale.h
  GEN      math.h
  GEN      signal.h
  GEN      spawn.h
  GEN      stdio.h
  GEN      string.h
  GEN      stdlib.h
  GEN      sys/stat.h
  GEN      sys/time.h
  GEN      sys/wait.h
  GEN      time.h
  GEN      unistd.h
  GEN      wchar.h
  GEN      wctype.h
/usr/bin/make  all-am
make[3]: Entering directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18/lib'
  CC       gl_avltree_oset.o
  CC       binary-io.o
  CC       c-ctype.o
  CC       c-stack.o
  CC       c-strcasecmp.o
  CC       c-strncasecmp.o
  CC       clean-temp.o
  CC       cloexec.o
  CC       close-stream.o
  CC       closein.o
  CC       closeout.o
  CC       dirname.o
  CC       basename.o
  CC       dirname-lgpl.o
  CC       basename-lgpl.o
  CC       stripslash.o
  CC       execute.o
  CC       fatal-signal.o
  CC       exitfail.o
  CC       fd-hook.o
  CC       fd-safer-flag.o
  CC       filenamecat.o
  CC       dup-safer-flag.o
  CC       filenamecat-lgpl.o
  CC       fopen-safer.o
  CC       freading.o
  CC       getprogname.o
  CC       hard-locale.o
  CC       gl_linkedhash_list.o
  CC       gl_list.o
  CC       localcharset.o
  CC       malloca.o
  CC       math.o
  CC       gl_oset.o
  CC       memchr2.o
  CC       pipe2.o
  CC       printf-frexp.o
  CC       pipe2-safer.o
  CC       printf-frexpl.o
  CC       progname.o
  CC       quotearg.o
  CC       sig-handler.o
  CC       spawn-pipe.o
  CC       mkstemp-safer.o
  CC       tempname.o
  CC       glthread/threadlib.o
  CC       glthread/tls.o
  CC       tmpdir.o
  CC       unistd.o
  CC       dup-safer.o
  CC       fd-safer.o
  CC       pipe-safer.o
  CC       verror.o
  CC       version-etc.o
  CC       wait-process.o
  CC       version-etc-fsf.o
  CC       wctype-h.o
  CC       xmalloc.o
  CC       xalloc-die.o
  CC       gl_xlist.o
  CC       xmalloca.o
  CC       gl_xoset.o
  CC       xprintf.o
  CC       xsize.o
  CC       xstrndup.o
  CC       xvasprintf.o
  CC       xasprintf.o
  CC       asnprintf.o
  CC       asprintf.o
  CC       fclose.o
  CC       fcntl.o
  CC       fflush.o
  CC       fpurge.o
  CC       freadahead.o
  CC       fseek.o
  CC       fseeko.o
freadahead.c: In function 'freadahead':
freadahead.c:92:3: error: #error "Please port gnulib freadahead.c to your platform! Look at the definition of fflush, fread, ungetc on your system, then report this to bug-gnulib."
   92 |  #error "Please port gnulib freadahead.c to your platform! Look at the definition of fflush, fread, ungetc on your system, then report this to bug-gnulib."
      |   ^~~~~
  CC       mbrtowc.o
make[3]: *** [Makefile:1915: freadahead.o] Error 1
make[3]: *** Waiting for unfinished jobs....
  CC       obstack.o
fseeko.c: In function 'rpl_fseeko':
fseeko.c:110:4: error: #error "Please port gnulib fseeko.c to your platform! Look at the code in fseeko.c, then report this to bug-gnulib."
  110 |   #error "Please port gnulib fseeko.c to your platform! Look at the code in fseeko.c, then report this to bug-gnulib."
      |    ^~~~~
make[3]: *** [Makefile:1915: fseeko.o] Error 1
make[3]: Leaving directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18/lib'
make[2]: *** [Makefile:1674: all] Error 2
make[2]: Leaving directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18/lib'
make[1]: *** [Makefile:1572: all-recursive] Error 1
make[1]: Leaving directory '/tmp/m4-20201210-744499-7k5ecv/m4-1.4.18'
make: *** [Makefile:1528: all] Error 2

HOMEBREW_VERSION: 2.6.1-27-g06c60b9
ORIGIN: https://github.com/Homebrew/brew
HEAD: 06c60b98924610b9c6707ff857b4f99039eb6266
Last commit: 2 hours ago
Core tap ORIGIN: https://github.com/Homebrew/linuxbrew-core
Core tap HEAD: 07337e40aba8dedfe81f095a6dff2d0f9933df05
Core tap last commit: 7 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /home/hutson/.linuxbrew
HOMEBREW_REPOSITORY: /home/hutson/.linuxbrew/Homebrew
HOMEBREW_CELLAR: /home/hutson/.linuxbrew/Cellar
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: :0
HOMEBREW_EDITOR: nano
HOMEBREW_MAKE_JOBS: 8
HOMEBREW_NO_ANALYTICS: set
Homebrew Ruby: 2.6.3 => /home/hutson/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/bin/ruby
CPU: octa-core 64-bit skylake
Clang: N/A
Git: 2.25.1 => /bin/git
Curl: 7.68.0 => /usr/bin/curl
Kernel: Linux 5.4.0-56-generic x86_64 GNU/Linux
OS: Ubuntu 20.04.1 LTS (focal)
Host glibc: 2.31
/usr/bin/gcc: 9.3.0
/usr/bin/ruby: N/A
glibc: N/A
gcc: N/A
xorg: N/A

HOMEBREW_CC: gcc-9
HOMEBREW_CXX: g++-9
MAKEFLAGS: -j8
CMAKE_PREFIX_PATH: /home/hutson/.linuxbrew
HOMEBREW_GIT: git
ACLOCAL_PATH: /home/hutson/.linuxbrew/share/aclocal
PATH: /home/hutson/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super:/usr/bin:/bin:/usr/sbin:/sbin
```