### PR TITLE
R: Fixed unable to find rpc/types.h when building from source on Ubuntu 20.10

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -4,7 +4,7 @@ class R < Formula
   url "https://cran.r-project.org/src/base/R-4/R-4.0.3.tar.gz"
   sha256 "09983a8a78d5fb6bc45d27b1c55f9ba5265f78fa54a55c13ae691f87c5bb9e0d"
   license "GPL-2.0-or-later"
-  revision 2
+  revision OS.mac? ? 1 : 2
 
   livecheck do
     url "https://cran.rstudio.com/banner.shtml"
@@ -15,7 +15,6 @@ class R < Formula
     sha256 "01bf5a586b3699a50b5e7ec6b7eebab213ef47dfa94754db497d0f41ac5a6110" => :big_sur
     sha256 "c600906bfe86b80c5c14129148692364a6a5c2d4c1417e7c9f8a4eff5f508ec2" => :catalina
     sha256 "22731d36544e6eb86b88e89638225133c8975377c3c4cdd1cc06e61e72f846b9" => :mojave
-    sha256 "0429f284050a1f1fde4c962cca7fde184b7334cb21fddde287eb38bb16d2c9c8" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -4,7 +4,7 @@ class R < Formula
   url "https://cran.r-project.org/src/base/R-4/R-4.0.3.tar.gz"
   sha256 "09983a8a78d5fb6bc45d27b1c55f9ba5265f78fa54a55c13ae691f87c5bb9e0d"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://cran.rstudio.com/banner.shtml"
@@ -35,6 +35,7 @@ class R < Formula
     depends_on "libice"
     depends_on "libx11"
     depends_on "libxt"
+    depends_on "libtirpc"
   end
 
   # needed to preserve executable permissions on files without shebangs
@@ -82,6 +83,11 @@ class R < Formula
 
     # Avoid references to homebrew shims
     args << "LD=ld" unless OS.mac?
+
+    unless OS.mac?
+      ENV.append "CPPFLAGS", "-I#{Formula["libtirpc"].opt_include}/tirpc"
+      ENV.append "LDFLAGS", "-L#{Formula["libtirpc"].opt_lib}"
+    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
This fixes #21759. Logs can be [found here](https://gist.github.com/756b19383c194f4bc25569b00d3fdef2).