### PR TITLE
valgrind: disable mpicc

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -2,6 +2,7 @@ class Valgrind < Formula
   desc "Dynamic analysis tools (memory, debug, profiling)"
   homepage "https://www.valgrind.org/"
   license "GPL-2.0"
+  revision 1 unless OS.mac?
 
   stable do
     url "https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2"
@@ -36,6 +37,7 @@ class Valgrind < Formula
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
+      --without-mpicc
     ]
 
     args << "--enable-only64bit"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This disables `mpicc` support in `valgrind`, which seems to cause build failures on host systems with `mpich` installed.  If we ever get a request to add support for `mpicc` to `valgrind`, we'd probably have to add `mpich` as a dependency.  But as per our usual policies, we are disabling the feature unless someones asks for it.    