### PR TITLE
mariadb: backport fixes for Linux in latest version

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -22,16 +22,17 @@ class Mariadb < Formula
   depends_on "pkg-config" => :build
   depends_on "groonga"
   depends_on "openssl@1.1"
-  unless OS.mac?
-    depends_on "gcc@7" => :build
-    depends_on "libcsv"
-    depends_on "linux-pam"
-  end
 
   uses_from_macos "bison" => :build
   uses_from_macos "bzip2"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc@7" => :build
+    depends_on "libcsv"
+    depends_on "linux-pam"
+  end
 
   conflicts_with "mysql", "percona-server",
     because: "mariadb, mysql, and percona install the same binaries"
@@ -72,7 +73,7 @@ class Mariadb < Formula
       -DCOMPILATION_COMMENT=Homebrew
     ]
 
-    unless OS.mac?
+    on_linux do
       args << "-DWITH_NUMA=OFF"
       args << "-DPLUGIN_ROCKSDB=NO"
       args << "-DPLUGIN_MROONGA=NO"
@@ -133,7 +134,7 @@ class Mariadb < Formula
 
   def post_install
     # Fails to build
-    return if ENV["CI"] && !OS.mac?
+    return if ENV["CI"]
 
     # Make sure the var/mysql directory exists
     (var/"mysql").mkpath
@@ -180,8 +181,6 @@ class Mariadb < Formula
   end
 
   test do
-    return if ENV["CI"] && !OS.mac?
-
     (testpath/"mysql").mkpath
     (testpath/"tmp").mkpath
     system bin/"mysql_install_db", "--no-defaults", "--user=#{ENV["USER"]}",

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -27,6 +27,21 @@ class MariadbAT102 < Formula
   depends_on "groonga"
   depends_on "openssl@1.1"
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc@7" => :build
+    depends_on "libcsv"
+    depends_on "linux-pam"
+  end
+
+  fails_with gcc: "4"
+  fails_with gcc: "5"
+  fails_with gcc: "6"
+
   def install
     # Set basedir and ldata so that mysql_install_db can find the server
     # without needing an explicit path to be set. This can still
@@ -56,6 +71,14 @@ class MariadbAT102 < Formula
       -DINSTALL_SYSCONFDIR=#{etc}
       -DCOMPILATION_COMMENT=Homebrew
     ]
+
+    on_linux do
+      args << "-DWITH_NUMA=OFF"
+      args << "-DPLUGIN_ROCKSDB=NO"
+      args << "-DPLUGIN_MROONGA=NO"
+      args << "-DENABLE_DTRACE=NO"
+      args << "-DCONNECT_WITH_JDBC=OFF"
+    end
 
     # disable TokuDB, which is currently not supported on macOS
     args << "-DPLUGIN_TOKUDB=NO"

--- a/Formula/mariadb@10.3.rb
+++ b/Formula/mariadb@10.3.rb
@@ -27,6 +27,21 @@ class MariadbAT103 < Formula
   depends_on "groonga"
   depends_on "openssl@1.1"
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc@7" => :build
+    depends_on "libcsv"
+    depends_on "linux-pam"
+  end
+
+  fails_with gcc: "4"
+  fails_with gcc: "5"
+  fails_with gcc: "6"
+
   def install
     # Set basedir and ldata so that mysql_install_db can find the server
     # without needing an explicit path to be set. This can still
@@ -56,6 +71,14 @@ class MariadbAT103 < Formula
       -DINSTALL_SYSCONFDIR=#{etc}
       -DCOMPILATION_COMMENT=Homebrew
     ]
+
+    on_linux do
+      args << "-DWITH_NUMA=OFF"
+      args << "-DPLUGIN_ROCKSDB=NO"
+      args << "-DPLUGIN_MROONGA=NO"
+      args << "-DENABLE_DTRACE=NO"
+      args << "-DCONNECT_WITH_JDBC=OFF"
+    end
 
     # disable TokuDB, which is currently not supported on macOS
     args << "-DPLUGIN_TOKUDB=NO"

--- a/Formula/mariadb@10.4.rb
+++ b/Formula/mariadb@10.4.rb
@@ -32,6 +32,16 @@ class MariadbAT104 < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "gcc@7" => :build
+    depends_on "libcsv"
+    depends_on "linux-pam"
+  end
+
+  fails_with gcc: "4"
+  fails_with gcc: "5"
+  fails_with gcc: "6"
+
   def install
     # Set basedir and ldata so that mysql_install_db can find the server
     # without needing an explicit path to be set. This can still
@@ -61,6 +71,14 @@ class MariadbAT104 < Formula
       -DINSTALL_SYSCONFDIR=#{etc}
       -DCOMPILATION_COMMENT=Homebrew
     ]
+
+    on_linux do
+      args << "-DWITH_NUMA=OFF"
+      args << "-DPLUGIN_ROCKSDB=NO"
+      args << "-DPLUGIN_MROONGA=NO"
+      args << "-DENABLE_DTRACE=NO"
+      args << "-DCONNECT_WITH_JDBC=OFF"
+    end
 
     # disable TokuDB, which is currently not supported on macOS
     args << "-DPLUGIN_TOKUDB=NO"
@@ -134,7 +152,7 @@ class MariadbAT104 < Formula
     EOS
   end
 
-  plist_options manual: "mysql.server start"
+  plist_options manual: "${HOMEBREW_PREFIX}/opt/mariadb@10.4/bin/mysql.server start"
 
   def plist
     <<~EOS

--- a/Formula/mecab.rb
+++ b/Formula/mecab.rb
@@ -22,7 +22,15 @@ class Mecab < Formula
     sha256 "4cff10addb8895df884fca8d81cd4d4c7530efdac45896299d85ab707a80cf4f" => :x86_64_linux
   end
 
+  on_linux do
+    depends_on "gcc@7"
+  end
+
   conflicts_with "mecab-ko", because: "both install mecab binaries"
+
+  fails_with gcc: "4"
+  fails_with gcc: "5"
+  fails_with gcc: "6"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This is a backport of the fixes I made in https://github.com/Homebrew/linuxbrew-core/pull/21644 to all other versions of `mariadb`.  Along the way, I backported the other changes that were in the latest version of `mariadb` but not the older ones. 