### PR TITLE
xcb-util-wm: depend on m4 for build

### DIFF
--- a/Formula/xcb-util-wm.rb
+++ b/Formula/xcb-util-wm.rb
@@ -23,6 +23,8 @@ class XcbUtilWm < Formula
   depends_on "pkg-config" => [:build, :test]
   depends_on "libxcb"
 
+  uses_from_macos "m4" => :build
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
