### PR TITLE
Use canonical names in dependencies

### DIFF
--- a/Formula/ansible@2.8.rb
+++ b/Formula/ansible@2.8.rb
@@ -599,7 +599,7 @@ class AnsibleAT28 < Formula
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.7"].opt_libexec/"bin"
 
     # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
     ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && MacOS.version == :sierra

--- a/Formula/at-spi2-atk.rb
+++ b/Formula/at-spi2-atk.rb
@@ -12,7 +12,7 @@ class AtSpi2Atk < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@3.9" => :build
   depends_on "at-spi2-core"
   depends_on "atk"
   depends_on "libxml2"

--- a/Formula/at-spi2-core.rb
+++ b/Formula/at-spi2-core.rb
@@ -14,7 +14,7 @@ class AtSpi2Core < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@3.9" => :build
   depends_on "dbus"
   depends_on "gettext"
   depends_on "glib"

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -133,7 +133,7 @@ class Crystal < Formula
       EMBEDDED_CRYSTAL_PATH=$("#{libexec/"crystal"}" env CRYSTAL_PATH)
       export CRYSTAL_PATH="${CRYSTAL_PATH:-"$EMBEDDED_CRYSTAL_PATH:#{prefix/"src"}"}"
       export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}#{prefix/"embedded/lib"}:/usr/local/lib"
-      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}#{Formula["openssl"].opt_lib/"pkgconfig"}"
+      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}#{Formula["openssl@1.1"].opt_lib/"pkgconfig"}"
       exec "#{libexec/"crystal"}" "${@}"
     SH
 

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -23,7 +23,7 @@ class Dotnet < Formula
   depends_on xcode: :build
   depends_on "curl"
   depends_on "icu4c"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Arguments needed to not artificially time-limit downloads from Azure.

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -30,7 +30,7 @@ class Folly < Formula
   depends_on "zstd"
   unless OS.mac?
     depends_on "jemalloc"
-    depends_on "python"
+    depends_on "python@3.9"
   end
 
   def install

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -52,7 +52,7 @@ class Gdb < Formula
       --disable-binutils
     ]
 
-    ENV.append "CPPFLAGS", "-I#{Formula["python"].opt_libexec}" unless OS.mac?
+    ENV.append "CPPFLAGS", "-I#{Formula["python@3.9"].opt_libexec}" unless OS.mac?
 
     mkdir "build" do
       system "../configure", *args

--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -11,7 +11,7 @@ class Libprelude < Formula
   depends_on "libtool" => :build
   depends_on "perl" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@3.9" => :build
   depends_on "ruby@2.6" => :build
   depends_on "swig" => :build
   depends_on "valgrind" => :build

--- a/Formula/ncspot.rb
+++ b/Formula/ncspot.rb
@@ -12,7 +12,7 @@ class Ncspot < Formula
     sha256 "765ec65802d29d0b65130d5333fdf6d0c9460204ae9f8d3e9d59c2dc2a8471b6" => :mojave
   end
 
-  depends_on "python3" => :build
+  depends_on "python@3.9" => :build
   depends_on "rust" => :build
 
   def install

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -23,7 +23,7 @@ class Newt < Formula
   depends_on "gettext"
   depends_on "popt"
   depends_on "s-lang"
-  depends_on "python" unless OS.mac?
+  depends_on "python@3.9" unless OS.mac?
 
   def install
     args = ["--prefix=#{prefix}", "--without-tcl"]

--- a/Formula/python-dbus.rb
+++ b/Formula/python-dbus.rb
@@ -13,10 +13,10 @@ class PythonDbus < Formula
   depends_on "dbus"
   depends_on "dbus-glib"
   depends_on :linux
-  depends_on "python"
+  depends_on "python@3.9"
 
   def install
-    ENV["PYTHON"] = Formula["python"].opt_bin/"python3"
+    ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -25,6 +25,6 @@ class PythonDbus < Formula
   end
 
   test do
-    system Formula["python"].opt_bin/"python3", "-c", "import dbus"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import dbus"
   end
 end

--- a/Formula/ranger.rb
+++ b/Formula/ranger.rb
@@ -8,7 +8,7 @@ class Ranger < Formula
 
   bottle :unneeded
 
-  depends_on "python" unless OS.mac?
+  depends_on "python@3.9" unless OS.mac?
 
   def install
     man1.install "doc/ranger.1"

--- a/Formula/serverless.rb
+++ b/Formula/serverless.rb
@@ -16,7 +16,7 @@ class Serverless < Formula
   depends_on "node"
 
   on_linux do
-    depends_on "python"
+    depends_on "python@3.9"
   end
 
   def install

--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -26,7 +26,7 @@ class Spidermonkey < Formula
   # No rule to make target '-lreadline', needed by 'js'.  Stop.
   depends_on "readline" if OS.mac?
   unless OS.mac?
-    depends_on "python" => :build
+    depends_on "python@3.9" => :build
     depends_on "zip" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
This PR replaces formulae aliases to their canonical names in dependencies. 

Also, it includes changes from https://github.com/Homebrew/homebrew-core/pull/67521 (please let me know if you want me to exclude these to not to cause any merge conflicts)