### PR TITLE
Add cellar :any

### DIFF
--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -8,6 +8,7 @@ class ArcadeLearningEnvironment < Formula
   head "https://github.com/mgbellemare/Arcade-Learning-Environment.git"
 
   bottle do
+    cellar :any
     sha256 "0cd35bdc93604828c1c9afc56f47f827ad27f735315a001a04c6864778daf03c" => :big_sur
     sha256 "ac79a55da2582b1750e695bbe66943cd3e79111708b0692edad3fdefb870d291" => :arm64_big_sur
     sha256 "86f7ee81ae0de6f7eebd78bf21dbc79b8230689c275ba812b6ef772b9774118f" => :catalina

--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -7,6 +7,7 @@ class Aria2 < Formula
   revision 1 unless OS.mac?
 
   bottle do
+    cellar :any
     sha256 "05ea0971d6834d9dc50df6a6ca62978ce0f8bf324758225f9d3df091b60fc875" => :big_sur
     sha256 "3db6c6a53e4bfd72eec10dc53179c424f2e72f1321c3f96b1b1b0e8740790af1" => :arm64_big_sur
     sha256 "9cc5e04be8b0a58d1f2b60b8abfc636168edbf23e7018003c40f1dd6952aab0c" => :catalina

--- a/Formula/atk.rb
+++ b/Formula/atk.rb
@@ -10,6 +10,7 @@ class Atk < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "8321e0ee7364e1de1a3667c50954b4b4f629cba7c2d8077114c4a5bc38a24655" => :big_sur
     sha256 "e7d40dbacc2c965c8b23224a5e1cd2a90d6c54758b957dcf3d66c2238feec518" => :arm64_big_sur
     sha256 "1065293046ab2984940dfa0b9c9e724439838e63f685c932d508ccd74bcf921b" => :catalina

--- a/Formula/aws-elasticbeanstalk.rb
+++ b/Formula/aws-elasticbeanstalk.rb
@@ -12,6 +12,7 @@ class AwsElasticbeanstalk < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "49497cfc82e4f7077a892545ad614413d6e987def058543240617efeeab39974" => :big_sur
     sha256 "09c2375ad6e5af51cc9bf164dbc24c959482e4817d3124d52ad65accdf45735b" => :catalina
     sha256 "de5a139b9a021fcbdb19ad4b706b1f6a82d5cb0532653619b3f016efb968d761" => :mojave

--- a/Formula/axel.rb
+++ b/Formula/axel.rb
@@ -7,6 +7,7 @@ class Axel < Formula
   head "https://github.com/eribertomota/axel.git"
 
   bottle do
+    cellar :any
     sha256 "94b9f93614705dab7c202df271f9bb1bcd30b4e1170f4ab4b160378e8e5c3a2f" => :big_sur
     sha256 "43a36bca363fd2a2700dbaca686de5d92793ae79b1813e26e6ba1965e9d0acc7" => :arm64_big_sur
     sha256 "32832dd93a31589c7f98e510a2edc54e918ee6bab8eab18f4f4a1b953030f3f1" => :catalina

--- a/Formula/babel.rb
+++ b/Formula/babel.rb
@@ -13,6 +13,7 @@ class Babel < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "b3f552dcd31cd35f83aa44d2b40586608c552ba07e009b96da23a53a75e59bd8" => :big_sur
     sha256 "15f6a428bb5e6fb70f24fbdc29693451f19f6866f2b6b94cec0dfa5df4542bb0" => :arm64_big_sur
     sha256 "4f57b7ad8dde162ef1aa46bd14e3f659ab128a19760603193b9386cdfb8784a6" => :catalina

--- a/Formula/bench.rb
+++ b/Formula/bench.rb
@@ -21,6 +21,7 @@ class Bench < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "c9ee5713f0c97785f37506da9e34f4cda353beaad06a5209fce27aeb93e3f770" => :big_sur
     sha256 "b1eccbf77a04e4de1a59a0eed5c0f6e2d8b6b191736ee9ad4fdea9a173010651" => :catalina
     sha256 "493de8888b6fe1745a887cda10a421448a08943496124b1cb49cc02453002638" => :mojave

--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -9,6 +9,7 @@ class Certbot < Formula
   head "https://github.com/certbot/certbot.git"
 
   bottle do
+    cellar :any
     sha256 "e1ba970a17f85f1ab0cb1d785ef1842e0ba2691604e25598335b403b69c2ea35" => :big_sur
     sha256 "52e9367676903b46ca27f92f189b119f425aea073d78e5be5cfa85be6f4cb396" => :arm64_big_sur
     sha256 "ffce387c91071c64807900aac16390562f44eff931c000f0af1d27b90c4d64e8" => :catalina

--- a/Formula/cgns.rb
+++ b/Formula/cgns.rb
@@ -12,6 +12,7 @@ class Cgns < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "e2e5eb665f0f5c94c7782f0aed3708124705792ff5a7adf945a537369db6d724" => :big_sur
     sha256 "abc3326bddbf58509b5ffb3834d68836ad803abf83f9958ae6a012870e7e9f85" => :arm64_big_sur
     sha256 "4371c695cad1aa0bccbaaf0deccb9a8f5ddf7271dcbbddf6307b8d0bc254cec5" => :catalina

--- a/Formula/cgrep.rb
+++ b/Formula/cgrep.rb
@@ -8,6 +8,7 @@ class Cgrep < Formula
   head "https://github.com/awgn/cgrep.git"
 
   bottle do
+    cellar :any
     sha256 "5b2e43b90ecf1dea0c622b55266feb1c0689580ac50d99311095c1a0814ebeb0" => :big_sur
     sha256 "cee7f82d8e3e6b46e2afae649e13cf55202771da2473fbbebc6a712aa2f46496" => :catalina
     sha256 "0ac8d5bcfc0ce6d295aa617cf0e5c624c61df4fc28a2ddb8c7b21bf753c7e369" => :mojave

--- a/Formula/comby.rb
+++ b/Formula/comby.rb
@@ -6,6 +6,7 @@ class Comby < Formula
   license "Apache-2.0"
 
   bottle do
+    cellar :any
     sha256 "b36a2c71ea7fce07482646776be5f4a380ddb7b8143a55350037d0576871cf2f" => :big_sur
     sha256 "8441273e383d1a79787cba483f9d27c78e03722596c4a80bd4bf636933226b69" => :catalina
     sha256 "2630927aa177293db660deea99133bab70247c0f9c751c5e21d9a18c38f5a2c0" => :mojave

--- a/Formula/confuse.rb
+++ b/Formula/confuse.rb
@@ -6,6 +6,7 @@ class Confuse < Formula
   license "ISC"
 
   bottle do
+    cellar :any
     sha256 "370cd5df07249d44cbf0a848001be19d41341f404d229dcdcb3b5ae6ead4300c" => :big_sur
     sha256 "1eeec2cb7b54cf11c1e13448f191ed97d4f2477c215130b6402256678019f36e" => :arm64_big_sur
     sha256 "13ad01ca606e746ab7f6bcd42b0da08abdcc29ccaaa9e8106f9d28bfe96bffd7" => :catalina

--- a/Formula/cpio.rb
+++ b/Formula/cpio.rb
@@ -11,6 +11,7 @@ class Cpio < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "5536f0e39997060791f3b7defe996e48e163068342a32340903783a74220347b" => :big_sur
     sha256 "88bef9fc6dd8b882e98bf245b7a9cca1a44155d7987725a547bd63877fa216da" => :arm64_big_sur
     sha256 "1e2e8f240d9455593a653d4cc0759ee1a0596fe88641ad6a79d652f6596bb21b" => :catalina

--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -11,6 +11,7 @@ class Cryptol < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "3602fbe74d5bba84b2e36ea3e5860b4a8ca3be54a2c13b57dff69621673d1a26" => :big_sur
     sha256 "42bbe475407645974fb9e90c6811ca103c2d7d92ec5d622428f753fd7f9077b0" => :catalina
     sha256 "e2dc3e5f38a0bb0f0bd288d9847be8be769e97ab1385b775daa1b35249fd4bff" => :mojave

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -20,6 +20,7 @@ class Crystal < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "c382e452d3586561986a8eea143dc09fb3ca089c989d9c54a7a3cd4d054f1624" => :big_sur
     sha256 "e3907b45ca9c3e0344d130141d23915c5825d34b27660b6f1ea847351b127fb5" => :catalina
     sha256 "0aa5aa3835d42d9139ede2d3e134d29db4d43cc29f0e735f17c48c1bdcc7ea0a" => :mojave

--- a/Formula/datamash.rb
+++ b/Formula/datamash.rb
@@ -11,6 +11,7 @@ class Datamash < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "50590b93f6f3a25e3e2724ddad696e6ed8a168f840fafe887be423f5020ce86c" => :big_sur
     sha256 "d808354a764a06427e4768aa451493e111c5324e36fde94fbbab4d7fb41f2055" => :arm64_big_sur
     sha256 "f592c4bda737ef924fb4c1642fb381db54c9ce246eb51d03a145dd28a8391406" => :catalina

--- a/Formula/diffutils.rb
+++ b/Formula/diffutils.rb
@@ -11,6 +11,7 @@ class Diffutils < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "626485c5fb898eecdc93c2b2af1e98651662afd78181a8ce5683d59c8562ea2e" => :big_sur
     sha256 "ffe8dc9603b805641fa3bedf9d33d50db10bcc47daaf1e0fec99a39184c2707c" => :arm64_big_sur
     sha256 "25a2f5fcdfcdf2efa36b97841e45455950fe322e1c642d97a36abbb2662007cf" => :catalina

--- a/Formula/elm.rb
+++ b/Formula/elm.rb
@@ -6,6 +6,7 @@ class Elm < Formula
   license "BSD-3-Clause"
 
   bottle do
+    cellar :any_skip_relocation
     rebuild 1
     sha256 "04efe8b2f66b7904b05578e59a07300e8f070521a87ab0733433609da531f29d" => :big_sur
     sha256 "bb6cd6a1bd9b3a7f280791b2ffba6631efa784f9068f48c4d6f9e64d756a4b2a" => :catalina

--- a/Formula/fairymax.rb
+++ b/Formula/fairymax.rb
@@ -8,6 +8,7 @@ class Fairymax < Formula
   head "http://hgm.nubati.net/git/fairymax.git"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "497488cd10ab4c0e87e6fc38cfa250b275e1ceea07ac7694b4ae37996da32c9d" => :big_sur
     sha256 "8dad1d34ed2ce478abebc9ac986bbf5d7d0bf7af5f8326839da735d8fb3d11c6" => :catalina
     sha256 "5c4d837d9726fd83661fac0703cda7829f2c81e48f69ac98016915f97dad15cf" => :mojave

--- a/Formula/fmt.rb
+++ b/Formula/fmt.rb
@@ -6,6 +6,7 @@ class Fmt < Formula
   license "MIT"
 
   bottle do
+    cellar :any
     sha256 "030400184b37be2dbefd79244622b6ba1db79a7a082063c9731422d67c1ec689" => :big_sur
     sha256 "ca7feb7f642cd97750e7df4a46229c5c8bf5948673a5b2be5cec24a4e4981ec3" => :arm64_big_sur
     sha256 "bc10923606cbc09de72d80d4fa35f2834cd3661791b493936a8d2853e571ef9d" => :catalina

--- a/Formula/fswatch.rb
+++ b/Formula/fswatch.rb
@@ -6,6 +6,7 @@ class Fswatch < Formula
   license "GPL-3.0"
 
   bottle do
+    cellar :any
     sha256 "f0e4988d417dc53f21f03a82358900a31be9f2962b067bddc49c9d786189d5e4" => :big_sur
     sha256 "12f1acafc38cc38fddb8a221897ace28a95b6927b1708c52cd764b0aa56472dd" => :arm64_big_sur
     sha256 "77233b7d6c11644f14682862d613ed37a5eda86ba1ec5a6ea3c18b75ccafe906" => :catalina

--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -12,6 +12,7 @@ class Gdbm < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "36b492f1b0910367dd394cbdcffe1606f64ab41ec6701210becfb591a8557dee" => :big_sur
     sha256 "801b2bf95118871ee206de507131325613a1aa59ab7809032bb456f1b5f01a89" => :arm64_big_sur
     sha256 "f7b5ab7363961fa6defcb66b4ffdf5365264fcb97d35bc413e754f173a3b1912" => :catalina

--- a/Formula/geocode-glib.rb
+++ b/Formula/geocode-glib.rb
@@ -11,6 +11,7 @@ class GeocodeGlib < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "7a36865ee432311c7a36e3541a430a1f32c80935e6b16e11d5454c09a8f773de" => :big_sur
     sha256 "878e80675652cec9dd995eb7d896681db3203a8567cce2b35577fbc952cb8be0" => :arm64_big_sur
     sha256 "52ce343c52ad20417f87bde9889b0086768b657874d94fd39eb54141f20fcedd" => :catalina

--- a/Formula/gexiv2.rb
+++ b/Formula/gexiv2.rb
@@ -11,6 +11,7 @@ class Gexiv2 < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "c70dc1804031fb8c387dc3eff59274de4fdd85152df44f42001c630302080ea7" => :big_sur
     sha256 "9ebb451be639c6e3557c4113dc999ab3a0ef6c0f9f2ab508a6eb5197da40e2c7" => :catalina
     sha256 "87d16bcad50a98b318106735fb10ed2652d8cab8768f2e9a5fb8690690d656d5" => :mojave

--- a/Formula/gleam.rb
+++ b/Formula/gleam.rb
@@ -6,6 +6,7 @@ class Gleam < Formula
   license "Apache-2.0"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "a197a01d2a4ccc244b3042a46dd1c498ee02480162fc9deba37bf74ac533192d" => :big_sur
     sha256 "a7f9676fbd4db882933f8f55bf649808b820057b9fb7eca2017c28389cee1c30" => :catalina
     sha256 "6e99065ad1c05a84707f42871a2852ec5b0d94cf8b98fb6165baa461d19f0682" => :mojave

--- a/Formula/gnu-sed.rb
+++ b/Formula/gnu-sed.rb
@@ -11,6 +11,7 @@ class GnuSed < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "3846b361699dd0260a616085b2a1678c874a2fcce8ce70e704a018dce3b4a882" => :big_sur
     sha256 "72bc2b8cf7c7e18d106d79c7db382f7160408aafa8fb765b084cbe965e92db9b" => :arm64_big_sur
     sha256 "726be75d6d7155820b408a10e5c1a5ba1406374a7fc167af62524a4f4bbbc099" => :catalina

--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -11,6 +11,7 @@ class GnuTar < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     rebuild 1
     sha256 "952e5c4dd04ddab0c2678edf97f24c02f6dfde9f5d031a98fc269064197a0872" => :big_sur
     sha256 "8f452aa6fe50b5af78c9ecb0290051af2ae2f08f89d0634eac0f2e1d7eaa64b5" => :arm64_big_sur

--- a/Formula/gom.rb
+++ b/Formula/gom.rb
@@ -10,6 +10,7 @@ class Gom < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "b8c298e1d442d15dd630bfe6b1edfeb11b77326b730237ffc4c6b3c607c48192" => :big_sur
     sha256 "ff2ac0dfef03bd08c7f03f13595af2e1476c396163e57066726c92e06cbe4fba" => :arm64_big_sur
     sha256 "c86f525462ffd97cb6bd469b5a26d1db56281d725916d5eb524f31a4750b1892" => :catalina

--- a/Formula/gphoto2.rb
+++ b/Formula/gphoto2.rb
@@ -11,6 +11,7 @@ class Gphoto2 < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "f78b5393c2d68ce33d628f59222612882fe93738ecbeffe76c2de4abccc3c296" => :big_sur
     sha256 "d268212bc96bdcd3df5f6cc289d7f62d9ad20ac0db6b2e5ca338c54b8e4b198f" => :arm64_big_sur
     sha256 "c4c42c50ee8bddf1a6b930f0eed9165a9e45ef1fb92476616833726b002ab077" => :catalina

--- a/Formula/graphene.rb
+++ b/Formula/graphene.rb
@@ -9,6 +9,7 @@ class Graphene < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "0e6af428f089a813408d7edc7a5196372a1ee8dd3ed13f7edbf4acfb1f62407a" => :big_sur
     sha256 "ed93a2b7f3830d38f82bece133afa43636e1cb90b3342c222909229260e63716" => :arm64_big_sur
     sha256 "d8519d2811ee796969121cd0b087fb7a5e96c2952c69bb2dfe206f3efc299e31" => :catalina

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -15,6 +15,7 @@ class Grpc < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "3e731c3e9d4c6d24f5293db3b93efc0d277f12f03679b6f35af9e0cea67e613c" => :big_sur
     sha256 "56d08703d69bc715c72b93a28c848ddaac63f1c2fbad09ebf39b271ff658fe8a" => :catalina
     sha256 "71b413ceeae0da5f236ef71fe9ea5168849df37462ba70a2ac9d99e1f5bf18c5" => :mojave

--- a/Formula/gsasl.rb
+++ b/Formula/gsasl.rb
@@ -11,6 +11,7 @@ class Gsasl < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "028f7609a7ca21f52e8341cf4c62a019297e0d156c8e3a6526ca68702d6da866" => :big_sur
     sha256 "83b752a80d1e1ebf8fc39b0fe64ffb53baa7fe0aad0c42df69a14bd3624158a7" => :arm64_big_sur
     sha256 "964ad480f7fafd04051fe76a288b5f109766ae39e4329b00f1a268b5082b316e" => :catalina

--- a/Formula/gssdp.rb
+++ b/Formula/gssdp.rb
@@ -10,6 +10,7 @@ class Gssdp < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "f5b00ceef2fed5c0140a8983fc8fed49cd220d1ad0cf1718125a81a047e370c3" => :big_sur
     sha256 "e3bc6dfa4ed41b0629533dbbe8fc4d9132a4349e05aacf0ea8099bf868fd6951" => :arm64_big_sur
     sha256 "9cda1333eede84e831da2553e50989bd5721460b0ab046c95414305c11e29adc" => :catalina

--- a/Formula/gst-rtsp-server.rb
+++ b/Formula/gst-rtsp-server.rb
@@ -11,6 +11,7 @@ class GstRtspServer < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "b4317689acd1ab2242fbf79485c6e41d3f7b6022f655cc5a1c0051a0e83fa58f" => :big_sur
     sha256 "ad3491746d607e87f9d3c413f993e95deea5f9cb1838fbd3155a241a8ec78886" => :arm64_big_sur
     sha256 "6de0097ebaf534fd685c904cea67866f038bfecf37c81f18b002746194d3a73c" => :catalina

--- a/Formula/gupnp.rb
+++ b/Formula/gupnp.rb
@@ -13,6 +13,7 @@ class Gupnp < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "40c8a74e84cbf2826c098c04e888989166cbe27a9f387754c69b046b3761e6e9" => :big_sur
     sha256 "0cb0e21dccf7a4cd8105303569e1f11409f46be63893eea7523d59eeff5b2398" => :catalina
     sha256 "24070ef84b5cad5ed79d0349b4f1bb41a1097aa20f0c401ab80b1c5646bdd153" => :mojave

--- a/Formula/h3.rb
+++ b/Formula/h3.rb
@@ -6,6 +6,7 @@ class H3 < Formula
   license "Apache-2.0"
 
   bottle do
+    cellar :any
     sha256 "65c2cd49b30043d5927f3cb1d83250e1cae623056faf823d596ed6e84186c145" => :big_sur
     sha256 "6fcd1a31fac3329f1f3d8e84e5d46cc601eb348956bca155e5aa614a18146101" => :catalina
     sha256 "2bb08dbd4274ba9f9195aefe3bd90d2afc3751b89ab11e3d2eb6e4ee67d418b5" => :mojave

--- a/Formula/hlint.rb
+++ b/Formula/hlint.rb
@@ -11,6 +11,7 @@ class Hlint < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "6fdfcfe8477ee9e8cd486931df5ecefbb385550bb5098e16bf7bcf985d3a1767" => :big_sur
     sha256 "3ae3bc2582fc2799f345778d5bd9e8e884192fc2c5b854c38014eea029190083" => :catalina
     sha256 "be1a75e267e36020847d93dbf1348f4263c135e25a292324795699fea70fb4ec" => :mojave

--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -13,6 +13,7 @@ class Infer < Formula
   end
 
   bottle do
+    cellar :any
     rebuild 1
     sha256 "1dc9c75c759611c8fe0efa8f63d7e55bbaa35d8dc2863f7a527069b11759f244" => :catalina
     sha256 "74b2dddff2bea362066395e28a797078d33514774511cc64771d0f89eea2466d" => :mojave

--- a/Formula/jrnl.rb
+++ b/Formula/jrnl.rb
@@ -12,6 +12,7 @@ class Jrnl < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "f9ca8bca15329ef3d89d3a2b8a5532ae7cceac1886d602042925f85880d63041" => :big_sur
     sha256 "d8b8f4d8b72fa13db0c6c233819684144f0f4a509354a9e7a3444dbd55bcea4a" => :arm64_big_sur
     sha256 "0b6415a27a1ae8295c766fe06a9eb0de676382ae46b27374e153e7d24d2528bf" => :catalina

--- a/Formula/jsonrpc-glib.rb
+++ b/Formula/jsonrpc-glib.rb
@@ -10,6 +10,7 @@ class JsonrpcGlib < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "922f8e0d4df5ea8c43e188ca633694d0665046c2a364c62348c32e22309f2b5b" => :big_sur
     sha256 "06160c00773beabdcff9556c7b3cc1149b281e693807adb50afa5004999482d1" => :arm64_big_sur
     sha256 "5dcab8d9974c1bd60c225d8ce2976fd20c0cedcaf2d537a57f42fe80aec20ece" => :catalina

--- a/Formula/kubebuilder.rb
+++ b/Formula/kubebuilder.rb
@@ -8,6 +8,7 @@ class Kubebuilder < Formula
   head "https://github.com/kubernetes-sigs/kubebuilder.git"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "c9fbe3f2af36d56afc501528827dd63aa7c2e450ae55d29372ea83b717b34d59" => :big_sur
     sha256 "6c271a2044413fe81d9c4671efbd2a66bce5ee9693731bfb2001292be1901a76" => :arm64_big_sur
     sha256 "b587ddd6d67b12a7fd2635f8f4da56402133a036fe79e635b08427b401a9b71b" => :catalina

--- a/Formula/libdazzle.rb
+++ b/Formula/libdazzle.rb
@@ -10,6 +10,7 @@ class Libdazzle < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "fa2282bdb8556341d8fdb814ced63d41a5936b7c2905c8e6f0f3e98c4d0b54da" => :big_sur
     sha256 "ef5f9dca4635b3347a8fda8285b55bd63b274ed51e6df5320ed3d61780b3bbab" => :arm64_big_sur
     sha256 "889b2107f7efceabc760c6e96f1a55c00765cf67a7d5d54a821f1d33e5b0db01" => :catalina

--- a/Formula/libepoxy.rb
+++ b/Formula/libepoxy.rb
@@ -14,6 +14,7 @@ class Libepoxy < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "70c98f994735bd0cd3c23286460c06fcbe324294f97b61ea91dc72303132c64d" => :big_sur
     sha256 "f4b0803937d1fa962e698890caa1ec96d7ba1847a4df990ad07db5ed480d8821" => :arm64_big_sur
     sha256 "f410ca0d9f4d101901beec178b22f4e65facdad58d496c7b2b5f9a56ec241852" => :catalina

--- a/Formula/libhttpseverywhere.rb
+++ b/Formula/libhttpseverywhere.rb
@@ -11,6 +11,7 @@ class Libhttpseverywhere < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "459d83997d7d69966ddee1e7a94e8583b4de8570ee1a796273a64a3d7845b8cd" => :big_sur
     sha256 "006bf3748d65067509e5b2e6d506f3b0a9a52c5eaab54780850b70b7f82ff249" => :arm64_big_sur
     sha256 "c8cc1d294949af9676e54f9a32c4dbe782dfc5d103f92bbee68acd2ccb5ff728" => :catalina

--- a/Formula/libidn.rb
+++ b/Formula/libidn.rb
@@ -10,6 +10,7 @@ class Libidn < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "86c6d6ed8d6ad080f9174997ffa8f37196a33d84ea914a6e11654560cc1475b0" => :big_sur
     sha256 "c0e93aac7cc1cc6dd1f7a99157e1713d8a05ecead8c8522fbcb631658577fc64" => :arm64_big_sur
     sha256 "1c1767101241edbd4141dc100e1c715b021be85e3fcf3657ea3bbdcb1fa884ec" => :catalina

--- a/Formula/mcrypt.rb
+++ b/Formula/mcrypt.rb
@@ -10,6 +10,7 @@ class Mcrypt < Formula
   end
 
   bottle do
+    cellar :any
     rebuild 3
     sha256 "284a74fc68549f1479e592b8daf2fd02f695292c5ca0334e7181906803396ceb" => :big_sur
     sha256 "488ff0ff6090f2d58c4bee440fe473f53f3755017bea445e84c94455c235a5b9" => :catalina

--- a/Formula/menhir.rb
+++ b/Formula/menhir.rb
@@ -6,6 +6,7 @@ class Menhir < Formula
   license "GPL-3.0-or-later"
 
   bottle do
+    cellar :any
     sha256 "2489afadf591e3052f81fc9219911e4c6d466d4933ea2a9fd44032f571e1abe4" => :big_sur
     sha256 "b5a6e90d021aa79d5b1b3f270bc4773b9fb06070c14ca1145b8ea04996ff7e8f" => :catalina
     sha256 "4d932e5fd011872bdc738b62ea7972a3ca6352aa5b7f74b59c3a5a3f9d4bea3e" => :mojave

--- a/Formula/mighttpd2.rb
+++ b/Formula/mighttpd2.rb
@@ -11,6 +11,7 @@ class Mighttpd2 < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "f4825cfc94adb7f0d47ca4dcaa3b924726845eef22dafa8a9603c6efe8a3e24d" => :big_sur
     sha256 "bcea435a9feba47df19b64d9fac972a1df8f580647204b07a73b2ade2e14c479" => :catalina
     sha256 "68e563757fb405de41a4312c03f7b72da99586430ea8f0aff98fdab48213635f" => :mojave

--- a/Formula/mpi4py.rb
+++ b/Formula/mpi4py.rb
@@ -10,6 +10,7 @@ class Mpi4py < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "3b761d6032292468252ff3c8aa01c61f4e71cf945235a88e18eebd97d9bfd957" => :big_sur
     sha256 "0f4729ca14721e02e752fa831f91c0463d32163e86c7097896843c553d0b8f30" => :arm64_big_sur
     sha256 "c6163dd690053dc5adcca25c63c54c5feb34d46248685e3d448ef673e907de36" => :catalina

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -17,6 +17,7 @@ class Mu < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "7feecba2de7299316bd86ced01e1546691c63d0b563a2c83b3957b8397169ad8" => :big_sur
     sha256 "43e9802fd4ce62ef3ce60126a01d047770b7bf17d9b74484b257275f74fee94a" => :arm64_big_sur
     sha256 "c2db643c69aaae50c5127dafd2018de2239c344c2b3a1cacb80cdb77d3710469" => :catalina

--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -7,6 +7,7 @@ class Multitail < Formula
   head "https://github.com/flok99/multitail.git"
 
   bottle do
+    cellar :any
     sha256 "bcba02065b68527b6e4826a42e8577d380b862c02c747a7de81b1aa40ef59dca" => :big_sur
     sha256 "931b37ad30df49390ef2e7c2d191821a735202d38b9fbb85f5ab9b00ed248eea" => :arm64_big_sur
     sha256 "6d0d74b45d02adc52fa6a5f666484c62941457da3cb10e50d65f5d772cc59c02" => :catalina

--- a/Formula/ncmpc.rb
+++ b/Formula/ncmpc.rb
@@ -11,6 +11,7 @@ class Ncmpc < Formula
   end
 
   bottle do
+    cellar :any
     rebuild 1
     sha256 "dcaf0d0af1cff22c8e2913fd55fef28a0205ca0ef88d38955e7dabaa06e3e241" => :big_sur
     sha256 "812169b73cb47055ee1574ff7278afa59ea92b70cafead63992052e7b193f4c0" => :arm64_big_sur

--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -11,6 +11,7 @@ class Numpy < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "980ff2b2a656a9bd8583d8ac53d79149db57c4e0ebc0787c7339ffff61196651" => :big_sur
     sha256 "12fa9cba958b6e32a78ac795469ba679dce6c8614e7fcd87a61a95de566feb00" => :arm64_big_sur
     sha256 "a9316c2fbc6289f359a8379f667d5c7db067f86c2be153d40cd400ab03fe83a5" => :catalina

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -10,6 +10,7 @@ class Ode < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "333320201f493ecb42eb9754a8c73d8490aa8d0155129865384fe2faf2706482" => :big_sur
     sha256 "3b69d29b04c4c733c4689be24f1ab4b49f646485650a6a55c10f2721de44e53b" => :arm64_big_sur
     sha256 "b033d3a8ddb92602728fbe921f5f421fed220c1d5293333d43801bf259a16cd5" => :catalina

--- a/Formula/open-sp.rb
+++ b/Formula/open-sp.rb
@@ -9,6 +9,7 @@ class OpenSp < Formula
   end
 
   bottle do
+    cellar :any
     rebuild 5
     sha256 "50109cdb514313693454259ba30f90f550618d48a1cc71df55ed04343d0cf641" => :big_sur
     sha256 "032676f1cd5c4bc0c1368cdf08bfe9a8b6df8f2c26ee4367c4a1285ab4fadc3a" => :arm64_big_sur

--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -8,6 +8,7 @@ class OperatorSdk < Formula
   head "https://github.com/operator-framework/operator-sdk.git"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "085720eb4fb2bfafd0475119ed704cadc62390e63829ea86337b4e5e763999f2" => :big_sur
     sha256 "1f5b6fc68245da7464e5ba868ec8e907a362def193c0339b2e44388c44fa3dc2" => :arm64_big_sur
     sha256 "8f65a0a7cb191314734b0eee3188e90d5c9f0f6441c7b103acbca01c51b67402" => :catalina

--- a/Formula/osmfilter.rb
+++ b/Formula/osmfilter.rb
@@ -9,6 +9,7 @@ class Osmfilter < Formula
   head "https://gitlab.com/osm-c-tools/osmctools.git"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "5647d8f3a704bd126e2b5f24237febb50989798b425147baf1d1ce1a08fbdaaa" => :big_sur
     sha256 "4b37db3c9ebe77673bbd83fb7d2e6c215760450987df2ded64044eccf6f34d3b" => :arm64_big_sur
     sha256 "5e2b755a970b7432fb076d787cb1777df18861832d0e4d45132fd84e4d7aea20" => :catalina

--- a/Formula/osslsigncode.rb
+++ b/Formula/osslsigncode.rb
@@ -6,6 +6,7 @@ class Osslsigncode < Formula
   license "GPL-3.0"
 
   bottle do
+    cellar :any
     sha256 "80c746077ac49b3e448559fe14b4802b3c0f3b4b54d720969a164d7f679afc5e" => :big_sur
     sha256 "8625c68db1963c4e359fd16862ccde8ae433889c441adb8892fc4cb0a63dc377" => :arm64_big_sur
     sha256 "964162e471801ec6335e1cb88fa7d71145a09acd7507f71d049af1edc6375f9e" => :catalina

--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -10,6 +10,7 @@ class PandocCrossref < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "158403ac3436da6fa1b74493dbe83f2d953438c5db16524ff58d81a9c619c8d8" => :big_sur
     sha256 "a20fe29a6b66f031331ee3cf1bb5f0f33a9ef7e501ea18ebd2575e291fd63cba" => :catalina
     sha256 "f23ddb7c3e1082203ebe84c084e4e13a769efcfbc6e2acf86263459072cc3a7d" => :mojave

--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -11,6 +11,7 @@ class Pandoc < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "32c22a3f7419bd316d13646c6a08a03063c5426809e55f6def0d6c119afbc31e" => :big_sur
     sha256 "1b72df54161967a99a125abfed2d2e1d3e398698cf687b7112e9a3477e68c5eb" => :catalina
     sha256 "c491b83ad4687043c7f525c2db08c6fddd38261697d7463d9dae6cc42fa4647b" => :mojave

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -11,6 +11,7 @@ class Pango < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "48d12081cc6415724e0b6f73fef7ac2df3d5c523a408d65c5105f7c83e4a2f40" => :big_sur
     sha256 "70e12652d4cb07296576f8f096e6a04fe51658a09ea4d904f4c1049400f45f1b" => :arm64_big_sur
     sha256 "8efc7e43fabedde9160927212857a7fa950a0ee4768374a5f36fc7b7a4e79c44" => :catalina

--- a/Formula/pinboard-notes-backup.rb
+++ b/Formula/pinboard-notes-backup.rb
@@ -7,6 +7,7 @@ class PinboardNotesBackup < Formula
   head "https://github.com/bdesham/pinboard-notes-backup.git"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "f5de063fa7d3ef372f34c0707fe22c4d1a9bef77142b221030ff75503d7a1194" => :big_sur
     sha256 "1735309c67f5ff12f212c8f780fe0cfb3d0409c53ce9376ee265597ceb517693" => :catalina
     sha256 "244865afa3cd3d89f059dd4e6a162de07ce8d404c9ea2c05dc92ef17869c75e8" => :mojave

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -7,6 +7,7 @@ class Ponyc < Formula
   license "BSD-2-Clause"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "fc1a3e92cdf2332a147126ea2ce4031fb6856e3f192152ae11190b29c63e723e" => :catalina
     sha256 "37cd9f8fe62fddafd4798b991598cffb36a446b4c5d153e6a4dbdf6b79e95713" => :mojave
     sha256 "299a27feca612c8d5dd6beb65e37ae16d8b259c1f9caedcb5d6b061a30f49dc0" => :high_sierra

--- a/Formula/postgrest.rb
+++ b/Formula/postgrest.rb
@@ -7,6 +7,7 @@ class Postgrest < Formula
   head "https://github.com/PostgREST/postgrest.git"
 
   bottle do
+    cellar :any
     sha256 "bb885e5c86b0e997b660b0ab3975d59c458f0db4436bce9ea158b89c65dcd6e2" => :big_sur
     sha256 "691546e89701fd582d47c697dc27551ef3284ee21933a5912f406e6fee4dd272" => :catalina
     sha256 "34c0413e71a41bc8550b7ea5286e0330aa888990d2e2a8fe6d81b57152c83d61" => :mojave

--- a/Formula/pre-commit.rb
+++ b/Formula/pre-commit.rb
@@ -8,6 +8,7 @@ class PreCommit < Formula
   license "MIT"
 
   bottle do
+    cellar :any
     sha256 "81f18e83e858feffacc9a9441c836a2abcf5b1a880f09ee99a261f12ac8ceca7" => :big_sur
     sha256 "ad84b382bed019d2574f985a6b9253634930764d14a16de1b9cc8c6c9b387b02" => :arm64_big_sur
     sha256 "16977b9f715b4330e7975761edddbaad4b891b25e6c8e4c4186ca4e2e99b11e7" => :catalina

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -11,6 +11,7 @@ class Protobuf < Formula
   end
 
   bottle do
+    cellar :any
     rebuild 1
     sha256 "b06e8c4247465d7773a359eeeaa39385e564fefab77dbbb245ac928eea334ce9" => :big_sur
     sha256 "67c2e767fbab9efc667ea729cfd08d081a1d3d7e93d7a86f68f8bd4a26ca5e8f" => :arm64_big_sur

--- a/Formula/psc-package.rb
+++ b/Formula/psc-package.rb
@@ -7,6 +7,7 @@ class PscPackage < Formula
   revision 1
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "f5baac6c49a67991b2ed0f2a2ba34898317e9cfd6864e8b446fb159f80ae04ec" => :catalina
     sha256 "e6cd795e5eade3414e2149f4fe4d529468293b122659ed5bd8b2b4df716c77cf" => :mojave
     sha256 "0b0411dfd516bac15b2e99cba163dbc3c77742eae9e09038ac85ef1793ce767c" => :high_sierra

--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -12,6 +12,7 @@ class Purescript < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "3fd65800108e0e185468ca1779a8e6599e1834be1f9f1179da5d964221d82461" => :catalina
     sha256 "2438c8f73284b0c5923f7bace263e0b00b8df592b073127cd4dd16178d512199" => :mojave
     sha256 "a12832fe00786da347d0069578ff78556aa93890a28e5ae36497e3b4b7f68aab" => :high_sierra

--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -11,6 +11,7 @@ class Pygobject3 < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "d9eb35a72a4970c2c6c537b7b8938f9147390a2cd4027d33bb119417c5693aa1" => :big_sur
     sha256 "7b65e09a52672b0b31ebeb73308d25adae46baf3d0a7d544da0c3a50617d90c4" => :arm64_big_sur
     sha256 "e4e592579b949b2b7df8cbd3b3956d3ee285054a4c1e3ecfbc9647a4e9bcf24e" => :catalina

--- a/Formula/qca.rb
+++ b/Formula/qca.rb
@@ -23,6 +23,7 @@ class Qca < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "0ce2bbd226e16d2e037c61f404123be202e6b3be814f3eab5be83f95f6803978" => :big_sur
     sha256 "4d4c37739a1afeeb5623bdbc7800b82652a93e02770cdc06b63379ae35746223" => :arm64_big_sur
     sha256 "55a109c49bc235dd6423f5924b3879c3c9677670bc45650306aa5f14cf9877aa" => :catalina

--- a/Formula/recode.rb
+++ b/Formula/recode.rb
@@ -6,6 +6,7 @@ class Recode < Formula
   license "GPL-3.0-or-later"
 
   bottle do
+    cellar :any
     sha256 "6d53af7b188693ffa022df92beea56d3963482c8206d1608e25d47ca5bd88848" => :big_sur
     sha256 "c116a7d29975a1649b79f96067de047149050454d11fb09146066e617fadd13f" => :arm64_big_sur
     sha256 "367ab01690803d0270de4734faf1ef5175c2e3df7528b9f64bdcc0c1a78f1668" => :catalina

--- a/Formula/recutils.rb
+++ b/Formula/recutils.rb
@@ -11,6 +11,7 @@ class Recutils < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "20ea3e2b014d2300a75f02b3c2beaf4c888c37214df878c5dccbad9255f65de4" => :big_sur
     sha256 "0ce93377375f551690f93d4cd68d2042f72354596dcae615ee632e8794bd7744" => :arm64_big_sur
     sha256 "a55cbe91cc2c264fe53e5e6425c1f3bb0c090f097f16098fdce766807a38ea6d" => :catalina

--- a/Formula/remarshal.rb
+++ b/Formula/remarshal.rb
@@ -14,6 +14,7 @@ class Remarshal < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "8521482cf34a60440f479a03265a6e7d8620ccf100496a6720f92eed4af11145" => :big_sur
     sha256 "b0c1b75665dca786bde756d4af9c520a8663cc940a9c7b10a105d447e14ec2c2" => :arm64_big_sur
     sha256 "204004c532be6254a8366067b285e5d900c0cb6961ad47e589d03f7cbd4eed55" => :catalina

--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -13,6 +13,7 @@ class Ripgrep < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "0ca7397f9a0ccef6cbb8ff0fd8fb18c6fe86219abaef350e3d7ef248d07440fd" => :big_sur
     sha256 "e0147ba489a8d96e33fc8be7e2172c632075d5d31a4f6267c3606e463280e0e3" => :arm64_big_sur
     sha256 "60460d422253113af3ed60332104f309638942821c655332211a6bc2213c472c" => :catalina

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -21,6 +21,7 @@ class Rust < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "da85eda34441caa60b6a639e5fc4dd23705c8716b4c9c6384b84305e96e4bd8c" => :big_sur
     sha256 "89d3f5672025a3b3004979f996f1c00b00a021e891fece6ec424dc65710485db" => :arm64_big_sur
     sha256 "52aa819637578a4ee9c75fdbc4c449b4d78c932294970d1e2480827d8c07dff0" => :catalina

--- a/Formula/sbcl.rb
+++ b/Formula/sbcl.rb
@@ -10,6 +10,7 @@ class Sbcl < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "e6a0d4ba798d435a261e93062461a15801a42af1cab9344cdeab824b00112318" => :big_sur
     sha256 "82afe9ba6dad370ba0895be28b3591eeae9bb88fbba93a916637cea1e6b140c3" => :catalina
     sha256 "a8eadb8a7b8a092995d0f29f4b68cf5450c070dd41bdf3f9f15e4907b516d48b" => :mojave

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -11,6 +11,7 @@ class Scipy < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "e6ac47d444999cbfdf8c68f4016af207e093fcfa8f60da704e6e1ca1bf8963d2" => :big_sur
     sha256 "c5624a8bf499a9b1491fd92a5b951f123348125a3ff362edabe83c52cb698324" => :arm64_big_sur
     sha256 "459a424a9433cefd235ae700f3016a070df09fadff99246ac72be3427a2259d1" => :catalina

--- a/Formula/seal.rb
+++ b/Formula/seal.rb
@@ -6,6 +6,7 @@ class Seal < Formula
   license "MIT"
 
   bottle do
+    cellar :any
     sha256 "fa0987fdcf86b96cf972ff894bbdd8d24afc3e72c41cb9be25278b851ddb7986" => :big_sur
     sha256 "24878952d071677bb9822e46cef024ddbc7d382ecbef9531eecf663dc9335323" => :arm64_big_sur
     sha256 "59fb7528d124443c8443c1f9ccb8f12ab357e005f1755b9eb8a230a3426fb9dc" => :catalina

--- a/Formula/shared-mime-info.rb
+++ b/Formula/shared-mime-info.rb
@@ -11,6 +11,7 @@ class SharedMimeInfo < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "a89243613f2b5108a735abbe0a65ee02dcc39b5246a8f8b284c28cc9d8b86014" => :big_sur
     sha256 "bc94b21215784d4c26772de6b88ef5d1a4efa497f5c8479033e0d523f115c4e7" => :arm64_big_sur
     sha256 "5aefdc7964e569188cb67a49f4a428c64130f7c048ffd55106c656eb0c6caa25" => :catalina

--- a/Formula/shellcheck.rb
+++ b/Formula/shellcheck.rb
@@ -7,6 +7,7 @@ class Shellcheck < Formula
   head "https://github.com/koalaman/shellcheck.git"
 
   bottle do
+    cellar :any_skip_relocation
     rebuild 1
     sha256 "c7bd19ca5bc623c8a958c4cb56b77ab89e652c20a1a66dfbbc0c5d8832b60ada" => :big_sur
     sha256 "0cd635d2172d5e6617be8cdfb2723b6aa6feb2aa22e36cb3172d8b6fa012f4a0" => :catalina

--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -7,6 +7,7 @@ class Spdlog < Formula
   head "https://github.com/gabime/spdlog.git", branch: "v1.x"
 
   bottle do
+    cellar :any
     sha256 "e3a306a9e37b2fa5d35857daed33e4ebbf0fdb503d0061a1e8ec443521abcf1f" => :big_sur
     sha256 "642108455663ea0eb7bb0d430c82b1dc359b6411f966cafbb0092af775468322" => :arm64_big_sur
     sha256 "0da73847d24190c8f51d017abab07176f6d609a409c58c0df27d1dcfd1bbd375" => :catalina

--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -7,6 +7,7 @@ class Sratoolkit < Formula
   head "https://github.com/ncbi/sra-tools.git"
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "2e6ba6ca7df3d84b405aa1f2f8f198a30428ad7c8b4b0e4f17c9b90499851e94" => :big_sur
     sha256 "4a0110b9f08743369503f72bbfcd24aec64f87a820e61ad75652f85ea058203d" => :catalina
     sha256 "bf46b5e1ba3fb51cc2ef92dd6bc3a3b30946cf505fb3c5262b826e04c5a09604" => :mojave

--- a/Formula/ssed.rb
+++ b/Formula/ssed.rb
@@ -6,6 +6,7 @@ class Ssed < Formula
   license "GPL-2.0-or-later"
 
   bottle do
+    cellar :any_skip_relocation
     rebuild 2
     sha256 "8ead33fc5954cd35bdff6291cec76e4ee2d6011d0f4d7025e832c9fa2514c31b" => :big_sur
     sha256 "2b6c860af3e99b067b867a53b1b7135918cf1ff10e27b744a4157c2134b866f5" => :arm64_big_sur

--- a/Formula/stormssh.rb
+++ b/Formula/stormssh.rb
@@ -12,6 +12,7 @@ class Stormssh < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "79e330e941213f27be8570d069e752ac8062a3956a84a7f62ba8965584011e54" => :big_sur
     sha256 "e79afe5b92e065a4700562f0c440ca31ca10942bf3d7bd53676e9db0fe76765e" => :catalina
     sha256 "63e97d8df81a1e56544fc231f404693cf0ce0263ea2a375d97b6a2c6608e72a2" => :mojave

--- a/Formula/texmath.rb
+++ b/Formula/texmath.rb
@@ -10,6 +10,7 @@ class Texmath < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "f091dafb8c9967d2a47b85f45361e60eb7c85b88b8346d76cb2db8a757a1f776" => :big_sur
     sha256 "2769946483f9d19111f011337b7a25f2cf46145ddc86990fe58c311194be0eb8" => :catalina
     sha256 "a155b6bad3842722d5bdbe2fa22be5c10aa191ab44ebaa63000a921acef24b1f" => :mojave

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -7,6 +7,7 @@ class Travis < Formula
   revision 2
 
   bottle do
+    cellar :any
     sha256 "99dc7883369970404609ba84dae65605c9c53be3deda72591fe19ffc67c06ef7" => :big_sur
     sha256 "8f1ccd0d3968312e30c5451e80704472d9b717275ad09d64c2d475fc92666d3e" => :arm64_big_sur
     sha256 "cd76462008b4094ecc79d7b715bc8bbe25c16648c2ae4be0a939415fa61b6d02" => :catalina

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -14,6 +14,7 @@ class UtilLinux < Formula
   ]
 
   bottle do
+    cellar :any
     rebuild 2
     sha256 "fc3327a2f46d034d163710b29b6b04fb44cabcb31102a2b099d9dbd73e302bce" => :big_sur
     sha256 "91a76aecae9e1fcdbd44614439c6eb379dcaf1c2e388403eb33d698b986cc587" => :arm64_big_sur

--- a/Formula/webpack.rb
+++ b/Formula/webpack.rb
@@ -14,6 +14,7 @@ class Webpack < Formula
   end
 
   bottle do
+    cellar :any_skip_relocation
     sha256 "c2ebd9cad7f2b642264f15666283a50305c6950509d025e52706980721ae6a37" => :big_sur
     sha256 "84c6816293c4065037800196ddeabeb6c9209be47c3248d71ff7a851eb4f84a3" => :arm64_big_sur
     sha256 "253d5b31cc29da6c3419d796f6d0e70371a984ba91f6bc03d3a3b8bb69cd7aee" => :catalina

--- a/Formula/wordgrinder.rb
+++ b/Formula/wordgrinder.rb
@@ -8,6 +8,7 @@ class Wordgrinder < Formula
   head "https://github.com/davidgiven/wordgrinder.git"
 
   bottle do
+    cellar :any
     sha256 "d2cb8d569e0a7a02abae8deb32adf8a564042cfd6cddaeef4bc1dc16ab05e53b" => :big_sur
     sha256 "370093b3705f72a5d6b87bacd2e64e229f3d6ac82e52e92fe147c037d65f210b" => :arm64_big_sur
     sha256 "e084da6193fd984ac541e7c21044f80927b60b85ab69512d3824255be1c54d17" => :catalina

--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -11,6 +11,7 @@ class XmlToolingC < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "57c8c16990f589f0e07a7e5d57dd202c4f35b6e66d57bbda66d4d9bc2af6bd33" => :big_sur
     sha256 "859a056b4271610e876b42606d145a0ddc2d79cb94c0470e2ca93cdef38c4e2b" => :catalina
     sha256 "69d6679f8c610867e03269af38ce56306af656a2e1f7b3bbce30d25085d6ae9a" => :mojave

--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -13,6 +13,7 @@ class Xz < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "4fbd4a9e3eb49c27e83bd125b0e76d386c0e12ae1139d4dc9e31841fb8880a35" => :big_sur
     sha256 "c84206005787304416ed81094bd3a0cdd2ae8eb62649db5a3a44fa14b276d09f" => :arm64_big_sur
     sha256 "2dcc8e0121c934d1e34ffdb37fcd70f0f7b5c2f4755f2f7cbcf360e9e54cb43b" => :catalina

--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -7,6 +7,7 @@ class Zig < Formula
   head "https://github.com/ziglang/zig.git"
 
   bottle do
+    cellar :any
     sha256 "f088607533abf8e77c38ad57b5c068b7c975d31d3558eda5ff9ef23221278650" => :big_sur
     sha256 "f1168c13a73d6677a8d6eb04ecd0d67e93038bd33218bafadd9aac9a23045e7d" => :catalina
     sha256 "eb2e0de16f666b740fb67529910712c517fed8ae3fd6e14d27acbbf19a41018a" => :mojave


### PR DESCRIPTION
Add cellar `:any` or `cellar :any_skip_relocation`.
Rust is `cellar :any` on macOS, so it should also be `cellar :any` on Linux.

See https://github.com/Homebrew/linuxbrew-core/pull/21804#issuecomment-750435924

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
