### PR TITLE
gcc: add cellar :any to other versions

### DIFF
--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -16,11 +16,11 @@ class GccAT6 < Formula
   # gcc is designed to be portable.
   # reminder: always add 'cellar :any'
   bottle do
+    cellar :any
     sha256 "cf8ac5c477ca44b95d3ef8c18685ca567386c2a839433842da0cb737a5cd7266" => :big_sur
     sha256 "59e24c6441d4ebd6e6462406d07a4722f765b81aa96b0c81117376cf342641b0" => :catalina
     sha256 "2280bb37e05ca20d3d797a4b75695ea6d57196c2f4b4003d43ba191883558073" => :mojave
     sha256 "e3ab3cd2f05c00351825fb0a6bf2b4e57e959400d8f7931d47b9c81a3e5b6ad3" => :high_sierra
-    sha256 "43508774d3ddc6d40b5513ef716ac568a4ac7b9bc120f070c810bf08c469c018" => :x86_64_linux
   end
 
   # The bottles are built on systems with the CLT installed, and do not work

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -15,11 +15,11 @@ class GccAT7 < Formula
 
   # gcc is designed to be portable.
   bottle do
+    cellar :any
     sha256 "4c0fc49fe4d65a7ab06a9417987cc2c1367959f885d0c77cd3ba36ca78e129d6" => :big_sur
     sha256 "4dca3b07173bffba262e003b345970119626a4d60a25c167d6bc216c46f1d83e" => :catalina
     sha256 "5d4086421866078dc4d9bfe623a38160dbcf04ff88b4d0284dee9da66ff50f4c" => :mojave
     sha256 "3c2135fc0b1c7f0ce048c1f610d2131a237911bdbd66d8bff731bbf9c6d84bcc" => :high_sierra
-    sha256 "6437a3ac47e16db165b34c81eb9baffd9615821ba62cf038db14a4bb64da9183" => :x86_64_linux
   end
 
   # The bottles are built on systems with the CLT installed, and do not work

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -16,11 +16,11 @@ class GccAT8 < Formula
   # gcc is designed to be portable.
   # reminder: always add 'cellar :any'
   bottle do
+    cellar :any
     sha256 "2b1ad3c27b2df7c7f888de7c977a22a5b7d5bf1b79d163d9a54186f634f7a672" => :big_sur
     sha256 "55525171b1a90425dab69799f3730492cd3f04b2755242340472925794104962" => :catalina
     sha256 "3321d929ae429e3ccf8b4c4e265e20e6302d361d5c444f4b7a5217771b8d0b01" => :mojave
     sha256 "80b73e0a1679e7ca9e098de1e82e19e312d159098b3355607b76a3673b80c2ee" => :high_sierra
-    sha256 "75adcf873c1cc4ad95a9d417eec1a1490546a500775b11c0750f8d6a69ce842b" => :x86_64_linux
   end
 
   # The bottles are built on systems with the CLT installed, and do not work

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -14,11 +14,11 @@ class GccAT9 < Formula
 
   # gcc is designed to be portable.
   bottle do
+    cellar :any
     sha256 "7145501b8ae1900115ed6ed6ed3d991cf1fde3ae733007a2150375026392c1a6" => :big_sur
     sha256 "68aa5249f09a70b9c46bd403a46ae42b64f6ea6b3a2af00603852ecaf77c72ce" => :catalina
     sha256 "445cf4a6a4f8f3da61c7e1e6aceaf6fe919a08c475126b2b1e159eae829617a4" => :mojave
     sha256 "682244d252f68de9513ed43f45e3e9f80bcd582e58df1d4aaa16197f3fc88742" => :high_sierra
-    sha256 "f0541e9d52543d196ea29085cb36a27ea4c844f4cef9bfd678473da270060c28" => :x86_64_linux
   end
 
   # The bottles are built on systems with the CLT installed, and do not work


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Currently gcc@4.9, gcc@5, and gcc@10 have `cellar :any` while `gcc@6`, `gcc@7`, `gcc@8`, and `gcc@9` do not, but have before.  I don't why they were lost (possibly because they don't have `cellar :any` in homebrew-core), but restoring it makes life a lot easier!  

I had also mentioned in [here](https://github.com/Homebrew/linuxbrew-core/pull/21804) that maybe we should be able to remove the code which depends on brewed `glibc`, but after looking at it, all it does is add `glibc` as a dependency and set up some symlinks in post-install.  The actual build block contains no references to brewed `glibc`, and I should note that as of now `gcc` doesn't actually compile with brewed `glibc`.  But that doesn't matter since `gcc` is relocatable.