### PR TITLE
open-mpi: remove unnecessary env variable

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -41,18 +41,13 @@ class OpenMpi < Formula
   conflicts_with "mpich", because: "both install MPI compiler wrappers"
 
   def install
-    # Fix libopen-pal.so: undefined reference to `__atomic_compare_exchange_16'
-    ENV["HOMEBREW_OPTFLAGS"] = "" if !OS.mac? && build.bottle?
-
-    if OS.mac?
-      if MacOS.version == :big_sur
-        # Fix for current GCC on Big Sur, which does not like 11 as version value
-        # (reported at https://github.com/iains/gcc-darwin-arm64/issues/31#issuecomment-750343944)
-        ENV["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
-      else
-        # Otherwise libmpi_usempi_ignore_tkr gets built as a static library
-        ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
-      end
+    if MacOS.version == :big_sur
+      # Fix for current GCC on Big Sur, which does not like 11 as version value
+      # (reported at https://github.com/iains/gcc-darwin-arm64/issues/31#issuecomment-750343944)
+      ENV["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
+    else
+      # Otherwise libmpi_usempi_ignore_tkr gets built as a static library
+      ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
     end
 
     # Avoid references to the Homebrew shims directory


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
