### PR TITLE
spidermonkey: cleanup as this does not build without Python 2

### DIFF
--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -5,7 +5,7 @@ class Spidermonkey < Formula
   version "1.8.5"
   sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
   license "MPL-1.1"
-  revision OS.mac? ? 4 : 5
+  revision 4
   head "https://hg.mozilla.org/mozilla-central", using: :hg
 
   livecheck do
@@ -23,11 +23,6 @@ class Spidermonkey < Formula
   depends_on :macos # Due to Python 2
   depends_on "nspr"
   depends_on "readline"
-
-  unless OS.mac?
-    depends_on "python@3.9" => :build
-    depends_on "zip" => :build
-  end
 
   conflicts_with "narwhal", because: "both install a js binary"
 
@@ -49,7 +44,6 @@ class Spidermonkey < Formula
 
     mkdir "brew-build" do
       system "../js/src/configure", "--prefix=#{prefix}",
-                                    *("--enable-readline" if OS.mac?),
                                     "--enable-threadsafe",
                                     "--with-system-nspr",
                                     "--with-nspr-prefix=#{Formula["nspr"].opt_prefix}",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
