### PR TITLE
petsc: fix build for Linux (temporarily reopened to test in CI)

### DIFF
--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -42,7 +42,16 @@ class Petsc < Formula
 
     # Avoid references to Homebrew shims
     rm_f lib/"petsc/conf/configure-hash"
-    inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
+
+    on_macos do
+      inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
+    end
+
+    on_linux do
+      if File.readlines("#{lib}/petsc/conf/petscvariables").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
+        inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
+      end
+    end
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

I'm temporarily reopening this only to test the new fix in CI.  As mentioned in https://github.com/Homebrew/linuxbrew-core/pull/21811, there is a step which removes Homebrew shims from a file.  On my local system, that file contains contains no shim references, but in CI it does.  To resolve this, I have added a check on Linux to make sure the shim references actually exist before trying to remove them.  As soon as this passes CI, I will close it and reopen in homebrew-core.  Apologies if this is an inefficient way of testing this in CI, if there is a better way that doesn't require me to reopen a PR, let me know and I can do that instead.