### PR TITLE
glibc: add display strings to Requirements

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -13,6 +13,10 @@ class BrewedGlibcNotOlderRequirement < Requirement
       Installing a version of glibc that is older than your system's can break formulae installed from source.
     EOS
   end
+
+  def display_s
+    "System glibc < #{Glibc.version}"
+  end
 end
 
 class GlibcBaseRequirement < Requirement
@@ -25,6 +29,10 @@ class GlibcBaseRequirement < Requirement
         sudo apt-get install #{tool}
         sudo yum install #{tool}
     EOS
+  end
+
+  def display_s
+    "#{self.class::TOOL} #{self.class::VERSION}".strip
   end
 end
 
@@ -67,6 +75,10 @@ class LinuxKernelRequirement < Requirement
       Linux kernel version #{MINIMUM_LINUX_KERNEL_VERSION} or later is required by glibc.
       Your system has Linux kernel version #{linux_kernel_version}.
     EOS
+  end
+
+  def display_s
+    "Linux kernel #{MINIMUM_LINUX_KERNEL_VERSION} (or later)"
   end
 end
 


### PR DESCRIPTION
Adds display text to the glibc requirements so it's a bit clearer what needs to be done on systems needing brewed glibc.

before:

```
==> Dependencies
Build: binutils ✘, linux-headers ✘
==> Requirements
Build: Gawk ✘, Make ✔, Sed ✔
Required: Brewedglibcnotolder ✘, Linux ✔, Linuxkernel ✔
```

after:

```
==> Dependencies
Build: binutils ✘, linux-headers ✘
==> Requirements
Build: gawk 3.1.2 (or later) ✘, make 3.79 (or later) ✔, sed ✔
Required: System glibc < 2.23 ✘, Linux ✔, Linux kernel 2.6.32 (or later) ✔
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----