### PR TITLE
docbook: align with upstream

### DIFF
--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -79,24 +79,20 @@ class Docbook < Formula
     end
   end
 
-  def xmlcatalog
-    OS.mac? ? "xmlcatalog" : "#{Formula["libxml2"].opt_bin}/xmlcatalog"
-  end
-
   def post_install
     etc_catalog = etc/"xml/catalog"
     ENV["XML_CATALOG_FILES"] = etc_catalog
 
     # only create catalog file if it doesn't exist already to avoid content added
     # by other formulae to be removed
-    system xmlcatalog, "--noout", "--create", etc_catalog unless File.file?(etc_catalog)
+    system "xmlcatalog", "--noout", "--create", etc_catalog unless File.file?(etc_catalog)
 
     %w[4.2 4.1.2 4.3 4.4 4.5 5.0 5.1].each do |version|
       catalog = opt_prefix/"docbook/xml/#{version}/catalog.xml"
 
-      system xmlcatalog, "--noout", "--del",
+      system "xmlcatalog", "--noout", "--del",
              "file://#{catalog}", etc_catalog
-      system xmlcatalog, "--noout", "--add", "nextCatalog",
+      system "xmlcatalog", "--noout", "--add", "nextCatalog",
              "", "file://#{catalog}", etc_catalog
     end
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This is a test PR to see if `Formula["libxml2"].opt_bin` needs to be added to `PATH` in order for the `xmlcatalog` command to work 