### PR TITLE
neomutt: remove linux-only dependencies; does not currently build

### DIFF
--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -23,10 +23,6 @@ class Neomutt < Formula
   depends_on "notmuch"
   depends_on "openssl@1.1"
   depends_on "tokyo-cabinet"
-  unless OS.mac?
-    depends_on "krb5"
-    depends_on "libsasl2"
-  end
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
