### PR TITLE
xcb-proto: Remove unneeded 'inreplace' statement.

### DIFF
--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -26,8 +26,6 @@ class XcbProto < Formula
   end
 
   def install
-    inreplace "xcbgen/align.py", "from fractions import gcd", "from math import gcd"
-
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}


### PR DESCRIPTION
Remove an 'inreplace' statement superceeded by the patch
with the fix to use math.gcd() or fractions.gcd() depending
on Python version which is the fix for #21816.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
