### PR TITLE
gnutar: replace compound `unless` with `if`

### DIFF
--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -39,7 +39,7 @@ class GnuTar < Formula
     ENV["gl_cv_func_getcwd_abort_bug"] = "no" if MacOS.version == :el_capitan
 
     # Fix configure: error: you should not run configure as root
-    ENV["FORCE_UNSAFE_CONFIGURE"] = "1" unless OS.mac? && ENV["CI"]
+    ENV["FORCE_UNSAFE_CONFIGURE"] = "1" if !OS.mac? || !ENV["CI"]
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
<!-- - [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

----- -->

This is part of https://github.com/Homebrew/brew/pull/10256, which adds a rubocop that disallows `unless` statements with multiple conditions

homebrew-core PR: https://github.com/Homebrew/homebrew-core/pull/68527

Truth table for reference:

<table class="truthTable">
<tr class="header">
<th class="variable">p</th>
<th class="variable">q</th>
<th class="expression">!(p && q)</th>
<th class="expression">!p || !q</th>
<th class="expression">!(p || q)</th>
<th class="expression">!p && !q</th>
</tr>
<tr>
<td>F</td><td>F</td><td>T</td><td>T</td><td>T</td><td>T</td>
</tr>
<tr>
<td>F</td><td>T</td><td>T</td><td>T</td><td>F</td><td>F</td>
</tr>
<tr>
<td>T</td><td>F</td><td>T</td><td>T</td><td>F</td><td>F</td>
</tr>
<tr>
<td>T</td><td>T</td><td>F</td><td>F</td><td>F</td><td>F</td>
</tr>
</table>