### PR TITLE
graphviz: disable poppler

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -61,6 +61,7 @@ class Graphviz < Formula
       --without-gdk
       --without-gdk-pixbuf
       --without-gtk
+      --without-poppler
       --without-qt
       --without-x
       --with-gts


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

If `poppler` is found by `graphviz`, the build will fail if `poppler` is not included as a dependency.  Since `poppler` brings in many dependencies, we should disable support rather than adding it as a dependency.