### PR TITLE
atomicparsley: use newer gcc

### DIFF
--- a/Formula/atomicparsley.rb
+++ b/Formula/atomicparsley.rb
@@ -19,6 +19,13 @@ class Atomicparsley < Formula
   depends_on "cmake" => :build
   uses_from_macos "zlib"
 
+  unless OS.mac?
+    fails_with gcc: "4"
+    fails_with gcc: "5"
+    fails_with gcc: "6"
+    depends_on "gcc@7" => :build
+  end
+
   def install
     system "cmake", ".", *std_cmake_args
     system "cmake", "--build", ".", "--config", "Release"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This formula needs a newer version of `gcc` to build on Linux.