### PR TITLE
gdb: use newer gcc

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -21,6 +21,13 @@ class Gdb < Formula
   depends_on "python@3.9"
   depends_on "xz" # required for lzma support
 
+  unless OS.mac?
+    fails_with gcc: "4"
+    fails_with gcc: "5"
+    fails_with gcc: "6"
+    depends_on "gcc@7"
+  end
+
   uses_from_macos "texinfo" => :build
   uses_from_macos "expat"
   uses_from_macos "ncurses"
@@ -53,6 +60,7 @@ class Gdb < Formula
     ]
 
     ENV.append "CPPFLAGS", "-I#{Formula["python@3.9"].opt_libexec}" unless OS.mac?
+    ENV.append "LDFLAGS", "-L#{Formula["gcc@7"].opt_lib}/gcc/7" unless OS.mac?
 
     mkdir "build" do
       system "../configure", *args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

GDB 10 seems to need a newer version of GCC.  I had to add the newer GCC path to the LDFLAGS to prevent if from using `libstdc++` from GCC 5.