### PR TITLE
ispell: Depends on bison to build

### DIFF
--- a/Formula/ispell.rb
+++ b/Formula/ispell.rb
@@ -17,6 +17,7 @@ class Ispell < Formula
     sha256 "14e8be247605fc01cacfeb0d115945217b028a1ff372f33fbe8132f03f88e9d8" => :mojave
   end
 
+  uses_from_macos "bison" => :build
   uses_from_macos "ncurses"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
Fix error:

+ yacc parse.y
/bin/sh: 3: yacc: not found

See https://gist.github.com/rwhogg/54d98699ff43d5c776541fb1c61a45c6 for full logs