### PR TITLE
go: don't hardcode gcc-* as CC

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -2,6 +2,7 @@ class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://golang.org"
   license "BSD-3-Clause"
+  revision 1 unless OS.mac?
 
   stable do
     if Hardware::CPU.arm?
@@ -31,7 +32,6 @@ class Go < Formula
     sha256 "c2bd24b5a24c19bfdf97a8904aaa76c4db2a8f59096aade83310fee7af4b186c" => :arm64_big_sur
     sha256 "9dac57ef268c5fee434ac7896fc77f16f16f34462822e216c9973ade6a768e0b" => :catalina
     sha256 "af0b8702944cde293206a5847bea8fb5aed66babed82fb202aff696ac5211691" => :mojave
-    sha256 "1f9fe5de75650da3e328b763ffc7a3c807c271b1029cab6859b1d291036c73fd" => :x86_64_linux
   end
 
   head do
@@ -72,7 +72,15 @@ class Go < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      system "./make.bash", "--no-clean"
+      on_macos do
+        system "./make.bash", "--no-clean"
+      end
+      on_linux do
+        env = {
+          "CC" => "gcc",
+        }
+        system env, "./make.bash", "--no-clean"
+      end
     end
 
     (buildpath/"pkg/obj").rmtree

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -71,16 +71,14 @@ class Go < Formula
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
 
     cd "src" do
-      ENV["GOROOT_FINAL"] = libexec
-      on_macos do
-        system "./make.bash", "--no-clean"
-      end
       on_linux do
-        env = {
-          "CC" => "gcc",
-        }
-        system env, "./make.bash", "--no-clean"
+        inreplace "cmd/dist/build.go" do |s|
+          s.gsub! "CC", "HOMEBREW_CC"
+          s.gsub! "CXX", "HOMEBREW_CXX"
+        end
       end
+      ENV["GOROOT_FINAL"] = libexec
+      system "./make.bash", "--no-clean"
     end
 
     (buildpath/"pkg/obj").rmtree

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -72,9 +72,11 @@ class Go < Formula
 
     cd "src" do
       on_linux do
+        ENV["HOMEBREW_GO_CC"] = "gcc"
+        ENV["HOMEBREW_GO_CXX"] = "g++"
         inreplace "cmd/dist/build.go" do |s|
-          s.gsub! "CC", "HOMEBREW_CC"
-          s.gsub! "CXX", "HOMEBREW_CXX"
+          s.gsub! "CC", "HOMEBREW_GO_CC"
+          s.gsub! "CXX", "HOMEBREW_GO_CXX"
         end
       end
       ENV["GOROOT_FINAL"] = libexec


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

`go env` reports:

```
CC="gcc-5"
CXX="g++-5"
```

this is wrong, not every user has `gcc-5` installed, but every one should have `gcc`.
So need to replace those strings, post-build.