### PR TITLE
Merge 2021-02-04 e2c833d326c

### DIFF
--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -7,7 +7,7 @@ class Allegro < Formula
   head "https://github.com/liballeg/allegro5.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -8,7 +8,7 @@ class ArduinoCli < Formula
   head "https://github.com/arduino/arduino-cli.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -1,8 +1,8 @@
 class Armadillo < Formula
   desc "C++ linear algebra library"
   homepage "https://arma.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/arma/armadillo-10.2.0.tar.xz"
-  sha256 "82f84d526c8da72240ab05cb12b3f3f1e674d20ccb38e008e4bf53355b1aa68a"
+  url "https://downloads.sourceforge.net/project/arma/armadillo-10.2.1.tar.xz"
+  sha256 "7d8e74d248769af23fc894d8bb88f05e32317933cbe4da8f3c56be8f89a9fcc4"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -9,7 +9,7 @@ class AzureCli < Formula
   head "https://github.com/Azure/azure-cli.git"
 
   livecheck do
-    url :head
+    url :stable
     strategy :github_latest
     regex(%r{href=.*?/tag/azure-cli[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end

--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -1,18 +1,26 @@
 class BdwGc < Formula
   desc "Garbage collector for C and C++"
   homepage "https://www.hboehm.info/gc/"
-  url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
-  sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
   license "MIT"
   revision 2
 
+  stable do
+    url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
+    sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
+
+    # Extension to handle multithreading
+    # https://github.com/ivmai/bdwgc/pull/277
+    patch do
+      url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch?full_index=1"
+      sha256 "5c42d4b37cf4997bb6af3f9b00f5513644e1287c322607dc980a1955a09246e3"
+    end
+  end
+
   bottle do
-    rebuild 1
-    sha256 cellar: :any, arm64_big_sur: "928805b89e3de74d9d45043077ee9e64de15079ae9730216a604603afb17b810"
-    sha256 cellar: :any, big_sur:       "bb94ab58bc20b01662c432d21920c9a2e644aad92208b640658d3fd9fb530636"
-    sha256 cellar: :any, catalina:      "31634ad61ce92329e34154feb1ad14e4786592555ef9a14259a09ea0648d5af7"
-    sha256 cellar: :any, mojave:        "898aa902c343deda1046532d36351a9d0a08d619dda393f4e50dbc78c674a580"
-    sha256 cellar: :any, x86_64_linux:  "5953cd08c52a9dbae1dac9c0d50cf95dd854140bd2cf4d60ed9913271241c984"
+    sha256 cellar: :any, arm64_big_sur: "ee743d115b619b02230863812224a1c33dc1d3430280728eb10990cc86caa994"
+    sha256 cellar: :any, big_sur:       "af8bfafe1425f3cc9923bd49a375f85c13255124ed7a952137fe924431adc1c4"
+    sha256 cellar: :any, catalina:      "73a3a75a47a0007a772fe229f11bc0710988af6a8603c56a0f7fae3d9a317149"
+    sha256 cellar: :any, mojave:        "960f60118f6f5cbf4e04a76e4c2103c7fb446e43e5db08362bca0b13763e137b"
   end
 
   head do
@@ -33,7 +41,8 @@ class BdwGc < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-cplusplus",
-                          "--enable-static"
+                          "--enable-static",
+                          "--enable-large-config"
     system "make"
     system "make", "check"
     system "make", "install"

--- a/Formula/beast.rb
+++ b/Formula/beast.rb
@@ -8,7 +8,7 @@ class Beast < Formula
   head "https://github.com/beast-dev/beast-mcmc.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/bitrise.rb
+++ b/Formula/bitrise.rb
@@ -1,8 +1,8 @@
 class Bitrise < Formula
   desc "Command-line automation tool"
   homepage "https://github.com/bitrise-io/bitrise"
-  url "https://github.com/bitrise-io/bitrise/archive/1.45.0.tar.gz"
-  sha256 "eb52a34688f31d0999c2817d87fd2cf920b4cbe50b5cb52c14ef84f53bcbcc0e"
+  url "https://github.com/bitrise-io/bitrise/archive/1.45.1.tar.gz"
+  sha256 "ce42200fdafe8257b01d08737545e86b3fb64c8462d08bf2a1d6b392b2b432ce"
   license "MIT"
 
   bottle do

--- a/Formula/boost-build.rb
+++ b/Formula/boost-build.rb
@@ -8,7 +8,7 @@ class BoostBuild < Formula
   head "https://github.com/boostorg/build.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^boost[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -8,7 +8,7 @@ class Buildkit < Formula
   head "https://github.com/moby/buildkit.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -7,7 +7,7 @@ class Castxml < Formula
   head "https://github.com/CastXML/castxml.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cgns.rb
+++ b/Formula/cgns.rb
@@ -7,7 +7,7 @@ class Cgns < Formula
   head "https://github.com/CGNS/CGNS.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/chibi-scheme.rb
+++ b/Formula/chibi-scheme.rb
@@ -7,7 +7,7 @@ class ChibiScheme < Formula
   head "https://github.com/ashinn/chibi-scheme.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -29,18 +29,6 @@ class ClangFormat < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "37a27e538177b4d9b44eeb6d7749301eba4422763994189cc50f1e2c6cc21344"
   end
 
-  head do
-    url "https://git.llvm.org/git/llvm.git"
-
-    resource "clang" do
-      url "https://git.llvm.org/git/clang.git"
-    end
-
-    resource "libcxx" do
-      url "https://git.llvm.org/git/libcxx.git"
-    end
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "subversion" => :build

--- a/Formula/clib.rb
+++ b/Formula/clib.rb
@@ -7,7 +7,7 @@ class Clib < Formula
   head "https://github.com/clibs/clib.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cmockery2.rb
+++ b/Formula/cmockery2.rb
@@ -7,7 +7,7 @@ class Cmockery2 < Formula
   head "https://github.com/lpabon/cmockery2.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -8,7 +8,7 @@ class Coccinelle < Formula
   head "https://github.com/coccinelle/coccinelle.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -8,7 +8,7 @@ class Consul < Formula
   head "https://github.com/hashicorp/consul.git", shallow: false
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/contentful-cli.rb
+++ b/Formula/contentful-cli.rb
@@ -3,8 +3,8 @@ require "language/node"
 class ContentfulCli < Formula
   desc "Contentful command-line tools"
   homepage "https://github.com/contentful/contentful-cli"
-  url "https://registry.npmjs.org/contentful-cli/-/contentful-cli-1.5.15.tgz"
-  sha256 "03b8146cdc28ba8cb2fa8564a65d26e5cf660e987f8fbb50954fc12346245485"
+  url "https://registry.npmjs.org/contentful-cli/-/contentful-cli-1.5.20.tgz"
+  sha256 "691bd583e2abe1cc3b36ed67f8cb69b060004d258b34e669a063eacbf228883a"
   license "MIT"
   head "https://github.com/contentful/contentful-cli.git"
 

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -7,7 +7,7 @@ class Coq < Formula
   head "https://github.com/coq/coq.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cpanminus.rb
+++ b/Formula/cpanminus.rb
@@ -8,7 +8,7 @@ class Cpanminus < Formula
   head "https://github.com/miyagawa/cpanminus.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cppad.rb
+++ b/Formula/cppad.rb
@@ -9,7 +9,7 @@ class Cppad < Formula
   head "https://github.com/coin-or/CppAD.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -2,6 +2,7 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
+  revision 1
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/0.36.1.tar.gz"
@@ -14,7 +15,7 @@ class Crystal < Formula
   end
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
@@ -32,11 +33,7 @@ class Crystal < Formula
     end
   end
 
-  depends_on "autoconf"      => :build # for building bdw-gc
-  depends_on "automake"      => :build # for building bdw-gc
-  depends_on "libatomic_ops" => :build # for building bdw-gc
-  depends_on "libtool"       => :build # for building bdw-gc
-
+  depends_on "bdw-gc"
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
@@ -44,18 +41,6 @@ class Crystal < Formula
   depends_on "openssl@1.1" # std uses it but it's not linked
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
-
-  # Crystal uses an extended version of bdw-gc to handle multi-threading
-  resource "bdw-gc" do
-    url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
-    sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
-
-    # extension to handle multi-threading
-    patch :p1 do
-      url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch?full_index=1"
-      sha256 "5c42d4b37cf4997bb6af3f9b00f5513644e1287c322607dc980a1955a09246e3"
-    end
-  end
 
   resource "boot" do
     on_macos do
@@ -74,15 +59,6 @@ class Crystal < Formula
     (buildpath/"boot").install resource("boot")
     ENV.append_path "PATH", "boot/bin"
 
-    resource("bdw-gc").stage(buildpath/"gc")
-    cd(buildpath/"gc") do
-      system "./configure", "--disable-debug",
-                            "--disable-dependency-tracking",
-                            "--disable-shared",
-                            "--enable-large-config"
-      system "make"
-    end
-
     # Build crystal
     crystal_build_opts = []
     crystal_build_opts << "release=true"
@@ -100,7 +76,7 @@ class Crystal < Formula
     #       building the formula. Otherwise this ad-hoc setup could be avoided.
     embedded_crystal_path=`"#{buildpath/".build/crystal"}" env CRYSTAL_PATH`.strip
     ENV["CRYSTAL_PATH"] = "#{embedded_crystal_path}:#{buildpath/"src"}"
-    ENV["CRYSTAL_LIBRARY_PATH"] = buildpath/"gc/.libs"
+    ENV["CRYSTAL_LIBRARY_PATH"] = ENV["HOMEBREW_LIBRARY_PATHS"]
 
     # Install shards
     resource("shards").stage do
@@ -121,13 +97,12 @@ class Crystal < Formula
       #!/bin/bash
       EMBEDDED_CRYSTAL_PATH=$("#{libexec/"crystal"}" env CRYSTAL_PATH)
       export CRYSTAL_PATH="${CRYSTAL_PATH:-"$EMBEDDED_CRYSTAL_PATH:#{prefix/"src"}"}"
-      export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}#{prefix/"embedded/lib"}:/usr/local/lib"
+      export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}#{HOMEBREW_PREFIX}/lib"
       export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}#{Formula["openssl@1.1"].opt_lib/"pkgconfig"}"
       exec "#{libexec/"crystal"}" "${@}"
     SH
 
     prefix.install "src"
-    (prefix/"embedded/lib").install "#{buildpath/"gc"}/.libs/libgc.a"
 
     bash_completion.install "etc/completion.bash" => "crystal"
     zsh_completion.install "etc/completion.zsh" => "_crystal"

--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -7,7 +7,7 @@ class Ddclient < Formula
   head "https://github.com/wimpunk/ddclient.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -7,7 +7,7 @@ class DnscryptProxy < Formula
   head "https://github.com/DNSCrypt/dnscrypt-proxy.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/docker-compose-completion.rb
+++ b/Formula/docker-compose-completion.rb
@@ -7,7 +7,7 @@ class DockerComposeCompletion < Formula
   head "https://github.com/docker/compose.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -8,7 +8,7 @@ class DosboxX < Formula
   head "https://github.com/joncampbell123/dosbox-x.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^dosbox-x[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dps8m.rb
+++ b/Formula/dps8m.rb
@@ -6,7 +6,7 @@ class Dps8m < Formula
   head "https://gitlab.com/dps8m/dps8m.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^R?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dub.rb
+++ b/Formula/dub.rb
@@ -8,7 +8,7 @@ class Dub < Formula
   head "https://github.com/dlang/dub.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -8,7 +8,7 @@ class Duti < Formula
   head "https://github.com/moretension/duti.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^duti[._-]v?(\d+(?:[.-]\d+)+)$/i)
   end
 

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -15,7 +15,7 @@ class Emscripten < Formula
   head "https://github.com/emscripten-core/emscripten.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/fetch.rb
+++ b/Formula/fetch.rb
@@ -1,8 +1,8 @@
 class Fetch < Formula
   desc "Download assets from a commit, branch, or tag of GitHub repositories"
   homepage "https://www.gruntwork.io/"
-  url "https://github.com/gruntwork-io/fetch/archive/v0.3.13.tar.gz"
-  sha256 "d4935a50565eaad3a9376c761276293181b7f912fe646e4ab66a724389e8fd8b"
+  url "https://github.com/gruntwork-io/fetch/archive/v0.3.14.tar.gz"
+  sha256 "af6513aadf2105bb2355c3b6acc74fa2b12df12d963292750df197b879c32868"
   license "MIT"
   head "https://github.com/gruntwork-io/fetch.git"
 

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -6,7 +6,7 @@ class Fish < Formula
   license "GPL-2.0"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/fluent-bit.rb
+++ b/Formula/fluent-bit.rb
@@ -7,7 +7,7 @@ class FluentBit < Formula
   head "https://github.com/fluent/fluent-bit.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -7,7 +7,7 @@ class FreeradiusServer < Formula
   head "https://github.com/FreeRADIUS/freeradius-server.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^release[._-](\d+(?:[._]\d+)+)$/i)
   end
 

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -39,7 +39,7 @@ class Freeswitch < Formula
   end
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/gdu.rb
+++ b/Formula/gdu.rb
@@ -1,8 +1,8 @@
 class Gdu < Formula
   desc "Disk usage analyzer with console interface written in Go"
   homepage "https://github.com/dundee/gdu"
-  url "https://github.com/dundee/gdu/archive/v4.3.3.tar.gz"
-  sha256 "8e5fbc10205d81b2a37c265cb8a29d53183827958c5d14fb4b9a3c670fb82bb2"
+  url "https://github.com/dundee/gdu/archive/v4.4.0.tar.gz"
+  sha256 "e44f678e973c2d09b47b14934854a95a0413bc8f6d1996c2e9f1b6c1f04237ef"
   license "MIT"
 
   bottle do
@@ -37,6 +37,6 @@ class Gdu < Formula
 
     assert_match version.to_s, shell_output("#{bin}/gdu -v")
     assert_match "colorized", shell_output("#{bin}/gdu --help 2>&1")
-    assert_match "5 B file1", shell_output("#{bin}/gdu --non-interactive --no-progress #{testpath}/test_dir 2>&1")
+    assert_match "4.0 KiB file1", shell_output("#{bin}/gdu --non-interactive --no-progress #{testpath}/test_dir 2>&1")
   end
 end

--- a/Formula/git-subrepo.rb
+++ b/Formula/git-subrepo.rb
@@ -7,7 +7,7 @@ class GitSubrepo < Formula
   head "https://github.com/ingydotnet/git-subrepo.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -8,7 +8,7 @@ class GitlabRunner < Formula
   head "https://gitlab.com/gitlab-org/gitlab-runner.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -8,7 +8,7 @@ class Goenv < Formula
   head "https://github.com/syndbg/goenv.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -8,7 +8,7 @@ class Htop < Formula
   head "https://github.com/htop-dev/htop.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/hypre.rb
+++ b/Formula/hypre.rb
@@ -7,7 +7,7 @@ class Hypre < Formula
   head "https://github.com/hypre-space/hypre.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ibex.rb
+++ b/Formula/ibex.rb
@@ -7,7 +7,7 @@ class Ibex < Formula
   head "https://github.com/ibex-team/ibex-lib.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^ibex[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/imagejs.rb
+++ b/Formula/imagejs.rb
@@ -7,7 +7,7 @@ class Imagejs < Formula
   head "https://github.com/jklmnn/imagejs.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -11,7 +11,7 @@ class Ipfs < Formula
   head "https://github.com/ipfs/go-ipfs.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/itk.rb
+++ b/Formula/itk.rb
@@ -7,7 +7,7 @@ class Itk < Formula
   head "https://github.com/InsightSoftwareConsortium/ITK.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/json-c.rb
+++ b/Formula/json-c.rb
@@ -8,7 +8,7 @@ class JsonC < Formula
   head "https://github.com/json-c/json-c.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^json-c[._-](\d+(?:\.\d+)+)(?:[._-]\d{6,8})?$/i)
   end
 

--- a/Formula/kapacitor.rb
+++ b/Formula/kapacitor.rb
@@ -8,7 +8,7 @@ class Kapacitor < Formula
   head "https://github.com/influxdata/kapacitor.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -7,7 +7,7 @@ class KitchenSync < Formula
   head "https://github.com/willbryant/kitchen_sync.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -7,7 +7,7 @@ class Kops < Formula
   head "https://github.com/kubernetes/kops.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/kotlin.rb
+++ b/Formula/kotlin.rb
@@ -1,8 +1,8 @@
 class Kotlin < Formula
   desc "Statically typed programming language for the JVM"
   homepage "https://kotlinlang.org/"
-  url "https://github.com/JetBrains/kotlin/releases/download/v1.4.21/kotlin-compiler-1.4.21.zip"
-  sha256 "46720991a716e90bfc0cf3f2c81b2bd735c14f4ea6a5064c488e04fd76e6b6c7"
+  url "https://github.com/JetBrains/kotlin/releases/download/v1.4.30/kotlin-compiler-1.4.30.zip"
+  sha256 "7b0aae9dca5ea899ef05dedc0a6fdd6e359451e56ff0dd3354443b3208b31800"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -8,7 +8,7 @@ class Ledger < Formula
   head "https://github.com/ledger/ledger.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/libp11.rb
+++ b/Formula/libp11.rb
@@ -6,7 +6,7 @@ class Libp11 < Formula
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^libp11[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/librdkafka.rb
+++ b/Formula/librdkafka.rb
@@ -7,7 +7,7 @@ class Librdkafka < Formula
   head "https://github.com/edenhill/librdkafka.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -7,7 +7,7 @@ class LibtorrentRasterbar < Formula
   revision 1
 
   livecheck do
-    url :head
+    url :stable
     regex(/^libtorrent[._-]v?(\d+(?:[-_.]\d+)+)$/i)
   end
 

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -8,7 +8,7 @@ class Logstash < Formula
   head "https://github.com/elastic/logstash.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/logtalk.rb
+++ b/Formula/logtalk.rb
@@ -1,9 +1,9 @@
 class Logtalk < Formula
   desc "Declarative object-oriented logic programming language"
   homepage "https://logtalk.org/"
-  url "https://github.com/LogtalkDotOrg/logtalk3/archive/lgt3430stable.tar.gz"
-  version "3.43.0"
-  sha256 "7e38652183d022abe7f41014037c9d334a445f8294e72426068c1d62170a0ac5"
+  url "https://github.com/LogtalkDotOrg/logtalk3/archive/lgt3440stable.tar.gz"
+  version "3.44.0"
+  sha256 "429088a4fea3fae3832946f12bdff5e24a1d99a55f07b1669ea99b54096a93fa"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/msitools.rb
+++ b/Formula/msitools.rb
@@ -5,8 +5,11 @@ class Msitools < Formula
   sha256 "0cc4d2e0d108fa6f2b4085b9a97dd5bc6d9fcadecdd933f2094f86bafdbe85fe"
   license "LGPL-2.1-or-later"
 
+  # msitools doesn't seem to use the GNOME version scheme, so we have to
+  # loosen the default `Gnome` strategy regex to match the latest version.
   livecheck do
     url :stable
+    regex(/msitools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -12,7 +12,7 @@ class Mu < Formula
   # as an odd-numbered minor version number indicates a development version:
   # https://github.com/djcb/mu/commit/23f4a64bdcdee3f9956a39b9a5a4fd0c5c2370ba
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
   end
 

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -5,11 +5,6 @@ class MysqlAT56 < Formula
   sha256 "262ccaf2930fca1f33787505dd125a7a04844f40d3421289a51974b5935d9abc"
   license "GPL-2.0-only"
 
-  livecheck do
-    url "https://dev.mysql.com/downloads/mysql/5.6.html?tpl=files&os=src&version=5.6"
-    regex(/href=.*?mysql[._-]v?(5\.6(?:\.\d+)*)\.t/i)
-  end
-
   bottle do
     sha256 big_sur:  "f11cd8885dc59020425bbdad88911471bc24de21810cbfbbcb6d9dd936473a85"
     sha256 catalina: "bbdc569f29b12fbcf5e877b15598b6adbbfa551df4ffdf8047832335b6dc829f"
@@ -17,6 +12,8 @@ class MysqlAT56 < Formula
   end
 
   keg_only :versioned_formula
+
+  deprecate! date: "2021-02-01", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "openssl@1.1"

--- a/Formula/ncompress.rb
+++ b/Formula/ncompress.rb
@@ -7,7 +7,7 @@ class Ncompress < Formula
   head "https://github.com/vapier/ncompress.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/netdata.rb
+++ b/Formula/netdata.rb
@@ -1,8 +1,8 @@
 class Netdata < Formula
   desc "Diagnose infrastructure problems with metrics, visualizations & alarms"
   homepage "https://netdata.cloud/"
-  url "https://github.com/netdata/netdata/releases/download/v1.28.0/netdata-v1.28.0.tar.gz"
-  sha256 "44801e240b1883a98d203156397cc8d9232492f3136891e61074e2e7facbf1a8"
+  url "https://github.com/netdata/netdata/releases/download/v1.29.0/netdata-v1.29.0.tar.gz"
+  sha256 "d898995faa3c269e6fbbf5456f237e25323213e6ec8c0a2b28007499b22e9f5d"
   license "GPL-3.0-or-later"
 
   livecheck do

--- a/Formula/node-build.rb
+++ b/Formula/node-build.rb
@@ -7,7 +7,7 @@ class NodeBuild < Formula
   head "https://github.com/nodenv/node-build.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -7,7 +7,7 @@ class NodeExporter < Formula
   head "https://github.com/prometheus/node_exporter.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -7,7 +7,7 @@ class Nomad < Formula
   head "https://github.com/hashicorp/nomad.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -8,7 +8,7 @@ class Nzbget < Formula
   head "https://github.com/nzbget/nzbget.git", branch: "develop"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ocproxy.rb
+++ b/Formula/ocproxy.rb
@@ -8,7 +8,7 @@ class Ocproxy < Formula
   head "https://github.com/cernekee/ocproxy.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d{1,3})+)$/i)
   end
 

--- a/Formula/osm2pgsql.rb
+++ b/Formula/osm2pgsql.rb
@@ -1,8 +1,8 @@
 class Osm2pgsql < Formula
   desc "OpenStreetMap data to PostgreSQL converter"
   homepage "https://wiki.openstreetmap.org/wiki/Osm2pgsql"
-  url "https://github.com/openstreetmap/osm2pgsql/archive/1.4.0.tar.gz"
-  sha256 "403e25a0310d088183a868d80e5325dceee88617d0df570056e50a2930905369"
+  url "https://github.com/openstreetmap/osm2pgsql/archive/1.4.1.tar.gz"
+  sha256 "33c4817dceed99764b089ead0e8e2f67c4c6675e761772339b635800970e66e2"
   license "GPL-2.0-only"
   head "https://github.com/openstreetmap/osm2pgsql.git"
 

--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -7,7 +7,7 @@ class OsrmBackend < Formula
   head "https://github.com/Project-OSRM/osrm-backend.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/pdftk-java.rb
+++ b/Formula/pdftk-java.rb
@@ -7,7 +7,7 @@ class PdftkJava < Formula
   head "https://gitlab.com/pdftk-java/pdftk.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/picard-tools.rb
+++ b/Formula/picard-tools.rb
@@ -1,8 +1,8 @@
 class PicardTools < Formula
   desc "Tools for manipulating HTS data and formats"
   homepage "https://broadinstitute.github.io/picard/"
-  url "https://github.com/broadinstitute/picard/releases/download/2.24.1/picard.jar"
-  sha256 "69c0ac607c99df9f2162a6b685a3b147e83a1501ad2be86cb587cb06f1cbc11f"
+  url "https://github.com/broadinstitute/picard/releases/download/2.24.2/picard.jar"
+  sha256 "3be6c0eef3fb63d01b140fa712313a3b58b40dc01654b3b61aec349edab9e6ce"
   license "MIT"
 
   livecheck do

--- a/Formula/pipes-sh.rb
+++ b/Formula/pipes-sh.rb
@@ -7,7 +7,7 @@ class PipesSh < Formula
   head "https://github.com/pipeseroni/pipes.sh.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -7,7 +7,7 @@ class Pjproject < Formula
   head "https://github.com/pjsip/pjproject.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/plank.rb
+++ b/Formula/plank.rb
@@ -7,7 +7,7 @@ class Plank < Formula
   head "https://github.com/pinterest/plank.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/rlwrap.rb
+++ b/Formula/rlwrap.rb
@@ -7,7 +7,7 @@ class Rlwrap < Formula
   head "https://github.com/hanslub42/rlwrap.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/spotifyd.rb
+++ b/Formula/spotifyd.rb
@@ -7,7 +7,7 @@ class Spotifyd < Formula
   head "https://github.com/Spotifyd/spotifyd.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/st.rb
+++ b/Formula/st.rb
@@ -8,7 +8,7 @@ class St < Formula
   head "https://github.com/nferraz/st.git"
 
   livecheck do
-    url :head
+    url :stable
     strategy :github_latest
   end
 

--- a/Formula/tcpflow.rb
+++ b/Formula/tcpflow.rb
@@ -1,14 +1,15 @@
 class Tcpflow < Formula
   desc "TCP/IP packet demultiplexer"
   homepage "https://github.com/simsong/tcpflow"
-  url "https://digitalcorpora.org/downloads/tcpflow/tcpflow-1.5.0.tar.gz"
+  url "https://github.com/simsong/tcpflow/releases/download/tcpflow-1.5.0/tcpflow-1.5.0.tar.gz"
   sha256 "20abe3353a49a13dcde17ad318d839df6312aa6e958203ea710b37bede33d988"
   license "GPL-3.0"
   revision 1
 
   livecheck do
-    url "http://downloads.digitalcorpora.org/downloads/tcpflow/"
-    regex(/href=.*?tcpflow[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{href=.*?/tag/(?:tcpflow[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/tcping.rb
+++ b/Formula/tcping.rb
@@ -7,7 +7,7 @@ class Tcping < Formula
   head "https://github.com/mkirchner/tcping.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -7,7 +7,7 @@ class Telegraf < Formula
   head "https://github.com/influxdata/telegraf.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -7,7 +7,7 @@ class Tesseract < Formula
   head "https://github.com/tesseract-ocr/tesseract.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/tfenv.rb
+++ b/Formula/tfenv.rb
@@ -7,7 +7,7 @@ class Tfenv < Formula
   head "https://github.com/tfutils/tfenv.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/tgenv.rb
+++ b/Formula/tgenv.rb
@@ -7,7 +7,7 @@ class Tgenv < Formula
   head "https://github.com/cunymatthieu/tgenv.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/v2ray-plugin.rb
+++ b/Formula/v2ray-plugin.rb
@@ -7,7 +7,7 @@ class V2rayPlugin < Formula
   head "https://github.com/shadowsocks/v2ray-plugin.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -7,7 +7,7 @@ class Vapoursynth < Formula
   head "https://github.com/vapoursynth/vapoursynth.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^R(\d+(?:\.\d+)*?)$/i)
   end
 

--- a/Formula/vlang.rb
+++ b/Formula/vlang.rb
@@ -8,7 +8,7 @@ class Vlang < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -19,7 +19,7 @@ class Watchman < Formula
   # The Git repo contains a few tags like `2020.05.18.00`, so we have to
   # restrict matching to versions with two to three parts (e.g., 1.2, 1.2.3).
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+){,2})$/i)
   end
 

--- a/Formula/zero-install.rb
+++ b/Formula/zero-install.rb
@@ -8,7 +8,7 @@ class ZeroInstall < Formula
   head "https://github.com/0install/0install.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/zeromq.rb
+++ b/Formula/zeromq.rb
@@ -6,7 +6,7 @@ class Zeromq < Formula
   license "LGPL-3.0-or-later" => { with: "LGPL-3.0-linking-exception" }
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
Merge Homebrew/homebrew-core into Homebrew/linuxbrew-core

+ [ ] a2ps
+ [ ] a52dec
+ [ ] aalib
+ [ ] aamath
+ [ ] aardvark_shell_utils
+ [ ] abcde
+ [ ] abcm2ps
+ [ ] abduco
+ [ ] abnfgen
+ [ ] abook
+ [ ] abseil
+ [ ] abyss
+ [ ] aces_container
+ [ ] acpica
+ [ ] activemq-cpp
+ [ ] admesh
+ [ ] adns
+ [ ] advancecomp
+ [ ] advancemame
+ [ ] advancemenu
+ [ ] advancescan
+ [ ] adwaita-icon-theme
+ [ ] aescrypt-packetizer
+ [ ] aescrypt
+ [ ] aespipe
+ [ ] afflib
+ [ ] afio
+ [ ] afl-fuzz
+ [ ] aften
+ [ ] afuse
+ [ ] agedu
+ [ ] aggregate
+ [ ] aha
+ [ ] ahcpd
+ [ ] ahoy
+ [ ] aide
+ [ ] aircrack-ng
+ [ ] airspy
+ [ ] akamai
+ [ ] alac
+ [ ] aldo
+ [ ] alexjs
+ [ ] algernon
+ [ ] algol68g
+ [ ] align
+ [ ] aliyun-cli
+ [ ] alp
+ [ ] alpine
+ [ ] amazon-ecs-cli
+ [ ] ampl-mp
+ [ ] amqp-cpp
+ [ ] amtk
+ [ ] analog
+ [ ] angle-grinder
+ [ ] angular-cli
+ [ ] anime-downloader
+ [ ] annie
+ [ ] ansible-lint
+ [ ] ansible
+ [ ] ansifilter
+ [ ] antibody
+ [ ] antiword
+ [ ] anycable-go
+ [ ] anyenv
+ [ ] aom
+ [ ] apache-arrow
+ [ ] apache-brooklyn-cli
+ [ ] apache-forrest
+ [ ] apachetop
+ [ ] apcupsd
+ [ ] ape
+ [ ] apib
+ [ ] apidoc
+ [ ] apng2gif
+ [ ] apollo-cli
+ [ ] apollo
+ [ ] apparix
+ [ ] appscale-tools
+ [ ] apr-util
+ [ ] apr
+ [ ] apt-dater
+ [ ] aptly
+ [ ] arabica
+ [ ] arcade-learning-environment
+ [ ] archivemount
+ [ ] archiver
+ [ ] arduino-cli
+ [ ] argon2
+ [ ] argtable
+ [ ] aria2
+ [ ] armadillo
+ [ ] armor
+ [ ] arp-scan
+ [ ] arp-sk
+ [ ] arpack
+ [ ] arping
+ [ ] arss
+ [ ] ascii
+ [ ] asciidoc
+ [ ] asciidoctor
+ [ ] asciinema
+ [ ] asciiquarium
+ [ ] asciitex
+ [ ] ask-cli
+ [ ] asn1c
+ [ ] aspell
+ [ ] assh
+ [ ] assimp
+ [ ] astyle
+ [ ] asuka
+ [ ] asymptote
+ [ ] atari800
+ [ ] atasm
+ [ ] aterm
+ [ ] atf
+ [ ] atk
+ [ ] atkmm
+ [ ] atkmm@2.28
+ [ ] atlantis
+ [ ] atomicparsley
+ [ ] atool
+ [ ] ats2-postiats
+ [ ] audiofile
+ [ ] augeas
+ [ ] augustus
+ [ ] aurora
+ [ ] autobench
+ [ ] autocode
+ [ ] autoconf-archive
+ [ ] autoconf
+ [ ] autogen
+ [ ] autojump
+ [ ] automake
+ [ ] autopep8
+ [ ] autossh
+ [ ] avanor
+ [ ] avce00
+ [ ] avfs
+ [ ] avian
+ [ ] aview
+ [ ] avimetaedit
+ [ ] avra
+ [ ] avro-c
+ [ ] awf
+ [ ] aws-apigateway-importer
+ [ ] aws-cdk
+ [ ] aws-elasticbeanstalk
+ [ ] aws-google-auth
+ [ ] aws-iam-authenticator
+ [ ] aws-okta
+ [ ] aws-shell
+ [ ] awscli
+ [ ] awscli@1
+ [ ] awscurl
+ [ ] awslogs
+ [ ] awsume
+ [ ] axel
+ [ ] azure-cli
+ [ ] b2-tools
+ [ ] b2sum
+ [ ] b3sum
+ [ ] babel
+ [ ] babeld
+ [ ] backupninja
+ [ ] bacula-fd
+ [ ] badtouch
+ [ ] balena-cli
+ [ ] ballerburg
+ [ ] bam
+ [ ] bamtools
+ [ ] bandcamp-dl
+ [ ] bandwhich
+ [ ] baobab
+ [ ] base64
+ [ ] base91
+ [ ] bash-completion
+ [ ] bash-completion@2
+ [ ] bash
+ [ ] bashdb
+ [ ] bashish
+ [ ] bastet
+ [ ] bat
+ [ ] bbcolors
+ [ ] bbe
+ [ ] bc
+ [ ] bcftools
+ [ ] bchunk
+ [ ] bcpp
+ [ ] bdw-gc
+ [ ] beagle
+ [ ] beansdb
+ [ ] beanstalkd
+ [ ] beast
+ [ ] bedops
+ [ ] bedtools
+ [ ] befunge93
+ [ ] bench
+ [ ] benthos
+ [ ] bento4
+ [ ] berglas
+ [ ] berkeley-db
+ [ ] berkeley-db@4
+ [ ] bettercap
+ [ ] bgpq3
+ [ ] bib-tool
+ [ ] bibclean
+ [ ] bibtex2html
+ [ ] bibtexconv
+ [ ] bibutils
+ [ ] bic
+ [ ] bind
+ [ ] bindfs
+ [ ] bingrep
+ [ ] binutils
+ [ ] binwalk
+ [ ] bioawk
+ [ ] bison
+ [ ] bit
+ [ ] bitcoin
+ [ ] bitlbee
+ [ ] bitrise
+ [ ] bitwarden-cli
+ [ ] bitwise
+ [ ] black
+ [ ] blahtexml
+ [ ] blast
+ [ ] blaze
+ [ ] blazeblogger
+ [ ] blitz
+ [ ] blitzwave
+ [ ] bloaty
+ [ ] bnfc
+ [ ] bogofilter
+ [ ] bonnie++
+ [ ] bookloupe
+ [ ] boost-build
+ [ ] boost-python3
+ [ ] boost
+ [ ] boost@1.60
+ [ ] bootloadhid
+ [ ] borgmatic
+ [ ] boringtun
+ [ ] bower
+ [ ] bowtie2
+ [ ] bpm-tools
+ [ ] breezy
+ [ ] brogue
+ [ ] broot
+ [ ] brotli
+ [ ] bsdconv
+ [ ] bsdsfv
+ [ ] bsponmpi
+ [ ] btparse
+ [ ] btpd
+ [ ] buku
+ [ ] bullet
+ [ ] burp
+ [ ] bvi
+ [ ] bwa
+ [ ] bwctl
+ [ ] bwfmetaedit
+ [ ] bwm-ng
+ [ ] byacc
+ [ ] byobu
+ [ ] bzip2
+ [ ] c-ares
+ [ ] c-blosc
+ [ ] c14-cli
+ [ ] c2048
+ [ ] cabal-install
+ [ ] cabextract
+ [ ] cacli
+ [ ] caddy
+ [ ] cairo
+ [ ] cairomm@1.14
+ [ ] calc
+ [ ] calceph
+ [ ] calcurse
+ [ ] calicoctl
+ [ ] camlp5
+ [ ] capnp
+ [ ] capstone
+ [ ] cargo-c
+ [ ] carina
+ [ ] cash-cli
+ [ ] cassandra-cpp-driver
+ [ ] cassandra@2.1
+ [ ] cassowary
+ [ ] castxml
+ [ ] catch2
+ [ ] catimg
+ [ ] cattle
+ [ ] cbc
+ [ ] cbmbasic
+ [ ] cc65
+ [ ] ccache
+ [ ] ccat
+ [ ] ccd2iso
+ [ ] ccfits
+ [ ] ccheck
+ [ ] ccls
+ [ ] ccm
+ [ ] ccrypt
+ [ ] ccze
+ [ ] cd-discid
+ [ ] cdk
+ [ ] cdktf
+ [ ] cdrtools
+ [ ] celero
+ [ ] ceres-solver
+ [ ] cern-ndiff
+ [ ] certbot
+ [ ] certigo
+ [ ] certstrap
+ [ ] cf-tool
+ [ ] cf
+ [ ] cfitsio
+ [ ] cfn-lint
+ [ ] cfssl
+ [ ] cgal
+ [ ] cgdb
+ [ ] cgl
+ [ ] cglm
+ [ ] cgns
+ [ ] cgrep
+ [ ] cgvg
+ [ ] chadwick
+ [ ] chafa
+ [ ] chalk-cli
+ [ ] chamber
+ [ ] chapel
+ [ ] charm-tools
+ [ ] charm
+ [ ] cheapglk
+ [ ] cheat
+ [ ] check
+ [ ] check_postgres
+ [ ] cheops
+ [ ] chibi-scheme
+ [ ] chicken
+ [ ] chinadns-c
+ [ ] chipmunk
+ [ ] chmlib
+ [ ] chocolate-doom
+ [ ] choose
+ [ ] chordii
+ [ ] chromaprint
+ [ ] chruby-fish
+ [ ] chruby
+ [ ] cidrmerge
+ [ ] cig
+ [ ] circleci
+ [ ] cksfv
+ [ ] clac
+ [ ] clang-format
+ [ ] classads
+ [ ] clean
+ [ ] clhep
+ [ ] cli11
+ [ ] cli53
+ [ ] click
+ [ ] clingo
+ [ ] cln
+ [ ] cloc
+ [ ] clog
+ [ ] cloog
+ [ ] cloud-nuke
+ [ ] cloudformation-guard
+ [ ] clozure-cl
+ [ ] clp
+ [ ] clpbar
+ [ ] clucene
+ [ ] clzip
+ [ ] cmake
+ [ ] cmark-gfm
+ [ ] cmark
+ [ ] cmatrix
+ [ ] cmdshelf
+ [ ] cmigemo
+ [ ] cminpack
+ [ ] cmix
+ [ ] cmocka
+ [ ] cmockery
+ [ ] cmockery2
+ [ ] cmuclmtk
+ [ ] cnats
+ [ ] cntlm
+ [ ] cobalt
+ [ ] cocot
+ [ ] code-server
+ [ ] codec2
+ [ ] codemod
+ [ ] codespell
+ [ ] coffeescript
+ [ ] cointop
+ [ ] coinutils
+ [ ] collector-sidecar
+ [ ] colordiff
+ [ ] colortail
+ [ ] comby
+ [ ] compface
+ [ ] conan
+ [ ] concurrencykit
+ [ ] confuse
+ [ ] conjure-up
+ [ ] connect
+ [ ] conserver
+ [ ] console_bridge
+ [ ] consul-backinator
+ [ ] consul-template
+ [ ] container-diff
+ [ ] contentful-cli
+ [ ] convertlit
+ [ ] convmv
+ [ ] convox
+ [ ] cookiecutter
+ [ ] coq
+ [ ] coreos-ct
+ [ ] coreutils
+ [ ] corkscrew
+ [ ] cosi
+ [ ] coturn
+ [ ] cowsay
+ [ ] cpio
+ [ ] cpl
+ [ ] cpp-gsl
+ [ ] cppad
+ [ ] cppcheck
+ [ ] cppman
+ [ ] cppp
+ [ ] cpptest
+ [ ] cppunit
+ [ ] cpr
+ [ ] cpu_features
+ [ ] cpulimit
+ [ ] cql
+ [ ] cquery
+ [ ] cracklib
+ [ ] crc32c
+ [ ] crcany
+ [ ] credstash
+ [ ] crf++
+ [ ] crm114
+ [ ] cronolog
+ [ ] crunch
+ [ ] cryptol
+ [ ] crystal-icr
+ [ ] crystal
+ [ ] cscope
+ [ ] csv-fix
+ [ ] csvkit
+ [ ] csvq
+ [ ] csvtomd
+ [ ] ctags
+ [ ] ctail
+ [ ] ctl
+ [ ] cubejs-cli
+ [ ] cucumber-cpp
+ [ ] cucumber-ruby
+ [ ] cunit
+ [ ] cups
+ [ ] curaengine
+ [ ] curl
+ [ ] cvs
+ [ ] cvsutils
+ [ ] cweb
+ [ ] cwlogs
+ [ ] cxxopts
+ [ ] cxxtest
+ [ ] cython
+ [ ] daemon
+ [ ] daemonize
+ [ ] dante
+ [ ] daq
+ [ ] darkhttpd
+ [ ] darksky-weather
+ [ ] dash
+ [ ] dashing
+ [ ] dasm
+ [ ] datamash
+ [ ] datetime-fortran
+ [ ] dateutils
+ [ ] dav1d
+ [ ] davix
+ [ ] dbacl
+ [ ] dbdeployer
+ [ ] dbhash
+ [ ] dbmate
+ [ ] dbus-glib
+ [ ] dbus
+ [ ] dbxml
+ [ ] dcd
+ [ ] dcfldd
+ [ ] dcled
+ [ ] dcm2niix
+ [ ] dcmtk
+ [ ] dcos-cli
+ [ ] dcraw
+ [ ] ddate
+ [ ] ddgr
+ [ ] ddrescue
+ [ ] deark
+ [ ] debianutils
+ [ ] deheader
+ [ ] delta
+ [ ] dep
+ [ ] depqbf
+ [ ] desktop-file-utils
+ [ ] devd
+ [ ] devdash
+ [ ] devspace
+ [ ] dfc
+ [ ] dfix
+ [ ] dfmt
+ [ ] dfu-programmer
+ [ ] dfu-util
+ [ ] dgen
+ [ ] dhall-json
+ [ ] dhcping
+ [ ] dhex
+ [ ] di
+ [ ] dialog
+ [ ] diamond
+ [ ] diceware
+ [ ] diction
+ [ ] dieharder
+ [ ] diff-pdf
+ [ ] diffoscope
+ [ ] diffr
+ [ ] diffstat
+ [ ] diffutils
+ [ ] digitemp
+ [ ] dirac
+ [ ] direnv
+ [ ] disktype
+ [ ] diskus
+ [ ] dive
+ [ ] djview4
+ [ ] djvulibre
+ [ ] dlib
+ [ ] dmd
+ [ ] dmtx-utils
+ [ ] dns2tcp
+ [ ] dnscontrol
+ [ ] dnscrypt-proxy
+ [ ] dnscrypt-wrapper
+ [ ] dnsmap
+ [ ] dnsmasq
+ [ ] docbook-xsl
+ [ ] docbook
+ [ ] docbook2x
+ [ ] docker-compose
+ [ ] docker-credential-helper-ecr
+ [ ] docker-gen
+ [ ] docker-ls
+ [ ] docker-machine-driver-vmware
+ [ ] docker-machine
+ [ ] docker-slim
+ [ ] docker-squash
+ [ ] docker-swarm
+ [ ] docker
+ [ ] docker2aci
+ [ ] dockerize
+ [ ] dockviz
+ [ ] dockward
+ [ ] doctl
+ [ ] docutils
+ [ ] docx2txt
+ [ ] dog
+ [ ] doitlive
+ [ ] dopewars
+ [ ] dos2unix
+ [ ] dosbox
+ [ ] dosfstools
+ [ ] dotenv-linter
+ [ ] double-conversion
+ [ ] dovecot
+ [ ] doxygen
+ [ ] dpkg
+ [ ] dps8m
+ [ ] draco
+ [ ] drafter
+ [ ] drip
+ [ ] drone-cli
+ [ ] dscanner
+ [ ] dsh
+ [ ] dssim
+ [ ] dsvpn
+ [ ] dtach
+ [ ] dtc
+ [ ] dub
+ [ ] dumb
+ [ ] dune
+ [ ] duo_unix
+ [ ] duplicity
+ [ ] dupseek
+ [ ] dust
+ [ ] dvanalyzer
+ [ ] dvd-vr
+ [ ] dvdauthor
+ [ ] dvm
+ [ ] dwarf
+ [ ] dwarfutils
+ [ ] dwatch
+ [ ] dxflib
+ [ ] dxpy
+ [ ] dylibbundler
+ [ ] dynet
+ [ ] e2fsprogs
+ [ ] eccodes
+ [ ] ecl
+ [ ] ecm
+ [ ] ed
+ [ ] editorconfig
+ [ ] eg
+ [ ] eigen
+ [ ] ejdb
+ [ ] ekg2
+ [ ] ekhtml
+ [ ] elektra
+ [ ] elinks
+ [ ] elixir
+ [ ] elm-format
+ [ ] elm
+ [ ] elvish
+ [ ] emacs-clang-complete-async
+ [ ] emp
+ [ ] ems-flasher
+ [ ] enchant
+ [ ] enet
+ [ ] enigma
+ [ ] enscript
+ [ ] ent
+ [ ] entityx
+ [ ] entr
+ [ ] envchain
+ [ ] envconsul
+ [ ] envv
+ [ ] eot-utils
+ [ ] ephemeralpg
+ [ ] epsilon
+ [ ] epstool
+ [ ] erlang
+ [ ] erlang@20
+ [ ] erlang@21
+ [ ] es
+ [ ] eslint
+ [ ] esptool
+ [ ] etcd
+ [ ] ethereum
+ [ ] etl
+ [ ] euler-py
+ [ ] eureka
+ [ ] eva
+ [ ] eventlog
+ [ ] exa
+ [ ] exempi
+ [ ] exercism
+ [ ] exif
+ [ ] exiftags
+ [ ] exiftool
+ [ ] exiv2
+ [ ] exomizer
+ [ ] expat
+ [ ] expect
+ [ ] eye-d3
+ [ ] faac
+ [ ] faad2
+ [ ] faas-cli
+ [ ] fabio
+ [ ] fades
+ [ ] fail2ban
+ [ ] fairymax
+ [ ] faiss
+ [ ] fakeroot
+ [ ] fastjar
+ [ ] fastlane
+ [ ] fastme
+ [ ] fastmod
+ [ ] fasttext
+ [ ] fatsort
+ [ ] faust
+ [ ] fb-client
+ [ ] fbi-servefiles
+ [ ] fcgi
+ [ ] fcgiwrap
+ [ ] fcl
+ [ ] fd
+ [ ] fdclone
+ [ ] fdk-aac-encoder
+ [ ] fdk-aac
+ [ ] fdroidserver
+ [ ] fdupes
+ [ ] fetch-crl
+ [ ] fetch
+ [ ] ffmpeg
+ [ ] ffmpegthumbnailer
+ [ ] ffms2
+ [ ] ffsend
+ [ ] fftw
+ [ ] ffuf
+ [ ] fibjs
+ [ ] ficy
+ [ ] fig2dev
+ [ ] figlet
+ [ ] file-formula
+ [ ] file-roller
+ [ ] findent
+ [ ] findutils
+ [ ] fio
+ [ ] firebase-cli
+ [ ] fish
+ [ ] fizsh
+ [ ] flac
+ [ ] flake
+ [ ] flake8
+ [ ] flann
+ [ ] flashrom
+ [ ] flatbuffers
+ [ ] flatcc
+ [ ] flawfinder
+ [ ] fleetctl
+ [ ] flex
+ [ ] flickcurl
+ [ ] flif
+ [ ] flint-checker
+ [ ] flint
+ [ ] flow-tools
+ [ ] flow
+ [ ] fltk
+ [ ] fluent-bit
+ [ ] fluid-synth
+ [ ] flux
+ [ ] fluxctl
+ [ ] flvmeta
+ [ ] flvstreamer
+ [ ] fmt
+ [ ] fn
+ [ ] foma
+ [ ] fondu
+ [ ] font-util
+ [ ] fontconfig
+ [ ] fontforge
+ [ ] fonttools
+ [ ] forcecli
+ [ ] forego
+ [ ] foremost
+ [ ] fork-cleaner
+ [ ] fortio
+ [ ] fortune
+ [ ] fourstore
+ [ ] fplll
+ [ ] freedink
+ [ ] freeglut
+ [ ] freeimage
+ [ ] freeradius-server
+ [ ] freerdp
+ [ ] freetds
+ [ ] freetype
+ [ ] freexl
+ [ ] frei0r
+ [ ] fribidi
+ [ ] frobtads
+ [ ] frpc
+ [ ] frps
+ [ ] frugal
+ [ ] fruit
+ [ ] fselect
+ [ ] fsql
+ [ ] fstrm
+ [ ] fswatch
+ [ ] ftgl
+ [ ] ftjam
+ [ ] functionalplus
+ [ ] fuse-emulator
+ [ ] fuzzy-find
+ [ ] fwup
+ [ ] fx
+ [ ] fzf
+ [ ] fzy
+ [ ] g2
+ [ ] g3log
+ [ ] gaffitter
+ [ ] gambit-scheme
+ [ ] gambit
+ [ ] gammu
+ [ ] gandi.cli
+ [ ] garmintools
+ [ ] gau
+ [ ] gaul
+ [ ] gawk
+ [ ] gbdfed
+ [ ] gcab
+ [ ] gcc
+ [ ] gcc@4.9
+ [ ] gcc@5
+ [ ] gcc@6
+ [ ] gcc@7
+ [ ] gcc@8
+ [ ] gcc@9
+ [ ] gconf
+ [ ] gcovr
+ [ ] gcsfuse
+ [ ] gd
+ [ ] gdal
+ [ ] gdb
+ [ ] gdbm
+ [ ] gdk-pixbuf
+ [ ] gdm
+ [ ] gdrive
+ [ ] gdu
+ [ ] gecode
+ [ ] genact
+ [ ] generate-json-schema
+ [ ] gengetopt
+ [ ] genometools
+ [ ] genstats
+ [ ] geographiclib
+ [ ] geoip
+ [ ] geoipupdate
+ [ ] geos
+ [ ] get_iplayer
+ [ ] getdns
+ [ ] getmail
+ [ ] gettext
+ [ ] getxbook
+ [ ] gexiv2
+ [ ] gf-complete
+ [ ] gflags
+ [ ] gh
+ [ ] ghc
+ [ ] ghc@8.6
+ [ ] ghc@8.8
+ [ ] ghex
+ [ ] ghi
+ [ ] ghostscript
+ [ ] ghq
+ [ ] ghr
+ [ ] ghz
+ [ ] gif2png
+ [ ] giflib
+ [ ] giflossy
+ [ ] gifsicle
+ [ ] gifski
+ [ ] gimme-aws-creds
+ [ ] ginac
+ [ ] gist
+ [ ] git-absorb
+ [ ] git-annex
+ [ ] git-appraise
+ [ ] git-archive-all
+ [ ] git-bug
+ [ ] git-crypt
+ [ ] git-delta
+ [ ] git-extras
+ [ ] git-flow-avh
+ [ ] git-flow
+ [ ] git-ftp
+ [ ] git-gui
+ [ ] git-hooks-go
+ [ ] git-hooks
+ [ ] git-hound
+ [ ] git-imerge
+ [ ] git-interactive-rebase-tool
+ [ ] git-lfs
+ [ ] git-now
+ [ ] git-number
+ [ ] git-plus
+ [ ] git-review
+ [ ] git-revise
+ [ ] git-secret
+ [ ] git-series
+ [ ] git-sh
+ [ ] git-sizer
+ [ ] git-standup
+ [ ] git-town
+ [ ] git-trim
+ [ ] git-vendor
+ [ ] git
+ [ ] gitbatch
+ [ ] github-markdown-toc
+ [ ] github-release
+ [ ] gitlab-gem
+ [ ] gitlab-runner
+ [ ] gitleaks
+ [ ] gitless
+ [ ] gitlint
+ [ ] gitmoji
+ [ ] gitter-cli
+ [ ] gitup
+ [ ] gl2ps
+ [ ] glade
+ [ ] glances
+ [ ] gleam
+ [ ] glew
+ [ ] glfw
+ [ ] glib-networking
+ [ ] glib-openssl
+ [ ] glib
+ [ ] glibmm
+ [ ] glibmm@2.66
+ [ ] glide
+ [ ] glm
+ [ ] global
+ [ ] globe
+ [ ] glog
+ [ ] glooctl
+ [ ] gloox
+ [ ] glow
+ [ ] glpk
+ [ ] glslang
+ [ ] glui
+ [ ] glyr
+ [ ] gmime
+ [ ] gmp
+ [ ] gnirehtet
+ [ ] gnome-common
+ [ ] gnome-themes-standard
+ [ ] gnu-apl
+ [ ] gnu-barcode
+ [ ] gnu-chess
+ [ ] gnu-complexity
+ [ ] gnu-getopt
+ [ ] gnu-go
+ [ ] gnu-indent
+ [ ] gnu-prolog
+ [ ] gnu-sed
+ [ ] gnu-shogi
+ [ ] gnu-tar
+ [ ] gnu-time
+ [ ] gnu-typist
+ [ ] gnu-units
+ [ ] gnu-which
+ [ ] gnunet
+ [ ] gnupg-pkcs11-scd
+ [ ] gnupg
+ [ ] gnupg@1.4
+ [ ] gnuplot
+ [ ] gnustep-make
+ [ ] gnutls
+ [ ] go-bindata
+ [ ] go-jira
+ [ ] go-md2man
+ [ ] go-statik
+ [ ] go
+ [ ] go@1.10
+ [ ] go@1.11
+ [ ] go@1.12
+ [ ] go@1.13
+ [ ] go@1.14
+ [ ] go@1.9
+ [ ] goad
+ [ ] gobject-introspection
+ [ ] gobuster
+ [ ] gocloc
+ [ ] gocr
+ [ ] gocryptfs
+ [ ] gofabric8
+ [ ] goffice
+ [ ] gofish
+ [ ] golang-migrate
+ [ ] golangci-lint
+ [ ] gollum
+ [ ] gom
+ [ ] gomplate
+ [ ] goocanvas
+ [ ] goofys
+ [ ] google-authenticator-libpam
+ [ ] google-benchmark
+ [ ] google-sparsehash
+ [ ] googler
+ [ ] googletest
+ [ ] goolabs
+ [ ] goose
+ [ ] gopass
+ [ ] gopls
+ [ ] goreleaser
+ [ ] goreman
+ [ ] gost
+ [ ] gosu
+ [ ] gotags
+ [ ] gotop
+ [ ] govc
+ [ ] govendor
+ [ ] gowsdl
+ [ ] gox
+ [ ] gpa
+ [ ] gpatch
+ [ ] gperf
+ [ ] gperftools
+ [ ] gpgme
+ [ ] gphoto2
+ [ ] gplcver
+ [ ] gpm
+ [ ] gpp
+ [ ] gpredict
+ [ ] gprof2dot
+ [ ] gpsbabel
+ [ ] gpsd
+ [ ] gpsim
+ [ ] gptsync
+ [ ] gputils
+ [ ] gpx
+ [ ] gqlplus
+ [ ] graphene
+ [ ] graphicsmagick
+ [ ] graphite2
+ [ ] graphviz
+ [ ] gravity
+ [ ] grep
+ [ ] grepcidr
+ [ ] grex
+ [ ] grip
+ [ ] groff
+ [ ] gron
+ [ ] groonga
+ [ ] grpc
+ [ ] grpcurl
+ [ ] grunt-cli
+ [ ] grv
+ [ ] gsar
+ [ ] gsasl
+ [ ] gsettings-desktop-schemas
+ [ ] gsl
+ [ ] gsoap
+ [ ] gssh
+ [ ] gst-devtools
+ [ ] gst-plugins-base
+ [ ] gst-rtsp-server
+ [ ] gstreamer
+ [ ] gti
+ [ ] gtk+
+ [ ] gtk+3
+ [ ] gtk-doc
+ [ ] gtk-vnc
+ [ ] gtkdatabox
+ [ ] gtkextra
+ [ ] gtkmm
+ [ ] gtkmm3
+ [ ] gtksourceview3
+ [ ] gts
+ [ ] guetzli
+ [ ] guile
+ [ ] guile@2
+ [ ] gumbo-parser
+ [ ] gvp
+ [ ] gx-go
+ [ ] gx
+ [ ] gxml
+ [ ] gzip
+ [ ] h264bitstream
+ [ ] h2o
+ [ ] h3
+ [ ] hackrf
+ [ ] hadolint
+ [ ] halibut
+ [ ] hamlib
+ [ ] haproxy
+ [ ] hardlink
+ [ ] harfbuzz
+ [ ] hashcash
+ [ ] hashcat
+ [ ] hashpump
+ [ ] haskell-stack
+ [ ] haste-client
+ [ ] hayai
+ [ ] hcloud
+ [ ] hdf5-mpi
+ [ ] hdf5
+ [ ] hdf5@1.8
+ [ ] heatshrink
+ [ ] hebcal
+ [ ] heimdal
+ [ ] hello
+ [ ] helm
+ [ ] helm@2
+ [ ] helmsman
+ [ ] help2man
+ [ ] hesiod
+ [ ] hevea
+ [ ] hexedit
+ [ ] hexyl
+ [ ] hey
+ [ ] hfstospell
+ [ ] hfsutils
+ [ ] hicolor-icon-theme
+ [ ] hidapi
+ [ ] highlight
+ [ ] hiredis
+ [ ] hivemind
+ [ ] hlint
+ [ ] hmmer
+ [ ] hoedown
+ [ ] homeassistant-cli
+ [ ] homeworlds
+ [ ] honcho
+ [ ] hostess
+ [ ] howard-hinnant-date
+ [ ] howdoi
+ [ ] hss
+ [ ] hstr
+ [ ] ht
+ [ ] html-xml-utils
+ [ ] html2text
+ [ ] htmlcxx
+ [ ] htmldoc
+ [ ] htop
+ [ ] htpdate
+ [ ] htslib
+ [ ] http-parser
+ [ ] http-server
+ [ ] http_load
+ [ ] httpd
+ [ ] httpdiff
+ [ ] httperf
+ [ ] httpie
+ [ ] httptunnel
+ [ ] httrack
+ [ ] hub
+ [ ] hugo
+ [ ] hunspell
+ [ ] hwloc
+ [ ] hydra
+ [ ] hyperfine
+ [ ] hypre
+ [ ] i2util
+ [ ] iamy
+ [ ] iat
+ [ ] ibex
+ [ ] icarus-verilog
+ [ ] icecast
+ [ ] icecream
+ [ ] icoutils
+ [ ] icu4c
+ [ ] id3ed
+ [ ] id3tool
+ [ ] ideviceinstaller
+ [ ] ifstat
+ [ ] igraph
+ [ ] ike-scan
+ [ ] ilmbase
+ [ ] imagemagick
+ [ ] imagemagick@6
+ [ ] imageworsener
+ [ ] imapsync
+ [ ] imlib2
+ [ ] immortal
+ [ ] inadyn
+ [ ] include-what-you-use
+ [ ] inetutils
+ [ ] influxdb
+ [ ] infracost
+ [ ] iniparser
+ [ ] inja
+ [ ] inspectrum
+ [ ] instalooter
+ [ ] internetarchive
+ [ ] intltool
+ [ ] io
+ [ ] ioping
+ [ ] ios-webkit-debug-proxy
+ [ ] iozone
+ [ ] ipbt
+ [ ] iperf
+ [ ] iperf3
+ [ ] ipfs
+ [ ] ipinfo
+ [ ] ipmitool
+ [ ] ipmiutil
+ [ ] ipopt
+ [ ] ipv6calc
+ [ ] ipython
+ [ ] ircd-irc2
+ [ ] ired
+ [ ] ironcli
+ [ ] irssi
+ [ ] isc-dhcp
+ [ ] isl
+ [ ] isl@0.18
+ [ ] iso-codes
+ [ ] isort
+ [ ] ispell
+ [ ] istioctl
+ [ ] isync
+ [ ] itpp
+ [ ] itstool
+ [ ] ivykis
+ [ ] jabba
+ [ ] jailkit
+ [ ] jam
+ [ ] janet
+ [ ] jansson
+ [ ] jasper
+ [ ] javacc
+ [ ] jbig2dec
+ [ ] jbig2enc
+ [ ] jbigkit
+ [ ] jd
+ [ ] jdnssec-tools
+ [ ] jdupes
+ [ ] jed
+ [ ] jemalloc
+ [ ] jenkins-job-builder
+ [ ] jerasure
+ [ ] jerm
+ [ ] jfrog-cli
+ [ ] jhipster
+ [ ] jid
+ [ ] jinja2-cli
+ [ ] jlog
+ [ ] jo
+ [ ] joe
+ [ ] john-jumbo
+ [ ] john
+ [ ] jose
+ [ ] joshua
+ [ ] jp
+ [ ] jp2a
+ [ ] jpeg-turbo
+ [ ] jpeg
+ [ ] jpeginfo
+ [ ] jpegoptim
+ [ ] jq
+ [ ] jrnl
+ [ ] jrtplib
+ [ ] jsdoc3
+ [ ] jshon
+ [ ] jsmin
+ [ ] json-c
+ [ ] json-glib
+ [ ] json-table
+ [ ] json_spirit
+ [ ] jsoncpp
+ [ ] jsonlint
+ [ ] jsonnet
+ [ ] jsonpp
+ [ ] jsonrpc-glib
+ [ ] jsvc
+ [ ] jthread
+ [ ] juju-wait
+ [ ] juju
+ [ ] jumanpp
+ [ ] jump
+ [ ] jupyterlab
+ [ ] just
+ [ ] jvgrep
+ [ ] jxrlib
+ [ ] k6
+ [ ] k9s
+ [ ] kafkacat
+ [ ] kahip
+ [ ] kakasi
+ [ ] kakoune
+ [ ] kallisto
+ [ ] kamel
+ [ ] kapacitor
+ [ ] karn
+ [ ] kcov
+ [ ] kedge
+ [ ] keepassc
+ [ ] kepubify
+ [ ] keydb
+ [ ] keystone
+ [ ] khal
+ [ ] khard
+ [ ] kimwitu++
+ [ ] kind
+ [ ] kitchen-sync
+ [ ] knot
+ [ ] known_hosts
+ [ ] kompose
+ [ ] krakend
+ [ ] krb5
+ [ ] krew
+ [ ] ksh
+ [ ] ktmpl
+ [ ] ktoblzcheck
+ [ ] kube-aws
+ [ ] kubeaudit
+ [ ] kubebuilder
+ [ ] kubecfg
+ [ ] kubecm
+ [ ] kubeless
+ [ ] kubeprod
+ [ ] kubernetes-cli
+ [ ] kubernetes-service-catalog-client
+ [ ] kubeseal
+ [ ] kubespy
+ [ ] kustomize
+ [ ] kvazaar
+ [ ] kyma-cli
+ [ ] kyoto-cabinet
+ [ ] kyoto-tycoon
+ [ ] kytea
+ [ ] l-smash
+ [ ] lame
+ [ ] landscaper
+ [ ] lapack
+ [ ] lasi
+ [ ] laszip
+ [ ] latex2html
+ [ ] latex2rtf
+ [ ] latexdiff
+ [ ] latexml
+ [ ] lazydocker
+ [ ] lazygit
+ [ ] lbdb
+ [ ] lbzip2
+ [ ] lcdf-typetools
+ [ ] lcdproc
+ [ ] lci
+ [ ] lcm
+ [ ] lcrack
+ [ ] ldc
+ [ ] ldns
+ [ ] ldpl
+ [ ] lean-cli
+ [ ] lean
+ [ ] leaps
+ [ ] ledit
+ [ ] legit
+ [ ] lego
+ [ ] lensfun
+ [ ] lepton
+ [ ] leptonica
+ [ ] lerna
+ [ ] less
+ [ ] lesspipe
+ [ ] leveldb
+ [ ] lf
+ [ ] lftp
+ [ ] lha
+ [ ] lhasa
+ [ ] lib3ds
+ [ ] libantlr3c
+ [ ] libao
+ [ ] libarchive
+ [ ] libart
+ [ ] libass
+ [ ] libassuan
+ [ ] libatomic_ops
+ [ ] libb2
+ [ ] libb64
+ [ ] libbi
+ [ ] libbluray
+ [ ] libbs2b
+ [ ] libcaca
+ [ ] libcanberra
+ [ ] libcbor
+ [ ] libccd
+ [ ] libcddb
+ [ ] libcdio
+ [ ] libcds
+ [ ] libcec
+ [ ] libcello
+ [ ] libcerf
+ [ ] libcmph
+ [ ] libcoap
+ [ ] libconfig
+ [ ] libcouchbase
+ [ ] libcroco
+ [ ] libcsv
+ [ ] libcue
+ [ ] libcuefile
+ [ ] libdaemon
+ [ ] libdap
+ [ ] libdazzle
+ [ ] libdbi
+ [ ] libdc1394
+ [ ] libdca
+ [ ] libde265
+ [ ] libdeflate
+ [ ] libdill
+ [ ] libdiscid
+ [ ] libdivecomputer
+ [ ] libdmtx
+ [ ] libdmx
+ [ ] libdnet
+ [ ] libdshconfig
+ [ ] libdv
+ [ ] libdvbpsi
+ [ ] libdvdcss
+ [ ] libdvdnav
+ [ ] libdvdread
+ [ ] libebml
+ [ ] libebur128
+ [ ] libedit
+ [ ] libelf
+ [ ] libepoxy
+ [ ] libestr
+ [ ] libetonyek
+ [ ] libev
+ [ ] libevent
+ [ ] libevhtp
+ [ ] libewf
+ [ ] libexif
+ [ ] libextractor
+ [ ] libfabric
+ [ ] libffcall
+ [ ] libffi
+ [ ] libfido2
+ [ ] libfishsound
+ [ ] libfixbuf
+ [ ] libfixposix
+ [ ] libfontenc
+ [ ] libforensic1394
+ [ ] libfreenect
+ [ ] libfs
+ [ ] libftdi
+ [ ] libftdi0
+ [ ] libgcrypt
+ [ ] libgee
+ [ ] libgeotiff
+ [ ] libgetdata
+ [ ] libgfshare
+ [ ] libghthash
+ [ ] libgit2-glib
+ [ ] libgit2
+ [ ] libglade
+ [ ] libgpg-error
+ [ ] libgphoto2
+ [ ] libgraphqlparser
+ [ ] libgsf
+ [ ] libgtop
+ [ ] libharu
+ [ ] libheif
+ [ ] libhid
+ [ ] libhttpserver
+ [ ] libical
+ [ ] libice
+ [ ] libicns
+ [ ] libid3tag
+ [ ] libident
+ [ ] libidl
+ [ ] libidn
+ [ ] libidn2
+ [ ] libilbc
+ [ ] libimagequant
+ [ ] libimobiledevice
+ [ ] libinfinity
+ [ ] libiodbc
+ [ ] libiptcdata
+ [ ] libirecovery
+ [ ] libiscsi
+ [ ] libjson-rpc-cpp
+ [ ] libjwt
+ [ ] libksba
+ [ ] liblcf
+ [ ] liblo
+ [ ] liblockfile
+ [ ] liblouis
+ [ ] liblqr
+ [ ] libltc
+ [ ] liblwgeom
+ [ ] libmagic
+ [ ] libmatio
+ [ ] libmatroska
+ [ ] libmaxminddb
+ [ ] libmemcached
+ [ ] libmetalink
+ [ ] libmicrohttpd
+ [ ] libmikmod
+ [ ] libmill
+ [ ] libming
+ [ ] libmodbus
+ [ ] libmodplug
+ [ ] libmowgli
+ [ ] libmp3splt
+ [ ] libmpc
+ [ ] libmpdclient
+ [ ] libmpeg2
+ [ ] libmtp
+ [ ] libmwaw
+ [ ] libmxml
+ [ ] libnatpmp
+ [ ] libnet
+ [ ] libnfs
+ [ ] libngspice
+ [ ] libnova
+ [ ] liboauth
+ [ ] libofx
+ [ ] libogg
+ [ ] liboil
+ [ ] libolm
+ [ ] libomp
+ [ ] libopendkim
+ [ ] libopennet
+ [ ] liboping
+ [ ] libopusenc
+ [ ] libosip
+ [ ] libosmium
+ [ ] libotr
+ [ ] libowfat
+ [ ] libpagemaker
+ [ ] libpano
+ [ ] libpcap
+ [ ] libpcl
+ [ ] libplctag
+ [ ] libplist
+ [ ] libpng
+ [ ] libpoker-eval
+ [ ] libpq
+ [ ] libpqxx
+ [ ] libpqxx@6
+ [ ] libproxy
+ [ ] libpthread-stubs
+ [ ] libquantum
+ [ ] libquicktime
+ [ ] libquvi
+ [ ] libraqm
+ [ ] libraw
+ [ ] librcsc
+ [ ] librdkafka
+ [ ] libre
+ [ ] librem
+ [ ] libreplaygain
+ [ ] libresample
+ [ ] libressl
+ [ ] librevenge
+ [ ] librsvg
+ [ ] librsync
+ [ ] librttopo
+ [ ] libsamplerate
+ [ ] libsass
+ [ ] libscrypt
+ [ ] libsecret
+ [ ] libserdes
+ [ ] libserialport
+ [ ] libshout
+ [ ] libsigc++
+ [ ] libsigc++@2
+ [ ] libsignal-protocol-c
+ [ ] libsigsegv
+ [ ] libsixel
+ [ ] libsm
+ [ ] libsmf
+ [ ] libsmi
+ [ ] libsndfile
+ [ ] libsodium
+ [ ] libsoxr
+ [ ] libspatialite
+ [ ] libspectre
+ [ ] libspectrum
+ [ ] libspiro
+ [ ] libspnav
+ [ ] libssh
+ [ ] libssh2
+ [ ] libstatgrab
+ [ ] libstfl
+ [ ] libstrophe
+ [ ] libstxxl
+ [ ] libsvg-cairo
+ [ ] libsvg
+ [ ] libsvm
+ [ ] libtar
+ [ ] libtasn1
+ [ ] libtecla
+ [ ] libtermkey
+ [ ] libtextcat
+ [ ] libtiff
+ [ ] libtomcrypt
+ [ ] libtommath
+ [ ] libtool
+ [ ] libtorrent-rakshasa
+ [ ] libtorrent-rasterbar
+ [ ] libtrng
+ [ ] libu2f-host
+ [ ] libu2f-server
+ [ ] libucl
+ [ ] libuecc
+ [ ] libuninameslist
+ [ ] libunistring
+ [ ] libupnp
+ [ ] libusb-compat
+ [ ] libusb
+ [ ] libusbmuxd
+ [ ] libuv
+ [ ] libuvc
+ [ ] libvbucket
+ [ ] libvdpau
+ [ ] libvidstab
+ [ ] libvmaf
+ [ ] libvncserver
+ [ ] libvo-aacenc
+ [ ] libvoikko
+ [ ] libvorbis
+ [ ] libvpx
+ [ ] libvterm
+ [ ] libwandevent
+ [ ] libwebsockets
+ [ ] libwmf
+ [ ] libx11
+ [ ] libxau
+ [ ] libxaw
+ [ ] libxaw3d
+ [ ] libxc
+ [ ] libxcb
+ [ ] libxcomposite
+ [ ] libxcursor
+ [ ] libxdamage
+ [ ] libxdg-basedir
+ [ ] libxdiff
+ [ ] libxdmcp
+ [ ] libxext
+ [ ] libxfixes
+ [ ] libxfont
+ [ ] libxft
+ [ ] libxi
+ [ ] libxinerama
+ [ ] libxkbcommon
+ [ ] libxkbfile
+ [ ] libxlsxwriter
+ [ ] libxml++
+ [ ] libxml++3
+ [ ] libxml++@5
+ [ ] libxml2
+ [ ] libxmlsec1
+ [ ] libxmp
+ [ ] libxmu
+ [ ] libxo
+ [ ] libxp
+ [ ] libxpm
+ [ ] libxrandr
+ [ ] libxrender
+ [ ] libxres
+ [ ] libxscrnsaver
+ [ ] libxshmfence
+ [ ] libxslt
+ [ ] libxt
+ [ ] libxtst
+ [ ] libxv
+ [ ] libxvmc
+ [ ] libxxf86dga
+ [ ] libxxf86vm
+ [ ] libyaml
+ [ ] libyubikey
+ [ ] libzdb
+ [ ] libzip
+ [ ] lightning
+ [ ] lighttpd
+ [ ] link-grammar
+ [ ] linkerd
+ [ ] links
+ [ ] liquid-dsp
+ [ ] literate-git
+ [ ] little-cms
+ [ ] little-cms2
+ [ ] lizard
+ [ ] lldpd
+ [ ] llvm
+ [ ] llvm@7
+ [ ] llvm@8
+ [ ] llvm@9
+ [ ] lm4tools
+ [ ] lmdb
+ [ ] lnav
+ [ ] loc
+ [ ] localstack
+ [ ] log4c
+ [ ] log4cplus
+ [ ] log4cpp
+ [ ] log4shib
+ [ ] logcheck
+ [ ] logrotate
+ [ ] logstalgia
+ [ ] logtalk
+ [ ] lolcat
+ [ ] loudmouth
+ [ ] lout
+ [ ] lpc21isp
+ [ ] lrdf
+ [ ] lrzip
+ [ ] lrzsz
+ [ ] lsd
+ [ ] lsdvd
+ [ ] lsof
+ [ ] lua
+ [ ] lua@5.1
+ [ ] lua@5.3
+ [ ] luajit-openresty
+ [ ] luajit
+ [ ] luarocks
+ [ ] luv
+ [ ] luvit
+ [ ] lv
+ [ ] lwtools
+ [ ] lxc
+ [ ] lxsplit
+ [ ] lynx
+ [ ] lz4
+ [ ] lzfse
+ [ ] lzip
+ [ ] lzlib
+ [ ] lzo
+ [ ] lzop
+ [ ] m4
+ [ ] mac-robber
+ [ ] mackup
+ [ ] mad
+ [ ] madplay
+ [ ] mafft
+ [ ] mage
+ [ ] magic-wormhole
+ [ ] mailcheck
+ [ ] mailutils
+ [ ] make
+ [ ] makedepend
+ [ ] makefile2graph
+ [ ] makepkg
+ [ ] malbolge
+ [ ] man-db
+ [ ] man2html
+ [ ] mandoc
+ [ ] mariadb
+ [ ] mariadb@10.1
+ [ ] mariadb@10.2
+ [ ] mariadb@10.3
+ [ ] mariadb@10.4
+ [ ] markdown
+ [ ] marked
+ [ ] marst
+ [ ] masscan
+ [ ] massren
+ [ ] math-comp
+ [ ] mawk
+ [ ] mbedtls
+ [ ] mboxgrep
+ [ ] mcabber
+ [ ] mcpp
+ [ ] mcrypt
+ [ ] md5deep
+ [ ] md5sha1sum
+ [ ] mdbook
+ [ ] mdbtools
+ [ ] mdcat
+ [ ] mdds
+ [ ] mdf2iso
+ [ ] mdk
+ [ ] mdp
+ [ ] mdv
+ [ ] mecab-ipadic
+ [ ] mecab-jumandic
+ [ ] mecab-ko-dic
+ [ ] mecab-ko
+ [ ] mecab-unidic-extended
+ [ ] mecab-unidic
+ [ ] mecab
+ [ ] media-info
+ [ ] mediaconch
+ [ ] mednafen
+ [ ] megacmd
+ [ ] megatools
+ [ ] memcached
+ [ ] memcacheq
+ [ ] menhir
+ [ ] mercurial
+ [ ] mesa-glu
+ [ ] mesa
+ [ ] meson
+ [ ] metis
+ [ ] mhash
+ [ ] mhonarc
+ [ ] micro
+ [ ] micropython
+ [ ] midnight-commander
+ [ ] mighttpd2
+ [ ] mikutter
+ [ ] miller
+ [ ] mingw-w64
+ [ ] minica
+ [ ] minikube
+ [ ] minimal-racket
+ [ ] minimodem
+ [ ] minio-mc
+ [ ] minio
+ [ ] minised
+ [ ] miniserve
+ [ ] miniupnpc
+ [ ] minizinc
+ [ ] minizip
+ [ ] minuit2
+ [ ] mit-scheme
+ [ ] mitmproxy
+ [ ] mjpegtools
+ [ ] mkcert
+ [ ] mkclean
+ [ ] mkdocs
+ [ ] mksh
+ [ ] mktorrent
+ [ ] mkvalidator
+ [ ] mlkit
+ [ ] mlogger
+ [ ] mm-common
+ [ ] mmark
+ [ ] mmctl
+ [ ] mmix
+ [ ] mmseqs2
+ [ ] mmsrip
+ [ ] mmv
+ [ ] moc
+ [ ] modd
+ [ ] modules
+ [ ] moe
+ [ ] molecule
+ [ ] mon
+ [ ] mongo-c-driver
+ [ ] mongo-cxx-driver
+ [ ] mongo-orchestration
+ [ ] mongoose
+ [ ] mongrel2
+ [ ] mongroup
+ [ ] mono-libgdiplus
+ [ ] monolith
+ [ ] moreutils
+ [ ] mosh
+ [ ] mosml
+ [ ] mosquitto
+ [ ] most
+ [ ] movgrab
+ [ ] moz-git-tools
+ [ ] mozjpeg
+ [ ] mp3cat
+ [ ] mp3check
+ [ ] mp3gain
+ [ ] mp3splt
+ [ ] mp3wrap
+ [ ] mp4v2
+ [ ] mpage
+ [ ] mpc
+ [ ] mpck
+ [ ] mpdecimal
+ [ ] mpdviz
+ [ ] mpegdemux
+ [ ] mpfi
+ [ ] mpfr
+ [ ] mpg123
+ [ ] mpg321
+ [ ] mpgtx
+ [ ] mpi4py
+ [ ] mplayer
+ [ ] mpop
+ [ ] mps-youtube
+ [ ] mpssh
+ [ ] mpw
+ [ ] mr
+ [ ] mrboom
+ [ ] mrtg
+ [ ] mruby-cli
+ [ ] mruby
+ [ ] mscgen
+ [ ] msdl
+ [ ] msgpack-tools
+ [ ] msgpack
+ [ ] msgpuck
+ [ ] msmtp
+ [ ] mstch
+ [ ] mtr
+ [ ] mujs
+ [ ] multimarkdown
+ [ ] multitail
+ [ ] muparser
+ [ ] mupdf-tools
+ [ ] mupdf
+ [ ] mutt
+ [ ] mvtools
+ [ ] mycli
+ [ ] myman
+ [ ] mypy
+ [ ] mysql++
+ [ ] mysql-client
+ [ ] mysql-connector-c++
+ [ ] mysql-sandbox
+ [ ] n
+ [ ] nacl
+ [ ] nano
+ [ ] nanomsg
+ [ ] nanomsgxx
+ [ ] nanopb-generator
+ [ ] nasm
+ [ ] nativefier
+ [ ] nats-server
+ [ ] nats-streaming-server
+ [ ] nauty
+ [ ] navi
+ [ ] nbdime
+ [ ] nbimg
+ [ ] ncdc
+ [ ] ncdu
+ [ ] ncftp
+ [ ] ncmpc
+ [ ] ncompress
+ [ ] ncp
+ [ ] ncrack
+ [ ] ncurses
+ [ ] ncview
+ [ ] ndiff
+ [ ] neatvi
+ [ ] nebula
+ [ ] neko
+ [ ] neofetch
+ [ ] neovim
+ [ ] nestopia-ue
+ [ ] net-snmp
+ [ ] netcat
+ [ ] netcat6
+ [ ] netcdf
+ [ ] netdata
+ [ ] nethack
+ [ ] nethogs
+ [ ] netlify-cli
+ [ ] netpbm
+ [ ] netperf
+ [ ] nettle
+ [ ] nettoe
+ [ ] newman
+ [ ] newsboat
+ [ ] newt
+ [ ] nexus
+ [ ] nghttp2
+ [ ] nginx
+ [ ] ngircd
+ [ ] ngspice
+ [ ] ngt
+ [ ] nickle
+ [ ] nift
+ [ ] nim
+ [ ] ninja
+ [ ] nkf
+ [ ] nload
+ [ ] nlohmann-json
+ [ ] nlopt
+ [ ] nmap
+ [ ] nnn
+ [ ] no-more-secrets
+ [ ] node-sass
+ [ ] node
+ [ ] node@12
+ [ ] nomad
+ [ ] nopoll
+ [ ] noti
+ [ ] notifiers
+ [ ] npth
+ [ ] nq
+ [ ] nrg2iso
+ [ ] nsd
+ [ ] nspr
+ [ ] nsq
+ [ ] nss
+ [ ] ntl
+ [ ] numcpp
+ [ ] numpy
+ [ ] nushell
+ [ ] nut
+ [ ] nutcracker
+ [ ] nuttcp
+ [ ] nuvie
+ [ ] nvi
+ [ ] nyancat
+ [ ] nylon
+ [ ] nzbget
+ [ ] oath-toolkit
+ [ ] oauth2l
+ [ ] ocaml-findlib
+ [ ] ocaml-num
+ [ ] ocaml-zarith
+ [ ] ocaml
+ [ ] ocamlbuild
+ [ ] ocproxy
+ [ ] ocrad
+ [ ] ocrmypdf
+ [ ] octave
+ [ ] octomap
+ [ ] ode
+ [ ] odpi
+ [ ] oggz
+ [ ] ogmtools
+ [ ] ohcount
+ [ ] okteto
+ [ ] omega
+ [ ] ompl
+ [ ] ondir
+ [ ] one-ml
+ [ ] onednn
+ [ ] oniguruma
+ [ ] onioncat
+ [ ] onnxruntime
+ [ ] opa
+ [ ] opam
+ [ ] open-babel
+ [ ] open-jtalk
+ [ ] open-mesh
+ [ ] open-mpi
+ [ ] open-ocd
+ [ ] open-sp
+ [ ] open-tyrian
+ [ ] openal-soft
+ [ ] openblas
+ [ ] opencolorio
+ [ ] openconnect
+ [ ] opencore-amr
+ [ ] opencv
+ [ ] opendetex
+ [ ] openexr
+ [ ] openfortivpn
+ [ ] openh264
+ [ ] openhmd
+ [ ] openjdk
+ [ ] openjdk@11
+ [ ] openjdk@8
+ [ ] openjpeg
+ [ ] openldap
+ [ ] openlibm
+ [ ] openmotif
+ [ ] opensaml
+ [ ] openslide
+ [ ] openslp
+ [ ] openssl@1.1
+ [ ] opentracing-cpp
+ [ ] openvpn
+ [ ] operator-sdk
+ [ ] ophcrack
+ [ ] optipng
+ [ ] opus-tools
+ [ ] opus
+ [ ] opusfile
+ [ ] orbit
+ [ ] orc
+ [ ] orocos-kdl
+ [ ] osc
+ [ ] osi
+ [ ] osm-pbf
+ [ ] osm2pgsql
+ [ ] osmfilter
+ [ ] osmium-tool
+ [ ] osqp
+ [ ] osslsigncode
+ [ ] ossp-uuid
+ [ ] otf2
+ [ ] otf2bdf
+ [ ] ott
+ [ ] overmind
+ [ ] owamp
+ [ ] owfs
+ [ ] oxipng
+ [ ] p11-kit
+ [ ] p7zip
+ [ ] pacapt
+ [ ] pachi
+ [ ] packer
+ [ ] packetq
+ [ ] packmol
+ [ ] packr
+ [ ] pacparser
+ [ ] pacvim
+ [ ] pagmo
+ [ ] pandoc-citeproc
+ [ ] pandoc-crossref
+ [ ] pandoc-include-code
+ [ ] pandoc
+ [ ] pango
+ [ ] pangomm@2.46
+ [ ] paperkey
+ [ ] par
+ [ ] par2
+ [ ] parallel-hashmap
+ [ ] parallel
+ [ ] pass-otp
+ [ ] pass
+ [ ] passpie
+ [ ] pastebinit
+ [ ] pastel
+ [ ] patchelf
+ [ ] patchutils
+ [ ] path-extractor
+ [ ] pbzip2
+ [ ] pce
+ [ ] pcre++
+ [ ] pcre
+ [ ] pcre2
+ [ ] pcsc-lite
+ [ ] pdf2json
+ [ ] pdf2svg
+ [ ] pdfcpu
+ [ ] pdfcrack
+ [ ] pdfgrep
+ [ ] pdflib-lite
+ [ ] pdftk-java
+ [ ] pdftohtml
+ [ ] pdns
+ [ ] pdnsd
+ [ ] pdnsrec
+ [ ] peco
+ [ ] peg-markdown
+ [ ] peg
+ [ ] pelikan
+ [ ] percona-toolkit
+ [ ] perkeep
+ [ ] perl-build
+ [ ] perl
+ [ ] perl@5.18
+ [ ] perltidy
+ [ ] peru
+ [ ] pex
+ [ ] pfetch
+ [ ] pg_top
+ [ ] pgbadger
+ [ ] pgbouncer
+ [ ] pgcli
+ [ ] pgdbf
+ [ ] pgformatter
+ [ ] pgloader
+ [ ] pgpdump
+ [ ] pgpool-ii
+ [ ] pgweb
+ [ ] phoon
+ [ ] php
+ [ ] php@7.2
+ [ ] php@7.3
+ [ ] physfs
+ [ ] pianobar
+ [ ] pianod
+ [ ] picat
+ [ ] picocom
+ [ ] pigz
+ [ ] pike
+ [ ] piknik
+ [ ] pillar
+ [ ] pilosa
+ [ ] pinboard-notes-backup
+ [ ] pinentry
+ [ ] pipebench
+ [ ] pipemeter
+ [ ] pipenv
+ [ ] pipes-sh
+ [ ] pipgrip
+ [ ] pipx
+ [ ] pius
+ [ ] pixman
+ [ ] pixz
+ [ ] pjproject
+ [ ] pkcs11-helper
+ [ ] pkg-config
+ [ ] pkgdiff
+ [ ] platformio
+ [ ] ploticus
+ [ ] plotutils
+ [ ] plplot
+ [ ] plzip
+ [ ] pmccabe
+ [ ] pms
+ [ ] png++
+ [ ] pngcrush
+ [ ] pngquant
+ [ ] pnpm
+ [ ] po4a
+ [ ] poco
+ [ ] pod2man
+ [ ] podiff
+ [ ] podofo
+ [ ] pokerstove
+ [ ] polyglot
+ [ ] polyml
+ [ ] pony-stable
+ [ ] ponyc
+ [ ] ponysay
+ [ ] poppler
+ [ ] popt
+ [ ] portaudio
+ [ ] posh
+ [ ] poster
+ [ ] postgresql
+ [ ] postgresql@10
+ [ ] postgresql@11
+ [ ] postgresql@12
+ [ ] postgresql@9.4
+ [ ] postgresql@9.5
+ [ ] postgresql@9.6
+ [ ] postgrest
+ [ ] postmark
+ [ ] povray
+ [ ] powerline-go
+ [ ] powerman
+ [ ] ppsspp
+ [ ] pre-commit
+ [ ] precomp
+ [ ] premake
+ [ ] prettier
+ [ ] primer3
+ [ ] primesieve
+ [ ] prips
+ [ ] procmail
+ [ ] procs
+ [ ] prodigal
+ [ ] profanity
+ [ ] proftpd
+ [ ] progress
+ [ ] proj
+ [ ] prometheus
+ [ ] proper
+ [ ] proselint
+ [ ] proteinortho
+ [ ] protobuf-c
+ [ ] protobuf-swift
+ [ ] protobuf
+ [ ] protobuf@3.7
+ [ ] protoc-gen-go-grpc
+ [ ] protoc-gen-go
+ [ ] protoc-gen-gogo
+ [ ] protoc-gen-gogofaster
+ [ ] protoc-gen-grpc-web
+ [ ] prototool
+ [ ] prover9
+ [ ] proxychains-ng
+ [ ] proxytunnel
+ [ ] psc-package
+ [ ] psftools
+ [ ] pspg
+ [ ] psqlodbc
+ [ ] pssh
+ [ ] pstoedit
+ [ ] pstree
+ [ ] psutils
+ [ ] ptex
+ [ ] pth
+ [ ] pueue
+ [ ] puf
+ [ ] pugixml
+ [ ] pulseaudio
+ [ ] pulumi
+ [ ] pumba
+ [ ] pup
+ [ ] purescript
+ [ ] putty
+ [ ] pv
+ [ ] pwgen
+ [ ] pwnat
+ [ ] pwsafe
+ [ ] py2cairo
+ [ ] py3cairo
+ [ ] pybind11
+ [ ] pyenv
+ [ ] pygitup
+ [ ] pygments
+ [ ] pygobject3
+ [ ] pyinvoke
+ [ ] pylint
+ [ ] pympress
+ [ ] pypy
+ [ ] pyqt
+ [ ] python-markdown
+ [ ] python-yq
+ [ ] python@3.7
+ [ ] python@3.8
+ [ ] python@3.9
+ [ ] pyvim
+ [ ] qcachegrind
+ [ ] qd
+ [ ] qdae
+ [ ] qhull
+ [ ] qp
+ [ ] qpdf
+ [ ] qpid-proton
+ [ ] qpm
+ [ ] qprint
+ [ ] qrcp
+ [ ] qrencode
+ [ ] qrupdate
+ [ ] qscintilla2
+ [ ] qt
+ [ ] qtfaststart
+ [ ] quantlib
+ [ ] quex
+ [ ] quickjs
+ [ ] quicktype
+ [ ] quilt
+ [ ] quotatool
+ [ ] quvi
+ [ ] r
+ [ ] r3
+ [ ] rabbitmq-c
+ [ ] rack
+ [ ] radamsa
+ [ ] radare2
+ [ ] ragel
+ [ ] rakudo-star
+ [ ] rancher-cli
+ [ ] rancher-compose
+ [ ] randomize-lines
+ [ ] rapidjson
+ [ ] raptor
+ [ ] rargs
+ [ ] rarian
+ [ ] rasqal
+ [ ] ratfor
+ [ ] rav1e
+ [ ] raxml-ng
+ [ ] rbenv
+ [ ] rbspy
+ [ ] rcm
+ [ ] rdate
+ [ ] rdfind
+ [ ] rdup
+ [ ] re2
+ [ ] re2c
+ [ ] react-native-cli
+ [ ] readline
+ [ ] rebar
+ [ ] rebar3
+ [ ] recon-ng
+ [ ] recoverjpeg
+ [ ] recutils
+ [ ] redis-leveldb
+ [ ] redis
+ [ ] redis@3.2
+ [ ] redis@4.0
+ [ ] redland
+ [ ] redshift
+ [ ] redsocks
+ [ ] regex-opt
+ [ ] regina-rexx
+ [ ] remake
+ [ ] remarshal
+ [ ] reminiscence
+ [ ] ren
+ [ ] rename
+ [ ] reposurgeon
+ [ ] reprepro
+ [ ] restic
+ [ ] resty
+ [ ] rex
+ [ ] rgbds
+ [ ] rgxg
+ [ ] rhash
+ [ ] riemann-client
+ [ ] riff
+ [ ] rinetd
+ [ ] ripgrep-all
+ [ ] ripgrep
+ [ ] ripmime
+ [ ] rke
+ [ ] rkflashtool
+ [ ] rkhunter
+ [ ] rlog
+ [ ] rlwrap
+ [ ] rmcast
+ [ ] rnv
+ [ ] robodoc
+ [ ] rocksdb
+ [ ] roll
+ [ ] roswell
+ [ ] roundup
+ [ ] rpl
+ [ ] rpm2cpio
+ [ ] rsnapshot
+ [ ] rst-lint
+ [ ] rsync
+ [ ] rsyslog
+ [ ] rtf2latex2e
+ [ ] rtmpdump
+ [ ] rtorrent
+ [ ] rtptools
+ [ ] rtv
+ [ ] rubberband
+ [ ] ruby-install
+ [ ] ruby
+ [ ] ruby@2.4
+ [ ] ruby@2.5
+ [ ] ruby@2.6
+ [ ] ruby@2.7
+ [ ] rubyfmt
+ [ ] run
+ [ ] rush
+ [ ] rust-analyzer
+ [ ] rust
+ [ ] rustup-init
+ [ ] ry
+ [ ] s-lang
+ [ ] s-search
+ [ ] s3cmd
+ [ ] s6
+ [ ] sagittarius-scheme
+ [ ] salt
+ [ ] sampler
+ [ ] samtools
+ [ ] samurai
+ [ ] sane-backends
+ [ ] sassc
+ [ ] sbcl
+ [ ] scalapack
+ [ ] scale2x
+ [ ] scamper
+ [ ] scc
+ [ ] sccache
+ [ ] scdoc
+ [ ] sceptre
+ [ ] schroedinger
+ [ ] scipy
+ [ ] scm-manager
+ [ ] scmpuff
+ [ ] scons
+ [ ] scour
+ [ ] screen
+ [ ] scriptcs
+ [ ] scrollkeeper
+ [ ] scrub
+ [ ] scummvm-tools
+ [ ] scw
+ [ ] scws
+ [ ] sd
+ [ ] sdb
+ [ ] sdcv
+ [ ] sdl
+ [ ] sdl2
+ [ ] sdl2_gfx
+ [ ] sdl2_image
+ [ ] sdl2_mixer
+ [ ] sdl2_net
+ [ ] sdl2_ttf
+ [ ] sdl_gfx
+ [ ] sdl_image
+ [ ] sdl_mixer
+ [ ] sdl_net
+ [ ] sdl_rtf
+ [ ] sdl_ttf
+ [ ] sdlpop
+ [ ] seal
+ [ ] securefs
+ [ ] seqtk
+ [ ] ser2net
+ [ ] serf
+ [ ] sersniff
+ [ ] serve
+ [ ] sfcgal
+ [ ] sfk
+ [ ] sgrep
+ [ ] sha1dc
+ [ ] sha2
+ [ ] shadowenv
+ [ ] shairport-sync
+ [ ] shairport
+ [ ] shapelib
+ [ ] shared-mime-info
+ [ ] shc
+ [ ] shellcheck
+ [ ] shellharden
+ [ ] shelltestrunner
+ [ ] shellz
+ [ ] shfmt
+ [ ] shmcat
+ [ ] shmux
+ [ ] shntool
+ [ ] shorten
+ [ ] shtool
+ [ ] shyaml
+ [ ] sic
+ [ ] sickle
+ [ ] sift
+ [ ] silk
+ [ ] simgrid
+ [ ] simh
+ [ ] simple-amqp-client
+ [ ] simple-obfs
+ [ ] since
+ [ ] sip
+ [ ] sipcalc
+ [ ] sipsak
+ [ ] sispmctl
+ [ ] sk
+ [ ] skaffold
+ [ ] skopeo
+ [ ] skymaker
+ [ ] sl
+ [ ] slackcat
+ [ ] slacknimate
+ [ ] sleef
+ [ ] sloc
+ [ ] sloccount
+ [ ] slowhttptest
+ [ ] slrn
+ [ ] smake
+ [ ] smartmontools
+ [ ] sn0int
+ [ ] snag
+ [ ] snakemake
+ [ ] snap-telemetry
+ [ ] snappy
+ [ ] snappystream
+ [ ] snapraid
+ [ ] sniffglue
+ [ ] snort
+ [ ] snow
+ [ ] snownews
+ [ ] snzip
+ [ ] socat
+ [ ] sofia-sip
+ [ ] softhsm
+ [ ] solid
+ [ ] somagic-tools
+ [ ] somagic
+ [ ] sonobuoy
+ [ ] sops
+ [ ] sound-touch
+ [ ] source-highlight
+ [ ] source-to-image
+ [ ] sox
+ [ ] spaceinvaders-go
+ [ ] spades
+ [ ] spandsp
+ [ ] sparkey
+ [ ] sparse
+ [ ] spatialindex
+ [ ] spawn-fcgi
+ [ ] spdlog
+ [ ] spdylay
+ [ ] speex
+ [ ] speexdsp
+ [ ] sphinx-doc
+ [ ] sphinx
+ [ ] spigot
+ [ ] spin
+ [ ] spirv-cross
+ [ ] splint
+ [ ] sql-translator
+ [ ] sqldiff
+ [ ] sqlite
+ [ ] sqlparse
+ [ ] squashfs
+ [ ] squid
+ [ ] squirrel
+ [ ] srmio
+ [ ] srt
+ [ ] srtp
+ [ ] ssdb
+ [ ] ssdeep
+ [ ] ssed
+ [ ] ssh-permit-a38
+ [ ] ssh-vault
+ [ ] sshfs
+ [ ] sshguard
+ [ ] sshtrix
+ [ ] sshuttle
+ [ ] ssldump
+ [ ] sslh
+ [ ] ssllabs-scan
+ [ ] sslscan
+ [ ] sstp-client
+ [ ] star
+ [ ] starship
+ [ ] staticcheck
+ [ ] statik
+ [ ] stdman
+ [ ] stella
+ [ ] step
+ [ ] stern
+ [ ] stgit
+ [ ] stlink
+ [ ] stm32flash
+ [ ] stoken
+ [ ] stolon
+ [ ] stormlib
+ [ ] stormssh
+ [ ] stout
+ [ ] stow
+ [ ] streamlink
+ [ ] streamripper
+ [ ] stress-ng
+ [ ] stuntman
+ [ ] subliminal
+ [ ] subnetcalc
+ [ ] subversion
+ [ ] suite-sparse
+ [ ] sundials
+ [ ] superlu
+ [ ] supervisor
+ [ ] surfraw
+ [ ] suricata
+ [ ] svgcleaner
+ [ ] svgo
+ [ ] swagger-codegen@2
+ [ ] swig
+ [ ] sword
+ [ ] sylpheed
+ [ ] syncthing
+ [ ] synscan
+ [ ] syntaxerl
+ [ ] sysbench
+ [ ] systemc
+ [ ] szip
+ [ ] t1lib
+ [ ] t1utils
+ [ ] ta-lib
+ [ ] taglib
+ [ ] taktuk
+ [ ] tal
+ [ ] talloc
+ [ ] tanka
+ [ ] task-spooler
+ [ ] task
+ [ ] taskell
+ [ ] tasksh
+ [ ] taskwarrior-tui
+ [ ] tass64
+ [ ] tbb
+ [ ] tcl-tk
+ [ ] tclap
+ [ ] tcpdump
+ [ ] tcptunnel
+ [ ] tcsh
+ [ ] td
+ [ ] tdkjs
+ [ ] tealdeer
+ [ ] tectonic
+ [ ] teleconsole
+ [ ] telegraf
+ [ ] telegram-cli
+ [ ] termius
+ [ ] termrec
+ [ ] termshare
+ [ ] termtosvg
+ [ ] terraform-docs
+ [ ] terraform-inventory
+ [ ] terraform-provisioner-ansible
+ [ ] terraform
+ [ ] terraform@0.11
+ [ ] terraform_landscape
+ [ ] terraformer
+ [ ] terrahub
+ [ ] terrascan
+ [ ] tesseract-lang
+ [ ] tesseract
+ [ ] texapp
+ [ ] texi2html
+ [ ] texinfo
+ [ ] texmath
+ [ ] textql
+ [ ] tflint
+ [ ] the_platinum_searcher
+ [ ] the_silver_searcher
+ [ ] thefuck
+ [ ] theora
+ [ ] thrift
+ [ ] thrulay
+ [ ] tidy-html5
+ [ ] tidyp
+ [ ] tiff2png
+ [ ] tig
+ [ ] tiger-vnc
+ [ ] tile38
+ [ ] timelimit
+ [ ] timewarrior
+ [ ] tinc
+ [ ] tintin
+ [ ] tiny-fugue
+ [ ] tinycdb
+ [ ] tinysvm
+ [ ] tinyxml
+ [ ] tinyxml2
+ [ ] tio
+ [ ] tippecanoe
+ [ ] tj
+ [ ] tldr
+ [ ] tlx
+ [ ] tmate
+ [ ] tmpwatch
+ [ ] tmux-mem-cpu-load
+ [ ] tmux
+ [ ] tmuxinator
+ [ ] tmx
+ [ ] tnef
+ [ ] tnftp
+ [ ] toast
+ [ ] todoman
+ [ ] tofrodos
+ [ ] toilet
+ [ ] tokei
+ [ ] tokyo-cabinet
+ [ ] topgit
+ [ ] topgrade
+ [ ] tor
+ [ ] torrentcheck
+ [ ] torsocks
+ [ ] tox
+ [ ] tractorgen
+ [ ] trader
+ [ ] trailscraper
+ [ ] translate-shell
+ [ ] translate-toolkit
+ [ ] transmission-cli
+ [ ] trash-cli
+ [ ] travis
+ [ ] tre
+ [ ] tree
+ [ ] treecc
+ [ ] triangle
+ [ ] triton
+ [ ] truecrack
+ [ ] truncate
+ [ ] trunk
+ [ ] tsung
+ [ ] tta
+ [ ] ttf2eot
+ [ ] ttf2pt1
+ [ ] ttfautohint
+ [ ] tth
+ [ ] tty-share
+ [ ] ttyplot
+ [ ] tundra
+ [ ] tunnel
+ [ ] tvnamer
+ [ ] twarc
+ [ ] tweak
+ [ ] twemcache
+ [ ] two-lame
+ [ ] twoping
+ [ ] twtxt
+ [ ] typescript
+ [ ] u-boot-tools
+ [ ] uade
+ [ ] ubertooth
+ [ ] ucg
+ [ ] uchardet
+ [ ] ucl
+ [ ] ucloud
+ [ ] ucommon
+ [ ] ucon64
+ [ ] udns
+ [ ] udptunnel
+ [ ] udpxy
+ [ ] ufraw
+ [ ] uftp
+ [ ] uggconv
+ [ ] ultralist
+ [ ] um
+ [ ] unbound
+ [ ] uncrustify
+ [ ] uni
+ [ ] unibilium
+ [ ] unison
+ [ ] unittest-cpp
+ [ ] unittest
+ [ ] uniutils
+ [ ] unixodbc
+ [ ] unpaper
+ [ ] unrtf
+ [ ] unyaffs
+ [ ] unzip
+ [ ] up
+ [ ] uptimed
+ [ ] upx
+ [ ] urdfdom
+ [ ] urdfdom_headers
+ [ ] uriparser
+ [ ] uru
+ [ ] urweb
+ [ ] usbredir
+ [ ] userspace-rcu
+ [ ] utf8cpp
+ [ ] utf8proc
+ [ ] util-linux
+ [ ] util-macros
+ [ ] uudeview
+ [ ] uwsgi
+ [ ] v2ray-plugin
+ [ ] vala
+ [ ] vale
+ [ ] vamp-plugin-sdk
+ [ ] vapoursynth
+ [ ] vaulted
+ [ ] vavrdiasm
+ [ ] vc4asm
+ [ ] vcdimager
+ [ ] vcftools
+ [ ] vcprompt
+ [ ] vcs
+ [ ] vde
+ [ ] vdirsyncer
+ [ ] vegeta
+ [ ] velero
+ [ ] vercel-cli
+ [ ] vert
+ [ ] vgmstream
+ [ ] vifm
+ [ ] vilistextum
+ [ ] vim
+ [ ] vimpager
+ [ ] virgil
+ [ ] virtuoso
+ [ ] virustotal-cli
+ [ ] visionmedia-watch
+ [ ] visitors
+ [ ] vitetris
+ [ ] vivid
+ [ ] vmtouch
+ [ ] vnstat
+ [ ] volt
+ [ ] vorbis-tools
+ [ ] vorbisgain
+ [ ] voro++
+ [ ] vpcs
+ [ ] vramsteg
+ [ ] vrpn
+ [ ] vsts-cli
+ [ ] vtk
+ [ ] vttest
+ [ ] vulkan-headers
+ [ ] vultr
+ [ ] w3m
+ [ ] wabt
+ [ ] wagyu
+ [ ] wakatime-cli
+ [ ] wal2json
+ [ ] wapm
+ [ ] wartremover
+ [ ] wasmer
+ [ ] watch
+ [ ] watchexec
+ [ ] watchman
+ [ ] watson
+ [ ] wavpack
+ [ ] wbox
+ [ ] wcslib
+ [ ] wdc
+ [ ] wdiff
+ [ ] webalizer
+ [ ] webdis
+ [ ] webp
+ [ ] webpack
+ [ ] websocat
+ [ ] websocketd
+ [ ] webtorrent-cli
+ [ ] weechat
+ [ ] wego
+ [ ] wellington
+ [ ] wemux
+ [ ] wget
+ [ ] whalebrew
+ [ ] whatmask
+ [ ] whatmp3
+ [ ] when
+ [ ] whistle
+ [ ] whois
+ [ ] wiki
+ [ ] wimlib
+ [ ] wiredtiger
+ [ ] wireguard-go
+ [ ] wireguard-tools
+ [ ] wla-dx
+ [ ] woff2
+ [ ] wolfmqtt
+ [ ] wolfssl
+ [ ] wordgrinder
+ [ ] wordplay
+ [ ] wrangler
+ [ ] wren-cli
+ [ ] wren
+ [ ] write-good
+ [ ] wrk
+ [ ] wsk
+ [ ] wskdeploy
+ [ ] wslay
+ [ ] wtfutil
+ [ ] wumpus
+ [ ] wv
+ [ ] wxmac
+ [ ] x264
+ [ ] x265
+ [ ] xa
+ [ ] xalan-c
+ [ ] xapian
+ [ ] xbee-comm
+ [ ] xbitmaps
+ [ ] xcb-proto
+ [ ] xcb-util-cursor
+ [ ] xcb-util-image
+ [ ] xcb-util-keysyms
+ [ ] xcb-util-renderutil
+ [ ] xcb-util-wm
+ [ ] xcb-util
+ [ ] xclip
+ [ ] xdelta
+ [ ] xdotool
+ [ ] xdpyinfo
+ [ ] xerces-c
+ [ ] xgboost
+ [ ] xinput
+ [ ] xkeyboardconfig
+ [ ] xmake
+ [ ] xml-security-c
+ [ ] xml-tooling-c
+ [ ] xml2
+ [ ] xmlcatmgr
+ [ ] xmlrpc-c
+ [ ] xmlstarlet
+ [ ] xmlto
+ [ ] xmltoman
+ [ ] xmount
+ [ ] xmp
+ [ ] xmrig
+ [ ] xonsh
+ [ ] xorgproto
+ [ ] xorgrgb
+ [ ] xorriso
+ [ ] xplanet
+ [ ] xqilla
+ [ ] xrootd
+ [ ] xsane
+ [ ] xsimd
+ [ ] xsv
+ [ ] xsw
+ [ ] xtail
+ [ ] xtensor
+ [ ] xterm
+ [ ] xtrans
+ [ ] xvid
+ [ ] xxhash
+ [ ] xz
+ [ ] yaegi
+ [ ] yaf
+ [ ] yajl
+ [ ] yaml-cpp
+ [ ] yamllint
+ [ ] yank
+ [ ] yapf
+ [ ] yash
+ [ ] yasm
+ [ ] yaz
+ [ ] yazpp
+ [ ] yetris
+ [ ] yh
+ [ ] ykpers
+ [ ] yle-dl
+ [ ] you-get
+ [ ] youtube-dl
+ [ ] yq
+ [ ] yubico-piv-tool
+ [ ] yydecode
+ [ ] z3
+ [ ] z80asm
+ [ ] z80dasm
+ [ ] zabbix-cli
+ [ ] zabbix
+ [ ] zbackup
+ [ ] zdelta
+ [ ] zenity
+ [ ] zeromq
+ [ ] zig
+ [ ] zile
+ [ ] zimg
+ [ ] zint
+ [ ] zip
+ [ ] zita-convolver
+ [ ] zlib
+ [ ] zlog
+ [ ] zmqpp
+ [ ] znapzend
+ [ ] znc
+ [ ] zola
+ [ ] zookeeper
+ [ ] zopfli
+ [ ] zork
+ [ ] zoxide
+ [ ] zpaq
+ [ ] zrepl
+ [ ] zsh-syntax-highlighting
+ [ ] zsh
+ [ ] zshdb
+ [ ] zssh
+ [ ] zstd
+ [ ] zsync
+ [ ] zydis
+ [ ] zzuf