### PR TITLE
libsecret: Fix build for linuxbrew

### DIFF
--- a/Formula/libsecret.rb
+++ b/Formula/libsecret.rb
@@ -21,11 +21,12 @@ class Libsecret < Formula
   depends_on "docbook-xsl" => :build
   depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
-  depends_on "libxslt" => :build
   depends_on "pkg-config" => :build
   depends_on "vala" => :build
   depends_on "glib"
   depends_on "libgcrypt"
+  
+  depends_on "libxslt" => :build unless OS.mac?
 
   def install
     # Needed by intltool (xml::parser)

--- a/Formula/libsecret.rb
+++ b/Formula/libsecret.rb
@@ -21,6 +21,7 @@ class Libsecret < Formula
   depends_on "docbook-xsl" => :build
   depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
+  depends_on "libxslt" => :build
   depends_on "pkg-config" => :build
   depends_on "vala" => :build
   depends_on "glib"


### PR DESCRIPTION
Fix build error by adding `libxslt` dependency

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The corresponding build log could be found at
https://gist.github.com/jnooree/b7f5105aafff6eb7d416928b4b9321ee#file-config-log-L757
> configure:16819: error: xsltproc is required to build manual pages