### PR TITLE
podman: fix for Linux x86_64

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -1,29 +1,12 @@
 class Podman < Formula
   desc "Tool for managing OCI containers and pods"
-  homepage "https://podman.io/"
-  url "https://github.com/containers/podman/archive/v2.2.1.tar.gz"
-  sha256 "bd86b181251e2308cb52f18410fb52d89df7f130cecf0298bbf9a848fe7daf60"
+  homepage "https://podman.io"
+  url "https://github.com/containers/podman/releases/download/v2.2.1/podman-remote-static.tar.gz"
+  sha256 "fcaa81f63dee7bbb1e5dce60d3877eaec500a24ad02978c1263dd6e7c669c070"
   license "Apache-2.0"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "2d4557414e96180dd119382303f932a685cfd9f810cb39c89e646f366d6e933c"
-    sha256 cellar: :any_skip_relocation, big_sur:       "9f1b52e8e1fbb23a43ed7e961cb5e119d38aaa6abec767d1c795ffcbb5a08d8f"
-    sha256 cellar: :any_skip_relocation, catalina:      "c495895437ba8d9fbc999a74d3d8e465f7980fc78b846b383c396e96a220e5d7"
-    sha256 cellar: :any_skip_relocation, mojave:        "a608e53d52bfa2448c1ca8a48aa2702107d60bcd9bc351f4387c9c3922f3ca3f"
-  end
-
-  depends_on "go" => :build
-  depends_on "go-md2man" => :build
-
   def install
-    system "make", "podman-remote-darwin"
-    bin.install "bin/podman-remote-darwin" => "podman"
-
-    system "make", "install-podman-remote-darwin-docs"
-    man1.install Dir["docs/build/remote/darwin/*.1"]
-
-    bash_completion.install "completions/bash/podman"
-    zsh_completion.install "completions/zsh/_podman"
+    bin.install "podman-remote-static" => "podman"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The current podman formula is not built for Linux, this fix use the prebuilt binary provided by the developers.