### PR TITLE
glibc: remove ENV.O2 (it's the default and deprecated).

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -134,9 +134,6 @@ class Glibc < Formula
       ENV["BUILD_LDFLAGS"] = "-L#{opt_lib}" if opt_lib.directory?
     end
 
-    # -Os confuses valgrind.
-    ENV.O2
-
     # Use brewed ld.so.preload rather than the hotst's /etc/ld.so.preload
     inreplace "elf/rtld.c", '= "/etc/ld.so.preload";', '= SYSCONFDIR "/ld.so.preload";'
 


### PR DESCRIPTION
See https://github.com/Homebrew/brew/blob/e818e8f4c6b27abe240d87cfb15ca81b7c0744aa/Library/Homebrew/extend/os/linux/extend/ENV/super.rb#L15
