### PR TITLE
avrdude: add uses_from_macos bison and flex

### DIFF
--- a/Formula/avrdude.rb
+++ b/Formula/avrdude.rb
@@ -33,6 +33,9 @@ class Avrdude < Formula
   depends_on "libhid"
   depends_on "libusb-compat"
 
+  uses_from_macos "bison"
+  uses_from_macos "flex"
+
   def install
     if build.head?
       inreplace "bootstrap", /libtoolize/, "glibtoolize"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
