### PR TITLE
workflows: remove HOMEBREW_PATCHELF_RB

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -8,7 +8,6 @@ jobs:
     container:
       image: homebrew/ubuntu16.04:master
     env:
-      HOMEBREW_PATCHELF_RB: 1
       HOMEBREW_GIT_NAME: BrewTestBot
       HOMEBREW_GIT_EMAIL: 'homebrew-test-bot@lists.sfconservancy.org'
       HOMEBREW_DEVELOPER: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: homebrew/ubuntu16.04:master
-    env:
-      HOMEBREW_PATCHELF_RB: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
It's not needed anymore

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
