### PR TITLE
Update wasmer -cmake -wabt +llvm

### DIFF
--- a/Formula/wasmer.rb
+++ b/Formula/wasmer.rb
@@ -14,13 +14,12 @@ class Wasmer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "cd673303dfef4b4924aa6cbbfb6c3c986993f1b512cc3999452addfa07627481"
   end
 
-  depends_on "cmake" => :build
+  depends_on "llvm" => :build
   depends_on "rust" => :build
-  depends_on "wabt" => :build
 
   def install
     chdir "lib/cli" do
-      system "cargo", "install", "--features", "cranelift", *std_cargo_args
+      system "cargo", "install", "--features", "cranelift,llvm", *std_cargo_args
     end
   end
 


### PR DESCRIPTION
Wasmer no longer requires cmake or wabt.
When building the bottle we want to install llvm so that compiler is also supported

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
