### PR TITLE
perl: drop cpan installation

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -74,15 +74,6 @@ class Perl < Formula
         # locale.h includes xlocale.h if the latter one exists
         inreplace "#{perl_core}/perl.h", "include <xlocale.h>", "include <locale.h>"
       end
-
-      # CPAN modules installed via the system package manager will not be visible to
-      # brewed Perl. As a temporary measure, install critical CPAN modules to ensure
-      # they are available. See https://github.com/Linuxbrew/homebrew-core/pull/1064
-      ENV.activate_extensions!
-      ENV.setup_build_environment(formula: self)
-      ENV["PERL_MM_USE_DEFAULT"] = "1"
-      system bin/"cpan", "-i", "XML::Parser"
-      system bin/"cpan", "-i", "XML::SAX"
     end
   end
 


### PR DESCRIPTION
We are installing these modules in the respective formulae, when needed.

Fixes:
2021-02-18T22:46:49.4354923Z Writing /github/home/.cpan/Metadata
2021-02-18T22:46:49.4355676Z Running install for module 'XML::Parser'
2021-02-18T22:46:49.4356133Z Fetching with HTTP::Tiny:
2021-02-18T22:46:49.4356898Z http://www.cpan.org/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz
2021-02-18T22:46:49.4357510Z Fetching with HTTP::Tiny:
2021-02-18T22:46:49.4358050Z http://www.cpan.org/authors/id/T/TO/TODDR/CHECKSUMS
2021-02-18T22:46:49.4358968Z Checksum for /github/home/.cpan/sources/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz ok
2021-02-18T22:46:49.4359917Z 'YAML' not installed, will not store persistent state
2021-02-18T22:46:49.4360749Z Configuring T/TO/TODDR/XML-Parser-2.46.tar.gz with Makefile.PL
2021-02-18T22:46:49.4361194Z
2021-02-18T22:46:49.4361941Z Expat must be installed prior to building XML::Parser and I can't find
2021-02-18T22:46:49.4362963Z it in the standard library directories. Install 'expat-devel' (or
2021-02-18T22:46:49.4363957Z 'libexpat1-dev') package with your OS package manager. See 'README'.
2021-02-18T22:46:49.4364429Z
2021-02-18T22:46:49.4364816Z Or you can download expat from:
2021-02-18T22:46:49.4365129Z
2021-02-18T22:46:49.4365666Z http://sourceforge.net/projects/expat/
2021-02-18T22:46:49.4366115Z
2021-02-18T22:46:49.4366823Z If expat is installed, but in a non-standard directory, then use the
2021-02-18T22:46:49.4367515Z following options to Makefile.PL:
2021-02-18T22:46:49.4367855Z
2021-02-18T22:46:49.4368390Z     EXPATLIBPATH=...  To set the directory in which to find libexpat
2021-02-18T22:46:49.4368835Z
2021-02-18T22:46:49.4369354Z     EXPATINCPATH=...  To set the directory in which to find expat.h
2021-02-18T22:46:49.4369794Z
2021-02-18T22:46:49.4370135Z For example:
2021-02-18T22:46:49.4370395Z
2021-02-18T22:46:49.4370991Z     perl Makefile.PL EXPATLIBPATH=/home/me/lib EXPATINCPATH=/home/me/include
2021-02-18T22:46:49.4371513Z
2021-02-18T22:46:49.4372454Z Note that if you build against a shareable library in a non-standard location
2021-02-18T22:46:49.4373349Z you may (on some platforms) also have to set your LD_LIBRARY_PATH environment
2021-02-18T22:46:49.4374116Z variable at run time for perl to find the library.
2021-02-18T22:46:49.4374502Z
2021-02-18T22:46:49.4375236Z No 'Makefile' created  TODDR/XML-Parser-2.46.tar.gz
2021-02-18T22:46:49.4417816Z   /home/linuxbrew/.linuxbrew/Cellar/perl/5.32.1/bin/perl Makefile.PL -- NOT OK

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
