### PR TITLE
Replace regex assertions with string assertions

### DIFF
--- a/Formula/dwarf.rb
+++ b/Formula/dwarf.rb
@@ -44,7 +44,7 @@ class Dwarf < Formula
       assert_equal "magic: 0xfeedfacf (-17958193)", output.lines[0].chomp
     else
       # pp may not be installed on Linux, test something else
-      assert_match /main header: elf/, shell_output("#{bin}/dwarf -p test")
+      assert_match "main header: elf", shell_output("#{bin}/dwarf -p test")
     end
   end
 end

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -66,6 +66,6 @@ class Elfutils < Formula
 
   test do
     output = `#{bin}/elfutils-nm #{bin}/elfutils-nm`
-    assert_match /elf_kind/, output
+    assert_match "elf_kind", output
   end
 end

--- a/Formula/otf2bdf.rb
+++ b/Formula/otf2bdf.rb
@@ -40,7 +40,7 @@ class Otf2bdf < Formula
       assert_match "MacRoman", shell_output("#{bin}/otf2bdf -et /System/Library/Fonts/LucidaGrande.ttc")
     else
       resource("test-font").stage do
-        assert_match /MacRoman/, shell_output("#{bin}/otf2bdf -et LucidaGrande.ttc")
+        assert_match "MacRoman", shell_output("#{bin}/otf2bdf -et LucidaGrande.ttc")
       end
     end
   end

--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -48,7 +48,7 @@ class Physfs < Formula
     if OS.mac?
       assert_match "Successful.\nhomebrew", shell_output("#{bin}/test_physfs < test 2>&1")
     else
-      assert_match /homebrew/, shell_output("#{bin}/test_physfs < test 2>&1")
+      assert_match "homebrew", shell_output("#{bin}/test_physfs < test 2>&1")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This is a linux-only follow up to https://github.com/Homebrew/homebrew-core/pull/71286.

`dwarf` and `elfutils` don't these regex assertions in Homebrew/homebrew-core which is why they weren't modified (actually, `elfutils` doesn't even exist in Homebrew/homebrew-core).

`otf2bdf` and `physfs` were modified in the Homebrew/homebrew-core PR, but the changes were lost due to merge conflicts (I believe).
