### PR TITLE
Readd markdown issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bottle.md
+++ b/.github/ISSUE_TEMPLATE/bottle.md
@@ -1,0 +1,14 @@
+---
+name: New issue for Bottle Request
+about: "Submit a request for a bottle"
+title: "FORMULA: Request for a bottle"
+labels: bottle
+
+---
+<!--Please replace FORMULA in the title to the name of formula you want to be bottled-->
+
+**Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.**
+
+- [ ] checked that there aren't other open issues for the same formula bottle request?
+- [ ] does the FORMULA not have the `bottle` block?
+- [ ] ran `brew install FORMULA` and it succeeded?

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,41 @@
+---
+name: New issue for Reproducible Bug
+about: "If you're sure it's reproducible and not just your machine: submit an issue so we can investigate."
+
+---
+
+# Bug report
+
+**Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.**
+
+- [ ] ran `brew update` and can still reproduce the problem?
+- [ ] ran `brew doctor`, fixed all issues and can still reproduce the problem?
+- [ ] ran `brew gist-logs <formula>` (where `<formula>` is the name of the formula that failed) and included the output link?
+- [ ] if `brew gist-logs` didn't work: ran `brew config` and `brew doctor` and included their output with your issue?
+
+<!-- To help us debug your issue, please complete these sections: -->
+
+## What you were trying to do (and why)
+
+<!-- replace me -->
+
+## What happened (include command output)
+
+<!-- replace me -->
+
+<details>
+  <summary>Command output</summary>
+  <pre>
+
+  <!-- replace this with the command output -->
+
+  </pre>
+</details>
+
+## What you expected to happen
+
+<!-- replace me -->
+
+## Step-by-step reproduction instructions (by running `brew install` commands)
+
+<!-- replace me -->


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Reverts #22316 (kind of)

I decided to leave the new issue template files around so a seamless transition can occur once they're enabled here. I've readded both the `bottle` and `bug` markdown issue templates to restore existing functionality in the meantime.

CC: @issyl0 and @Bo98
