### PR TITLE
apr: delete Linux-specific workaround

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -44,11 +44,6 @@ class Apr < Formula
     # The internal libtool throws an enormous strop if we don't do...
     ENV.deparallelize
 
-    if OS.linux? && build.bottle?
-      # Prevent hardcoded /usr/bin/gcc-4.8 compiler
-      ENV["CC"] = "cc"
-    end
-
     # Needed to apply the patch.
     system "autoconf"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Linux-specific workaround was added in https://github.com/Homebrew/linuxbrew-core/pull/865 and doesn't appear to be needed anymore