### PR TITLE
sdcc: fix Linux build

### DIFF
--- a/Formula/sdcc.rb
+++ b/Formula/sdcc.rb
@@ -3,7 +3,8 @@ class Sdcc < Formula
   homepage "https://sdcc.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sdcc/sdcc/4.0.0/sdcc-src-4.0.0.tar.bz2"
   sha256 "489180806fc20a3911ba4cf5ccaf1875b68910d7aed3f401bbd0695b0bef4e10"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-only", "GPL-3.0-only", :public_domain, "Zlib"]
+  revision 1
   head "https://svn.code.sf.net/p/sdcc/code/trunk/sdcc"
 
   livecheck do
@@ -23,6 +24,11 @@ class Sdcc < Formula
   depends_on "automake" => :build
   depends_on "boost"
   depends_on "gputils"
+  depends_on "readline"
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "texinfo" => :build
 
   def install
     system "./configure", "--prefix=#{prefix}"
@@ -32,6 +38,12 @@ class Sdcc < Formula
   end
 
   test do
-    system "#{bin}/sdcc", "-v"
+    (testpath/"test.c").write <<~EOS
+      int main() {
+        return 0;
+      }
+    EOS
+    system "#{bin}/sdcc", "-mz80", "-o", "#{testpath}/test", "#{testpath}/test.c"
+    assert_predicate testpath/"test", :exist?
   end
 end


### PR DESCRIPTION
Builds fine on macOS because the configure script detects and uses system `flex`, `bison` and `makeinfo`.

Also fix license and test stanzas.

Fixes #22466.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
