### PR TITLE
lua, lua@5.3, lua@5.1: deduplicate shared libraries; align symlinks with macOS

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -4,6 +4,7 @@ class Lua < Formula
   url "https://www.lua.org/ftp/lua-5.4.2.tar.gz"
   sha256 "11570d97e9d7303c0a59567ed1ac7c648340cd0db10d5fd594c09223ef2f524f"
   license "MIT"
+  revision 1 unless OS.mac?
 
   livecheck do
     url "https://www.lua.org/ftp/"
@@ -15,7 +16,6 @@ class Lua < Formula
     sha256 cellar: :any, big_sur:       "f7e0d6c4b3cd8d3fba1f26dd81d23eb68e1adfcd6f7915732449a8671eedfb1c"
     sha256 cellar: :any, catalina:      "7fa53bc358e3fc6ebd2e1bcc326cd13f18141d780d07daadcecb891ebe61aa94"
     sha256 cellar: :any, mojave:        "0196098bf8f4f49c78061412237acda0e2e2010f4abc61a7ac085ede71e9b7a3"
-    sha256 cellar: :any, x86_64_linux:  "1d96ad51e1cbbb6e520b36c81380397e637be2f0ed4dedb76bb1118d45324bbb"
   end
 
   uses_from_macos "unzip" => :build
@@ -60,12 +60,7 @@ class Lua < Formula
     # We ship our own pkg-config file as Lua no longer provide them upstream.
     arch = OS.mac? ? "macosx" : "linux"
     system "make", arch, "INSTALL_TOP=#{prefix}", "INSTALL_INC=#{include}/lua", "INSTALL_MAN=#{man1}"
-    system "make",
-           "install",
-           "INSTALL_TOP=#{prefix}",
-           "INSTALL_INC=#{include}/lua",
-           "INSTALL_MAN=#{man1}",
-           *("TO_LIB=liblua.a liblua.so liblua.so.#{version.major_minor} liblua.so.#{version}" unless OS.mac?)
+    system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_INC=#{include}/lua", "INSTALL_MAN=#{man1}"
     (lib/"pkgconfig/lua.pc").write pc_file
 
     # Fix some software potentially hunting for different pc names.
@@ -74,7 +69,8 @@ class Lua < Formula
     bin.install_symlink "luac" => "luac#{version.major_minor}"
     bin.install_symlink "luac" => "luac-#{version.major_minor}"
     (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
-    lib.install_symlink "liblua.#{version.major_minor}.dylib" => "liblua#{version.major_minor}.dylib"
+    lib.install Dir[shared_library("src/liblua", "*")] unless OS.mac?
+    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
     (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
     (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
   end

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -6,7 +6,7 @@ class LuaAT51 < Formula
   mirror "https://deb.debian.org/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
   sha256 "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
   license "MIT"
-  revision OS.mac? ? 8 : 11
+  revision OS.mac? ? 8 : 12
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "cde11765109e69c6484206f4b2a63081b535253f32233471343f03b52505a89b"
@@ -16,7 +16,6 @@ class LuaAT51 < Formula
     sha256 cellar: :any, high_sierra:   "d374b94b3e4b9af93cb5c04086f4a9836c06953b4b1941c68a92986ba57356b1"
     sha256 cellar: :any, sierra:        "67ce3661b56fe8dd0daf6f94b7da31a9516b00ae85d9bbe9eabd7ed2e1dbb324"
     sha256 cellar: :any, el_capitan:    "e43d1c75fe4462c5dca2d95ebee9b0e4897c872f03c4331d5898a06a408cbcb3"
-    sha256 cellar: :any, x86_64_linux:  "e31f283dedde4b288f527674a1e48fa700a64a344e655244192051a4d9880d4f"
   end
 
   unless OS.mac?
@@ -73,7 +72,7 @@ class LuaAT51 < Formula
            "INSTALL_TOP=#{prefix}",
            "INSTALL_MAN=#{man1}",
            "INSTALL_INC=#{include}/lua-5.1",
-           *("TO_LIB=liblua.so.5.1 liblua.so.5.1.5" unless OS.mac?)
+           *("TO_LIB=liblua.so.5.1.5" unless OS.mac?)
 
     (lib/"pkgconfig").install "etc/lua.pc"
 
@@ -94,8 +93,9 @@ class LuaAT51 < Formula
 
     unless OS.mac?
       # Hack around wrong .so file naming
-      lib.install_symlink "liblua.so.5.1.5" => "liblua.5.1.5.so"
-      lib.install_symlink "liblua.so.5.1" => "liblua.5.1.so"
+      %w[.so.5.1 .5.1.5.so .5.1.so 5.1.so].each do |suffix|
+        lib.install_symlink "liblua.so.5.1.5" => "liblua#{suffix}"
+      end
     end
   end
 

--- a/Formula/lua@5.3.rb
+++ b/Formula/lua@5.3.rb
@@ -4,6 +4,7 @@ class LuaAT53 < Formula
   url "https://www.lua.org/ftp/lua-5.3.6.tar.gz"
   sha256 "fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60"
   license "MIT"
+  revision 1 unless OS.mac?
 
   livecheck do
     url "https://www.lua.org/ftp/"
@@ -16,7 +17,6 @@ class LuaAT53 < Formula
     sha256 cellar: :any, big_sur:       "3fec7275812f0646dc113da036b77ab09af80421ae5ab2d90f8a122b5b225f1e"
     sha256 cellar: :any, catalina:      "1ba7031cba6c4b703e6ac2729ceb8bb23fb9ce12915888bcf395c9ebbfbb95b5"
     sha256 cellar: :any, mojave:        "180e59018eb294a00e41b426071ffbca0d3dc522569217064472e39aed359c0e"
-    sha256 cellar: :any, x86_64_linux:  "80f2fb1fd8a7ac5199aaef540b510b8fe466bdbe30a1aa9b9329c87580f71215"
   end
 
   keg_only :versioned_formula
@@ -63,12 +63,7 @@ class LuaAT53 < Formula
     # We ship our own pkg-config file as Lua no longer provide them upstream.
     arch = OS.mac? ? "macosx" : "linux"
     system "make", arch, "INSTALL_TOP=#{prefix}", "INSTALL_INC=#{include}/lua", "INSTALL_MAN=#{man1}"
-    system "make",
-           "install",
-           "INSTALL_TOP=#{prefix}",
-           "INSTALL_INC=#{include}/lua",
-           "INSTALL_MAN=#{man1}",
-           *("TO_LIB=liblua.a liblua.so liblua.so.#{version.major_minor} liblua.so.#{version}" unless OS.mac?)
+    system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_INC=#{include}/lua", "INSTALL_MAN=#{man1}"
     (lib/"pkgconfig/lua.pc").write pc_file
 
     # Fix some software potentially hunting for different pc names.
@@ -77,7 +72,8 @@ class LuaAT53 < Formula
     bin.install_symlink "luac" => "luac#{version.major_minor}"
     bin.install_symlink "luac" => "luac-#{version.major_minor}"
     (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
-    lib.install_symlink "liblua.#{version.major_minor}.dylib" => "liblua#{version.major_minor}.dylib"
+    lib.install Dir[shared_library("src/liblua", "*")] unless OS.mac?
+    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
     (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
     (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
This PR would not have been this concise without https://github.com/Homebrew/brew/pull/7751. Great work! Looking forward to a large-scale rewrite of core formulae with this new functionality.

The primary motivation of this PR was due to a link failure with `-llua5.3` that worked just fine on macOS. Digging through the differences between the two repos, the hardcoded `.dylib` line was found to be the culprit. Then, while trying to fix that issue, it also became clear that the current approach of relying on coreutils' `install` is not the way to go for these formulae.

The result is a closer match to the corresponding formulae in `homebrew-core`, as well as smaller bottles. I believe the changes are made without side-effects on macOS, so no bump is necessary there.

Note that bumping the revision for `lua@5.3` is a must as [latest changes to `lua.pc`](https://github.com/Homebrew/linuxbrew-core/pull/21720) are not yet reflected in the current bottle.