### PR TITLE
hardlink: delete duplicate depends_on

### DIFF
--- a/Formula/hardlink.rb
+++ b/Formula/hardlink.rb
@@ -18,7 +18,6 @@ class Hardlink < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "attr" if OS.linux?
   depends_on "gnu-getopt"
   depends_on "pcre"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

`depends_on "attr" if OS.linux?` is not needed since there is already this:

```ruby
on_linux do
  depends_on "attr"
end
```