### PR TITLE
hardlink: fix Linux build and add better test

### DIFF
--- a/Formula/hardlink.rb
+++ b/Formula/hardlink.rb
@@ -21,15 +21,23 @@ class Hardlink < Formula
   depends_on "gnu-getopt"
   depends_on "pcre"
 
-  on_linux do
-    depends_on "attr"
-  end
+  conflicts_with "util-linux", because: "both install `hardlink` binaries"
 
   def install
+    # xattr syscalls are provided by glibc
+    inreplace "hardlink.c", "#include <attr/xattr.h>", "#include <sys/xattr.h>"
+
     system "make", "PREFIX=#{prefix}", "MANDIR=#{man}", "BINDIR=#{bin}", "install"
   end
 
   test do
-    system "#{bin}/hardlink", "--help"
+    (testpath/"foo").write "hello\n"
+    (testpath/"bar").write "hello\n"
+    system bin/"hardlink", "--ignore-time", testpath
+    (testpath/"foo").append_lines "world"
+    assert_equal <<~EOS, (testpath/"bar").read
+      hello
+      world
+    EOS
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

`<attr/xattr.h>` was removed in favor of glibc's `<sys/xattr.h>`
https://git.savannah.nongnu.org/cgit/attr.git/commit/?id=7921157890d07858d092f4003ca4c6bae9fd2c38