### PR TITLE
SED=/usr/bin/sed shim workaround unnecessary as of Homebrew/brew#10802

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -37,9 +37,6 @@ class Fish < Formula
       -Dextra_completionsdir=#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
       -Dextra_confdir=#{HOMEBREW_PREFIX}/share/fish/vendor_conf.d
     ]
-    on_macos do
-      args << "-DSED=/usr/bin/sed"
-    end
     system "cmake", ".", *std_cmake_args, *args
     system "make", "install"
   end

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -116,9 +116,6 @@ class Gcc < Formula
         args << "--with-sysroot=#{sdk}"
       end
 
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
-
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/legacy-homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -142,9 +142,6 @@ class GccAT49 < Formula
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{sdk}"
       end
-
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
     else
       args << "--disable-multilib"
     end

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -143,9 +143,6 @@ class GccAT5 < Formula
         args << "--with-sysroot=#{sdk}"
       end
 
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
-
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -124,9 +124,6 @@ class GccAT6 < Formula
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{sdk}"
       end
-
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
     end
 
     # Ensure correct install names when linking against libgcc_s;

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -105,9 +105,6 @@ class GccAT7 < Formula
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{sdk}"
       end
-
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
     end
 
     # Ensure correct install names when linking against libgcc_s;

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -105,9 +105,6 @@ class GccAT8 < Formula
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{sdk}"
       end
-
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
     end
 
     # Ensure correct install names when linking against libgcc_s;

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -106,9 +106,6 @@ class GccAT9 < Formula
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{sdk}"
       end
-
-      # Avoid reference to sed shim
-      args << "SED=/usr/bin/sed"
     end
 
     # Ensure correct install names when linking against libgcc_s;

--- a/Formula/i686-elf-gcc.rb
+++ b/Formula/i686-elf-gcc.rb
@@ -28,8 +28,7 @@ class I686ElfGcc < Formula
                              "--without-headers",
                              "--with-as=#{Formula["i686-elf-binutils"].bin}/i686-elf-as",
                              "--with-ld=#{Formula["i686-elf-binutils"].bin}/i686-elf-ld",
-                             "--enable-languages=c,c++",
-                             "SED=/usr/bin/sed"
+                             "--enable-languages=c,c++"
       system "make", "all-gcc"
       system "make", "install-gcc"
       system "make", "all-target-libgcc"

--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -71,9 +71,6 @@ class Libgccjit < Formula
       args << "--with-sysroot=#{sdk}"
     end
 
-    # Avoid reference to sed shim
-    args << "SED=/usr/bin/sed"
-
     # Use -headerpad_max_install_names in the build,
     # otherwise updated load commands won't fit in the Mach-O header.
     # This is needed because `gcc` avoids the superenv shim.

--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -94,10 +94,6 @@ class MingwW64 < Formula
         --disable-nls
         --enable-threads=posix
       ]
-      on_macos do
-        # Avoid reference to sed shim
-        args << "SED=/usr/bin/sed"
-      end
 
       mkdir "#{buildpath}/gcc/build-#{arch}" do
         system "../configure", *args

--- a/Formula/openvpn.rb
+++ b/Formula/openvpn.rb
@@ -41,8 +41,6 @@ class Openvpn < Formula
       inreplace "sample/sample-plugins/Makefile" do |s|
         s.gsub! HOMEBREW_LIBRARY/"Homebrew/shims/mac/super/pkg-config",
                 Formula["pkg-config"].opt_bin/"pkg-config"
-        s.gsub! HOMEBREW_LIBRARY/"Homebrew/shims/mac/super/sed",
-                "/usr/bin/sed"
       end
     end
     unless OS.mac?

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -43,9 +43,6 @@ class Perl < Formula
       -Duselargefiles
       -Dusethreads
     ]
-    on_macos do
-      args << "-Dsed=/usr/bin/sed"
-    end
 
     args << "-Dusedevel" if build.head?
     # Fix for https://github.com/Linuxbrew/homebrew-core/issues/405

--- a/Formula/perl@5.18.rb
+++ b/Formula/perl@5.18.rb
@@ -34,9 +34,6 @@ class PerlAT518 < Formula
       -Duselargefiles
       -Dusethreads
     ]
-    on_macos do
-      args << "-Dsed=/usr/bin/sed"
-    end
 
     system "./Configure", *args
     system "make"

--- a/Formula/quilt.rb
+++ b/Formula/quilt.rb
@@ -29,12 +29,6 @@ class Quilt < Formula
       "--prefix=#{prefix}",
       "--without-getopt",
     ]
-    on_macos do
-      args << "--with-sed=#{HOMEBREW_PREFIX}/bin/gsed"
-    end
-    on_linux do
-      args << "--with-sed=#{HOMEBREW_PREFIX}/bin/sed"
-    end
     system "./configure", *args
 
     system "make"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -58,9 +58,6 @@ class R < Formula
       "--disable-java",
     ]
 
-    # don't remember Homebrew's sed shim
-    args << "SED=/usr/bin/sed" if File.exist?("/usr/bin/sed")
-
     if OS.mac?
       args << "--without-cairo"
       args << "--without-x"

--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -58,7 +58,6 @@ class Rpm < Formula
                           "--with-vendor=homebrew",
                           # Don't allow superenv shims to be saved into lib/rpm/macros
                           "__MAKE=/usr/bin/make",
-                          "__SED=/usr/bin/sed",
                           "__GIT=/usr/bin/git",
                           "__LD=/usr/bin/ld"
     system "make", "install"

--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -33,7 +33,6 @@ class Sleuthkit < Formula
   def install
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_libexec/"openjdk.jdk/Contents/Home"
     ENV["ANT_FOUND"]=Formula["ant"].opt_bin/"ant"
-    ENV["SED"]="/usr/bin/sed"
     ENV.append_to_cflags "-DNDEBUG"
 
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/x86_64-elf-gcc.rb
+++ b/Formula/x86_64-elf-gcc.rb
@@ -27,8 +27,7 @@ class X8664ElfGcc < Formula
                              "--without-headers",
                              "--with-as=#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-as",
                              "--with-ld=#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-ld",
-                             "--enable-languages=c,c++",
-                             "SED=/usr/bin/sed"
+                             "--enable-languages=c,c++"
       system "make", "all-gcc"
       system "make", "install-gcc"
       system "make", "all-target-libgcc"

--- a/Formula/xmlto.rb
+++ b/Formula/xmlto.rb
@@ -36,8 +36,6 @@ class Xmlto < Formula
   def install
     # GNU getopt is keg-only, so point configure to it
     ENV["GETOPT"] = Formula["gnu-getopt"].opt_bin/"getopt"
-    # Prevent reference to Homebrew shim
-    ENV["SED"] = "/usr/bin/sed"
     # Find our docbook catalog
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 

--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -34,8 +34,7 @@ class Yaws < Formula
     system "autoreconf", "-fvi"
     system "./configure", "--prefix=#{prefix}",
                           # Ensure pam headers are found on Xcode-only installs
-                          "--with-extrainclude=#{MacOS.sdk_path}/usr/include/security",
-                          "SED=/usr/bin/sed"
+                          "--with-extrainclude=#{MacOS.sdk_path}/usr/include/security"
     system "make", "install", "WARNINGS_AS_ERRORS="
 
     cd "applications/yapp" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] ~~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~~
- [ ] ~~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~~
- [ ] ~~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~~
- [ ] ~~Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.~~

-----

Waiting on Homebrew/brew#10802 to be merged. See also Homebrew/homebrew-core#72637 ; @iMichka this PR will avoid some conflicts when you next merge `homebrew/master` into `linuxbrew/master` if that PR is merged first, but is otherwise identical. :)

I'm expecting checks to fail for now with

> Error: Files were found with references to the Homebrew shims directory.

hence this PR is still in draft. Once the above is merged I'll trigger another set of checks.