### PR TITLE
lcov: fixes for Linux

### DIFF
--- a/Formula/lcov.rb
+++ b/Formula/lcov.rb
@@ -18,9 +18,12 @@ class Lcov < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "9c3a3586283d61ae1f1ce30145b613ebdc50e28a7656cf4b4f4e935408f4c147"
   end
 
-  depends_on "gcc" => :test
-
   uses_from_macos "perl"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gcc" => :test
+  end
 
   resource "JSON" do
     url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.02.tar.gz"
@@ -56,9 +59,14 @@ class Lcov < Formula
   end
 
   test do
-    gcc_major_ver = Formula["gcc"].any_installed_version.major
-    gcc = Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}"
-    gcov = Formula["gcc"].opt_bin/"gcov-#{gcc_major_ver}"
+    gcc = ENV.cc
+    gcov = "gcov"
+
+    on_macos do
+      gcc_major_ver = Formula["gcc"].any_installed_version.major
+      gcc = Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}"
+      gcov = Formula["gcc"].opt_bin/"gcov-#{gcc_major_ver}"
+    end
 
     (testpath/"hello.c").write <<~EOS
       #include <stdio.h>


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This formula should only need brewed GCC for the test on macOS.  I had to modify the test somewhat to make that work, and I'm not sure if could be written better.