### PR TITLE
eudev 3.2.10 (new formula)

### DIFF
--- a/Formula/eudev.rb
+++ b/Formula/eudev.rb
@@ -1,0 +1,36 @@
+class Eudev < Formula
+  desc "Device file manager for the Linux kernel"
+  homepage "https://wiki.gentoo.org/wiki/Eudev"
+  url "https://dev.gentoo.org/~blueness/eudev/eudev-3.2.10.tar.gz"
+  sha256 "87bb028d470fd1b85169349b44c55d5b733733dc2d50ddf1196e026725ead034"
+  license "GPL-2.0-or-later"
+
+  depends_on :linux
+
+  uses_from_macos "gperf" => :build
+
+  conflicts_with "systemd", because: "both install `udev` (a.k.a. `libudev`)"
+
+  def install
+    args = std_configure_args + %W[
+      --disable-silent-rules
+      --sysconfdir=#{etc}
+      --localstatedir=#{var}
+    ]
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libudev.h>
+      int main() {
+        struct udev *udev = udev_new();
+        udev_unref(udev);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ludev", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This is the same as https://github.com/Homebrew/homebrew-core/pull/72800 but for linuxbrew-core. `systemd` hasn't yet been migrated to homebrew-core, which causes `conflicts_with "systemd"` to return an error.