### PR TITLE
lttng-ust 2.12.1, numactl 2.0.14 (new formulae)

### DIFF
--- a/Formula/lttng-ust.rb
+++ b/Formula/lttng-ust.rb
@@ -1,0 +1,22 @@
+class LttngUst < Formula
+  desc "Linux Trace Toolkit Next Generation Userspace Tracer"
+  homepage "https://lttng.org/"
+  url "https://lttng.org/files/lttng-ust/lttng-ust-2.12.1.tar.bz2"
+  sha256 "48a3948b168195123a749d22818809bd25127bb5f1a66458c3c012b210d2a051"
+  license all_of: ["LGPL-2.1-only", "MIT", "GPL-2.0-only", "BSD-3-Clause", "BSD-2-Clause", "GPL-3.0-or-later"]
+
+  depends_on :linux
+  depends_on "numactl"
+  depends_on "userspace-rcu"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    cp_r (share/"doc/lttng-ust/examples/demo").children, testpath
+    system "make"
+    system "./demo"
+  end
+end

--- a/Formula/numactl.rb
+++ b/Formula/numactl.rb
@@ -1,0 +1,29 @@
+class Numactl < Formula
+  desc "NUMA support for Linux"
+  homepage "https://github.com/numactl/numactl"
+  url "https://github.com/numactl/numactl/releases/download/v2.0.14/numactl-2.0.14.tar.gz"
+  sha256 "826bd148c1b6231e1284e42a4db510207747484b112aee25ed6b1078756bcff6"
+  license all_of: ["GPL-2.0-only", "LGPL-2.1-only", :public_domain, :cannot_represent]
+
+  depends_on :linux
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <numa.h>
+      int main() {
+        if (numa_available() >= 0) {
+          struct bitmask *mask = numa_allocate_nodemask();
+          numa_free_nodemask(mask);
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lnuma", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This adds `lttng-ust` formula to be used in `dotnet` Linux build. This also adds `numactl` as it is required by `lttng-ust`.

Related: #22063, #22225, #22537