### PR TITLE
workflows/tests: upload failed bottles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,22 @@ jobs:
           count=$(ls *.json | wc -l | xargs echo -n)
           echo "$count bottles"
           echo "::set-output name=count::$count"
+          failures=$(ls failed/*.json | wc -l | xargs echo -n)
+          echo "$failures failed bottles"
+          echo "::set-output name=failures::$failures"
+
+      - name: Upload failed bottles
+        if: always() && steps.bottles.outputs.failures > 0
+        uses: actions/upload-artifact@main
+        with:
+          name: bottles (failed)
+          path: ~/bottles/failed
+
+      # Must be run before the `Upload bottles` step so that failed
+      # bottles are not included in the `bottles` artifact.
+      - name: Delete failed bottles
+        if: always()
+        run: rm -rvf ~/bottles/failed
 
       - name: Upload bottles
         if: always() && steps.bottles.outputs.count > 0


### PR DESCRIPTION
This PR is https://github.com/Homebrew/homebrew-core/pull/69733 but for linuxbrew-core

> With [Homebrew/homebrew-test-bot#561](https://github.com/Homebrew/homebrew-test-bot/pull/561) merged, bottles are now moved to the `failed` subdirectory instead of being deleted when `brew linkage` or `brew test` fails. This PR changes the `GitHub Actions CI` workflow to upload these failed bottles