### PR TITLE
texinfo: enable Perl XS

### DIFF
--- a/Formula/texinfo.rb
+++ b/Formula/texinfo.rb
@@ -5,7 +5,7 @@ class Texinfo < Formula
   mirror "https://ftpmirror.gnu.org/texinfo/texinfo-6.7.tar.xz"
   sha256 "988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa"
   license "GPL-3.0"
-  revision 1 unless OS.mac?
+  revision 2 unless OS.mac?
 
   bottle do
     sha256 arm64_big_sur: "8767f78e25929771eeb011b44247b0d864765094e707aeaff9b4783385ba05a8"
@@ -13,7 +13,6 @@ class Texinfo < Formula
     sha256 catalina:      "0686381d97b0448c10d11eaba59722c029d17c8423c17ad524b76ec086790f44"
     sha256 mojave:        "419fccc89f850de008e954984c65eea9b7f82940178f7ee439e42c2c892a2e52"
     sha256 high_sierra:   "a634a1bd15d3d7735e4934fcf26bfa295ce17108912ae7451d2761c6d578de6a"
-    sha256 x86_64_linux:  "1127fa6649f3d5b8d8aaffa2a662841ecf20d13976838a2c4b34cea9414ce2ed"
   end
 
   depends_on "gettext" if MacOS.version <= :high_sierra
@@ -26,7 +25,6 @@ class Texinfo < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-install-warnings",
-                          *("--disable-perl-xs" unless OS.mac?),
                           "--prefix=#{prefix}"
     system "make", "install"
     doc.install Dir["doc/refcard/txirefcard*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Reverts https://github.com/Homebrew/linuxbrew-core/pull/9139. At the time, `perl` was not a dependency of `texinfo`, but this is not the case anymore.