### PR TITLE
systemd: disable gcrypt to prevent opportunistic linkage

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -51,6 +51,7 @@ class Systemd < Formula
       -Dcreate-log-dirs=false
       -Dhwdb=false
       -Dlz4=true
+      -Dgcrypt=false
     ]
 
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

`systemd` depends on `libxslt` during build. `libxslt`, in turn, depends on `libgcrypt`, which results in opportunistic linkage when building `systemd`.

This adds a flag to explicitly disable gcrypt, which fixes the linkage errors in https://github.com/Homebrew/linuxbrew-core/pull/22629 and https://github.com/Homebrew/linuxbrew-core/pull/22572.

A revision bump probably isn't needed since the current bottle already doesn't have any linkage with `libgcrypt`.