### PR TITLE
util-linux: only apply patch on macOS

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -29,7 +29,6 @@ class UtilLinux < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
 
-  uses_from_macos "bison" => :build
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
@@ -48,16 +47,18 @@ class UtilLinux < Formula
     ]
   end
 
-  # Fix build for MacOS
-  # Remove in the next release
-  # Also remove autoconf/automake/libtool/pkg-config dependencies and autogen.sh call
-  patch do
-    url "https://github.com/karelzak/util-linux/commit/71ba2792ab3f96b5f5d5d3b0a68d35ecfd0f93a2.patch?full_index=1"
-    sha256 "bc5188d3f41a7f248ba622f51c8ab8fed0e05355cbe20a5d3b02bbc274e2c7b4"
+  if OS.mac?
+    # Fix build for MacOS
+    # Remove in the next release
+    # Also remove autoconf/automake/libtool/pkg-config dependencies and autogen.sh call
+    patch do
+      url "https://github.com/karelzak/util-linux/commit/71ba2792ab3f96b5f5d5d3b0a68d35ecfd0f93a2.patch?full_index=1"
+      sha256 "bc5188d3f41a7f248ba622f51c8ab8fed0e05355cbe20a5d3b02bbc274e2c7b4"
+    end
   end
 
   def install
-    system "./autogen.sh"
+    system "./autogen.sh" if OS.mac?
 
     args = [
       "--disable-dependency-tracking",

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -23,10 +23,13 @@ class UtilLinux < Formula
 
   keg_only "macOS provides the uuid.h header" if OS.mac?
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
-  depends_on "pkg-config" => :build
+  if OS.mac?
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "pkg-config" => :build
+  end
+
   depends_on "gettext"
 
   uses_from_macos "ncurses"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This should allow `util-linux` to build on Linux without needing `bison`

Related: https://github.com/Homebrew/homebrew-core/pull/71854