### PR TITLE
pypy: remove useless OS.mac?, libffi is defined below

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -21,7 +21,7 @@ class Pypy < Formula
   depends_on "gdbm"
   # pypy does not find system libffi, and its location cannot be given
   # as a build option
-  depends_on "libffi" if OS.mac? && DevelopmentTools.clang_build_version >= 1000
+  depends_on "libffi" if DevelopmentTools.clang_build_version >= 1000
   depends_on "openssl@1.1"
   depends_on "sqlite"
   depends_on "tcl-tk"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
