### PR TITLE
libzdb: test backport to homebrew-core

### DIFF
--- a/Formula/libzdb.rb
+++ b/Formula/libzdb.rb
@@ -25,17 +25,13 @@ class Libzdb < Formula
   depends_on "postgresql"
   depends_on "sqlite"
 
-  unless OS.mac?
-    depends_on "gcc@7" # C++ 17 is required
-
-    fails_with gcc: "4"
-    fails_with gcc: "5"
-    fails_with gcc: "6"
+  on_linux do
+    depends_on "gcc" # C++ 17 is required
   end
 
+  fails_with gcc: "5"
+
   def install
-    # workaround for error: 'assert' was not declared in this scope
-    system "sed", "-i", "1,1i#include <cassert>", "test/zdbpp.cpp" unless OS.mac?
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
     (pkgshare/"test").install Dir["test/*.{c,cpp}"]
@@ -44,8 +40,13 @@ class Libzdb < Formula
   test do
     cp_r pkgshare/"test", testpath
     cd "test" do
+      args = []
+      on_linux do
+        args = "-lpthread"
+      end
+
       system ENV.cc, "select.c", "-L#{lib}",
-             *("-lpthread" unless OS.mac?), "-lzdb", "-I#{include}/zdb", "-o", "select"
+             *args, "-lzdb", "-I#{include}/zdb", "-o", "select"
       system "./select"
     end
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

The assert workaround looks suspiciously like something that would happen if using the wrong version of GCC.  The `-lpthread` workaround makes sense as this is a known issue I see all the time.