### PR TITLE
kibana: remove OS.mac? and dependency

### DIFF
--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -22,8 +22,6 @@ class Kibana < Formula
   depends_on "yarn" => :build
   depends_on "node@10"
 
-  depends_on "libx11" unless OS.mac?
-
   def install
     inreplace "package.json", /"node": "10\.\d+\.\d+"/, %Q("node": "#{Formula["node@10"].version}")
 


### PR DESCRIPTION
This formula is deprecated and does not build on Linux anyway

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
