### PR TITLE
shadowsocks-libev: re-enable build on Linux

### DIFF
--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -26,7 +26,6 @@ class ShadowsocksLibev < Formula
   depends_on "c-ares"
   depends_on "libev"
   depends_on "libsodium"
-  depends_on :macos # Due to Python 2
   depends_on "mbedtls"
   depends_on "pcre"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

I can't find any indication that this still depends on Python 2.  I suspect I something in the dependency tree used to but has since been migrated to Python 3.