### PR TITLE
ssldump: remove workaround

### DIFF
--- a/Formula/ssldump.rb
+++ b/Formula/ssldump.rb
@@ -34,7 +34,6 @@ class Ssldump < Formula
 
   def install
     ENV["LIBS"] = "-lssl -lcrypto"
-    ENV.prepend "CFLAGS", "-DLINUX=1" unless OS.mac?
 
     # .dylib, not .a
     inreplace "configure.in", "if test -f $dir/libpcap.a; then",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
