### PR TITLE
git-flow-avh: remove test workaround

### DIFF
--- a/Formula/git-flow-avh.rb
+++ b/Formula/git-flow-avh.rb
@@ -52,10 +52,6 @@ class GitFlowAvh < Formula
 
   test do
     system "git", "init"
-    unless OS.mac?
-      system "git", "config", "--global", "user.email", "\"you@example.com\""
-      system "git", "config", "--global", "user.name", "\"Your Name\""
-    end
     system "#{bin}/git-flow", "init", "-d"
     system "#{bin}/git-flow", "config"
     assert_equal "develop", shell_output("git symbolic-ref --short HEAD").chomp


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
