### PR TITLE
ircd-hybrid: remove unneeded workaround

### DIFF
--- a/Formula/ircd-hybrid.rb
+++ b/Formula/ircd-hybrid.rb
@@ -72,9 +72,6 @@ class IrcdHybrid < Formula
   end
 
   test do
-    # Won't run as root
-    return if Process.uid.zero?
-
     system "#{bin}/ircd", "-version"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This workaround shouldn't be needed now that we don't build as root.