### PR TITLE
libedit: remove libedit.so.2 workaround

### DIFF
--- a/Formula/libedit.rb
+++ b/Formula/libedit.rb
@@ -31,8 +31,6 @@ class Libedit < Formula
     unless OS.mac?
       # Conflicts with ncurses.
       mv man3/"history.3", man3/"history_libedit.3"
-      # Symlink libedit.so.0 to libedit.so.2 for binary compatibility with Debian/Ubuntu.
-      ln_s lib/"libedit.so.0", lib/"libedit.so.2"
     end
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

As discussed here: https://github.com/Homebrew/homebrew-core/pull/74469, we will try removing this symlinking step and seeing if anything breaks.