### PR TITLE
sshfs: Fix build for linux by upgrading to 3.7.1

### DIFF
--- a/Formula/sshfs.rb
+++ b/Formula/sshfs.rb
@@ -1,10 +1,9 @@
 class Sshfs < Formula
   desc "File system client based on SSH File Transfer Protocol"
   homepage "https://osxfuse.github.io/"
-  url "https://github.com/libfuse/sshfs/releases/download/sshfs-2.10/sshfs-2.10.tar.gz"
-  sha256 "70845dde2d70606aa207db5edfe878e266f9c193f1956dd10ba1b7e9a3c8d101"
-  license "GPL-2.0"
-  revision OS.mac? ? 2 : 3
+  url "https://github.com/libfuse/sshfs/archive/refs/tags/sshfs-3.7.1.tar.gz"
+  sha256 "0f0f8f239555effd675d03a3cabfb35ef691a3054c98b62bc28e85620ad9e30d"
+  license any_of: ["LGPL-2.1-only", "GPL-2.0-only"]
 
   bottle do
     sha256 cellar: :any, catalina:     "aceff3131dd0b098bdef8b5dda54d117b5dd5269ca146f7a5032ecde3c99b6d2"
@@ -13,34 +12,19 @@ class Sshfs < Formula
     sha256 cellar: :any, sierra:       "dc4a7f24c2cbebd7c35891200b043d737ba6586a28992708ef849ffedff7bb01"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
-
-  on_macos do
-    deprecate! date: "2020-11-10", because: "requires FUSE"
-    depends_on :osxfuse
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
-
-  # Apply patch that clears one remaining roadblock that prevented setting
-  # a custom I/O buffer size on macOS. With this patch in place, it's
-  # recommended to use e.g. `-o iosize=1048576` (or other, reasonable value)
-  # when launching `sshfs`, for improved performance.
-  # See also: https://github.com/libfuse/sshfs/issues/11
-  patch do
-    url "https://github.com/libfuse/sshfs/commit/667cf34622e2e873db776791df275c7a582d6295.patch?full_index=1"
-    sha256 "ab2aa697d66457bf8a3f469e89572165b58edb0771aa1e9c2070f54071fad5f6"
-  end
+  depends_on "libfuse"
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make", "install"
+    mkdir("build") do
+      system "meson", ".."
+      system "meson", "configure", "--prefix", prefix
+      system "ninja"
+      system "ninja", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
Fixes #22813 

The error message was:
```
configure: error: Package requirements (fuse >= 2.3 glib-2.0 gthread-2.0) were not met:

No package 'fuse' found
```

I'm no expert in Brew formulae nor in the usage of tools like Meson and ninja. So I'm happy to change this in any better way if needed. 

I based the idea for the solution, upgrading the version and dropping the OSX support completely, of this comment on the bug report: https://github.com/Homebrew/linuxbrew-core/issues/22813#issuecomment-812958714.