### PR TITLE
libqalculate: add intltool dependency according to #4499

### DIFF
--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -16,7 +16,6 @@ class Libqalculate < Formula
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "gnuplot"
   depends_on "mpfr"
   depends_on "readline"
 
@@ -31,6 +30,7 @@ class Libqalculate < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--without-icu",
+                          "--without-gnuplot-call",
                           "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -20,7 +20,13 @@ class Libqalculate < Formula
   depends_on "mpfr"
   depends_on "readline"
 
+  uses_from_macos "curl"
+  uses_from_macos "perl"
+
   def install
+    # Needed by intltool (xml::parser)
+    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" unless OS.mac?
+
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -30,6 +30,7 @@ class Libqalculate < Formula
   end
 
   test do
-    system "#{bin}/qalc", "-nocurrencies", "(2+2)/4 hours to minutes"
+    output = shell_output("#{bin}/qalc -nocurrencies '(2+2)/4 hours to minutes'")
+    assert_equal output, "((2 + 2) / 4) × hour = 60 min\n"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
