### PR TITLE
stellar-core: build with gcc-10

### DIFF
--- a/Formula/stellar-core.rb
+++ b/Formula/stellar-core.rb
@@ -22,15 +22,16 @@ class StellarCore < Formula
   depends_on "libpq"
   depends_on "libpqxx"
   depends_on "libsodium"
-  unless OS.mac?
-    # Needs libraries at runtime:
-    # /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.22' not found
-    depends_on "gcc@6"
-    fails_with gcc: "5"
-  end
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+
+  depends_on "gcc" unless OS.mac?
+
+  # Needs libraries at runtime:
+  # /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.22' not found
+  # Upstream has explicitly stated gcc-5 is too old: https://github.com/stellar/stellar-core/issues/1903
+  fails_with gcc: "5"
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

I'm not sure the original comment for why this needs a newer GCC is really relevant anymore.  Now if you try to build with `gcc-5` it will fail while running `configure`.  I left the original comment in for now, but perhaps we should remove it.  I did add a new comment with a link to an upstream issue that explicitly states that `gcc-5` is too old.