### PR TITLE
boost@1.60: remove workaround

### DIFF
--- a/Formula/boost@1.60.rb
+++ b/Formula/boost@1.60.rb
@@ -82,10 +82,6 @@ class BoostAT160 < Formula
       link=shared,static
     ]
 
-    # Fix error: bzlib.h: No such file or directory
-    # and /usr/bin/ld: cannot find -lbz2
-    args += ["include=#{HOMEBREW_PREFIX}/include", "linkflags=-L#{HOMEBREW_PREFIX}/lib"] unless OS.mac?
-
     system "./bootstrap.sh", *bootstrap_args
     system "./b2", "headers"
     system "./b2", *args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
