### PR TITLE
double-conversion: remove workaround

### DIFF
--- a/Formula/double-conversion.rb
+++ b/Formula/double-conversion.rb
@@ -28,16 +28,6 @@ class DoubleConversion < Formula
       system "make"
       lib.install "libdouble-conversion.a"
     end
-
-    unless OS.mac?
-      # Move lib64/* to lib/ on Linuxbrew
-      lib64 = Pathname.new "#{lib}64"
-      if lib64.directory?
-        mkdir_p lib
-        mv lib64, lib
-        rmdir lib64
-      end
-    end
   end
 
   test do


### PR DESCRIPTION
This is now handled by the std cmake args

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
