### PR TITLE
mpi4py: remove unneeded workaround

### DIFF
--- a/Formula/mpi4py.rb
+++ b/Formula/mpi4py.rb
@@ -39,11 +39,6 @@ class Mpi4py < Formula
     # Somehow our Azure CI only has two CPU cores available.
     cpu_cores = (ENV["HOMEBREW_GITHUB_ACTIONS"] ? 2 : 4).to_s
 
-    if Process.uid.zero?
-      ENV["OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"] = "1"
-      ENV["OMPI_ALLOW_RUN_AS_ROOT"] = "1"
-    end
-
     system "mpiexec", "-n", cpu_cores, "#{Formula["python@3.9"].opt_bin}/python3",
            "-m", "mpi4py.run", "-m", "mpi4py.bench", "helloworld"
     system "mpiexec", "-n", cpu_cores, "#{Formula["python@3.9"].opt_bin}/python3",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
