### PR TITLE
certbot: remove unneeded workaround

### DIFF
--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -205,10 +205,6 @@ class Certbot < Formula
     # This throws a bad exit code but we can check it actually is failing
     # for the right reasons by asserting. --version never fails even if
     # resources are missing or outdated/too new/etc.
-    if Process.uid.zero?
-      assert_match "Saving debug log", shell_output("#{bin}/certbot 2>&1", 1)
-    else
-      assert_match "Either run as root", shell_output("#{bin}/certbot 2>&1", 1)
-    end
+    assert_match "Either run as root", shell_output("#{bin}/certbot 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Ironically this test was more functional when building as root.  However, it is **not** worth the trouble given how many other problems that creates!