### PR TITLE
various formulae, part 1: use `.diff` for GitLab patches

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -43,8 +43,8 @@ class Cairo < Formula
   # Avoid segfaults on Big Sur. Remove at version bump.
   # https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
   patch do
-    url "https://gitlab.freedesktop.org/cairo/cairo/-/commit/e22d7212acb454daccc088619ee147af03883974.patch"
-    sha256 "363a6018efc52721e2eace8df3aa319c93f3ad765ef7e3ea04e2ddd4ee94d0e1"
+    url "https://gitlab.freedesktop.org/cairo/cairo/-/commit/e22d7212acb454daccc088619ee147af03883974.diff"
+    sha256 "3b98004d7321c06d294fa901ac91964b6a4277ce4e53ef0cf98bf89e00d93332"
   end
 
   def install

--- a/Formula/gitg.rb
+++ b/Formula/gitg.rb
@@ -33,8 +33,8 @@ class Gitg < Formula
   # Fix libgitg compile on macOS from https://gitlab.gnome.org/GNOME/gitg/-/merge_requests/142
   # Remove for next version
   patch do
-    url "https://gitlab.gnome.org/GNOME/gitg/-/commit/67f5cd6925e8bf1e4c7e5b65fe9370c2cdd1d273.patch"
-    sha256 "e81c59f77aceb8c1ae3914ffebf24f5a0287bd2cf9511996eb8a3f4282e8542d"
+    url "https://gitlab.gnome.org/GNOME/gitg/-/commit/67f5cd6925e8bf1e4c7e5b65fe9370c2cdd1d273.diff"
+    sha256 "b9b842d1be3e435ce14a57d30702138a0e08ba0f9ef95249876fc05aeac2417c"
   end
 
   def install

--- a/Formula/gst-python.rb
+++ b/Formula/gst-python.rb
@@ -25,8 +25,8 @@ class GstPython < Formula
 
   # See https://gitlab.freedesktop.org/gstreamer/gst-python/-/merge_requests/41
   patch do
-    url "https://gitlab.freedesktop.org/gstreamer/gst-python/-/commit/3e752ede7ed6261681ef3831bc3dbb594f189e76.patch"
-    sha256 "ad63ba452d97da70601854cc8e46e8bd53db708a3d98bf7411483d52aadcebf3"
+    url "https://gitlab.freedesktop.org/gstreamer/gst-python/-/commit/3e752ede7ed6261681ef3831bc3dbb594f189e76.diff"
+    sha256 "d6522bb29f1894d3d426ee6c262a18669b0759bd084a6d2a2ea1ba0612a80068"
   end
 
   def install

--- a/Formula/libhttpseverywhere.rb
+++ b/Formula/libhttpseverywhere.rb
@@ -29,8 +29,8 @@ class Libhttpseverywhere < Formula
   # see https://gitlab.gnome.org/GNOME/libhttpseverywhere/issues/1
   # remove when next version is released
   patch do
-    url "https://gitlab.gnome.org/GNOME/libhttpseverywhere/commit/6da08ef1ade9ea267cecf14dd5cb2c3e6e5e50cb.patch"
-    sha256 "511c5aa10f466e879e04e794e09716de6bb18413bd23a72cffb323be5a982919"
+    url "https://gitlab.gnome.org/GNOME/libhttpseverywhere/commit/6da08ef1ade9ea267cecf14dd5cb2c3e6e5e50cb.diff"
+    sha256 "e5499c290c5b48b243f67763a2c710acc5bd52b90541eb8da3f8b24b516f7430"
   end
 
   def install


### PR DESCRIPTION
I've split up part of #22752 into this one to get around the 6-hour timeout.
