### PR TITLE
various formulae, part 2: use `.diff` for GitLab patches

### DIFF
--- a/Formula/libslirp.rb
+++ b/Formula/libslirp.rb
@@ -22,8 +22,8 @@ class Libslirp < Formula
   # Fix QEMU networking
   # https://gitlab.freedesktop.org/slirp/libslirp/-/issues/35
   patch do
-    url "https://gitlab.freedesktop.org/slirp/libslirp/-/commit/7271345efe182199acaeae602cb78a94a7c6dc9d.patch"
-    sha256 "9b6fa60ad5ea251dda70c898078cbbc25b1dad035d1530d0cb5ae7db16333f92"
+    url "https://gitlab.freedesktop.org/slirp/libslirp/-/commit/7271345efe182199acaeae602cb78a94a7c6dc9d.diff"
+    sha256 "240e5b8c3cc21729936ae8a79056a58b4024e2f9d0fbad3c76a4f9398f9dfe65"
   end
 
   def install

--- a/Formula/libtasn1.rb
+++ b/Formula/libtasn1.rb
@@ -18,8 +18,8 @@ class Libtasn1 < Formula
   # Remove the patch when the issue is resolved:
   # https://gitlab.com/gnutls/libtasn1/-/issues/30
   patch do
-    url "https://gitlab.com/gnutls/libtasn1/-/commit/088c9f3e946cb8a15867f6f09f0ef503a7551961.patch"
-    sha256 "0791ee7d9e0f231018956a0a5eac80165ede1ec7732490d7d8bea7dc83022d3a"
+    url "https://gitlab.com/gnutls/libtasn1/-/commit/088c9f3e946cb8a15867f6f09f0ef503a7551961.diff"
+    sha256 "a4328a01c6bb4440f21fe2b6e54a5e612bc76e5bc9292c5e198178307824b761"
   end
 
   def install

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -59,8 +59,8 @@ class Libxml2 < Formula
   # Fix compatibility with Python 3.9
   # https://gitlab.gnome.org/GNOME/libxml2/-/issues/149
   patch do
-    url "https://gitlab.gnome.org/nwellnhof/libxml2/-/commit/e4fb36841800038c289997432ca547c9bfef9db1.patch"
-    sha256 "c3fa874b78d76b8de8afbbca9f83dc94e9a0da285eaf6ee1f6976ed4cd41e367"
+    url "https://gitlab.gnome.org/nwellnhof/libxml2/-/commit/e4fb36841800038c289997432ca547c9bfef9db1.diff"
+    sha256 "318a5e235d4a39579557185f8b80a40a302be49bfaa419c17c8acf52113acb27"
   end
 
   def sdk_include

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -70,8 +70,8 @@ class Mesa < Formula
   end
 
   patch do
-    url "https://gitlab.freedesktop.org/mesa/mesa/-/commit/50064ad367449afad03c927f7e572c138b05c5d4.patch"
-    sha256 "aa3fa361a8626d442aefdac922a7193612b77cab2410452acee40b6dbc10a800"
+    url "https://gitlab.freedesktop.org/mesa/mesa/-/commit/50064ad367449afad03c927f7e572c138b05c5d4.diff"
+    sha256 "2f17f8f03a54350025fff65ec6d410b1c2f924a30199551457a0f43a9bada7b6"
   end
 
   def install


### PR DESCRIPTION
I've split up part of #22752 into this one to get around the 6-hour timeout.