### PR TITLE
various formulae, part 3: use `.diff` for GitLab patches

### DIFF
--- a/Formula/picoc.rb
+++ b/Formula/picoc.rb
@@ -13,8 +13,8 @@ class Picoc < Formula
     # Fix abort trap due to stack overflow
     # Upstream commit from 14 Oct 2013 "Fixed a problem with PlatformGetLine()"
     patch do
-      url "https://gitlab.com/zsaleeba/picoc/commit/ed54c519169b88b7b40d1ebb11599d89a4228a71.patch"
-      sha256 "bdedbb6e70e6378e05e50d0ef055306045e460f2675f8bd870566ae28b654589"
+      url "https://gitlab.com/zsaleeba/picoc/commit/ed54c519169b88b7b40d1ebb11599d89a4228a71.diff"
+      sha256 "45b49c860c0fac1ce2f7687a2662a86d2fcfb6947cf8ad6cf21e2a3d696d7d72"
     end
   end
 

--- a/Formula/spice-gtk.rb
+++ b/Formula/spice-gtk.rb
@@ -52,8 +52,8 @@ class SpiceGtk < Formula
 
   # Upstream patch: https://gitlab.freedesktop.org/spice/spice-gtk/issues/88
   patch do
-    url "https://gitlab.freedesktop.org/spice/spice-gtk/commit/3c9b37bfc7c88969dfe16b8bfd874745e0fceb8a.patch"
-    sha256 "893878f2682d663cce38b9769f08e68fd7d60d650f4974728f380847d87dcbc1"
+    url "https://gitlab.freedesktop.org/spice/spice-gtk/commit/3c9b37bfc7c88969dfe16b8bfd874745e0fceb8a.diff"
+    sha256 "c2bb9c6dc0d07f333d10077987386680818296f1deb3b796ea7e35453aba7d91"
   end
 
   def install

--- a/Formula/suil.rb
+++ b/Formula/suil.rb
@@ -28,8 +28,8 @@ class Suil < Formula
   # Disable qt5_in_gtk3 because it depends upon X11
   # Can be removed if https://gitlab.com/lv2/suil/-/merge_requests/1 is merged
   patch do
-    url "https://gitlab.com/lv2/suil/-/commit/33ea47e18ddc1eb384e75622c0e75164d351f2c0.patch"
-    sha256 "10dddc02f0a61f03babb4d9692a63aaa2dc9e66e364a2c3098ec5710822002fd"
+    url "https://gitlab.com/lv2/suil/-/commit/33ea47e18ddc1eb384e75622c0e75164d351f2c0.diff"
+    sha256 "2f335107e26c503460965953f94410e458c5e8dd86a89ce039f65c4e3ae16ba7"
   end
 
   def install

--- a/Formula/tepl.rb
+++ b/Formula/tepl.rb
@@ -24,8 +24,8 @@ class Tepl < Formula
 
   # Submitted upstream at https://gitlab.gnome.org/GNOME/tepl/-/merge_requests/8
   patch do
-    url "https://gitlab.gnome.org/GNOME/tepl/-/commit/a8075b0685764d1243762e569fc636fa4673d244.patch"
-    sha256 "cf4966f9975026ad349eac05980bdbc6cdfc2ed581b04c099ed892777db0767c"
+    url "https://gitlab.gnome.org/GNOME/tepl/-/commit/a8075b0685764d1243762e569fc636fa4673d244.diff"
+    sha256 "b5d646c194955b0c14bbb7604c96e237a82632dc548f66f2d0163595ef18ee88"
   end
 
   def install


### PR DESCRIPTION
I've split up part of #22752 into this one to get around the 6-hour timeout.
