### PR TITLE
boost-mpi: remove unneeded workaround

### DIFF
--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -106,8 +106,9 @@ class BoostMpi < Formula
       }
     EOS
     boost = Formula["boost"]
-    system "mpic++", "test.cpp", "-L#{lib}", "-L#{boost.lib}", "-lboost_mpi", "-lboost_serialization", "-o", "test"
-    system "mpirun", *("--allow-run-as-root" if ENV["HOMEBREW_GITHUB_ACTIONS"]), "-np", "2", "./test"
+    system "mpic++", "test.cpp", "-Wl,-rpath=#{lib}", "-Wl,-rpath=#{boost.lib}", "-L#{lib}", "-L#{boost.lib}",
+           "-lboost_mpi-mt", "-lboost_serialization", "-o", "test"
+    system "mpirun", "-np", "2", "./test"
 
     (testpath/"CMakeLists.txt").write "find_package(Boost COMPONENTS mpi REQUIRED)"
     system "cmake", ".", "-Wno-dev"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
