### PR TITLE
makepkg: remove unneeded workaround

### DIFF
--- a/Formula/makepkg.rb
+++ b/Formula/makepkg.rb
@@ -48,11 +48,6 @@ class Makepkg < Formula
       pkgrel=0
       pkgver=0
     EOS
-    # Won't run as root, use more permissive test
-    if ENV["USER"] == "root"
-      assert_match "makepkg (pacman) #{version}", pipe_output("#{bin}/makepkg --version")
-    else
-      assert_match "md5sums=('e232a2683c0", pipe_output("#{bin}/makepkg -dg 2>&1")
-    end
+    assert_match "md5sums=('e232a2683c0", pipe_output("#{bin}/makepkg -dg 2>&1")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
