### PR TITLE
cminkpack: remove workaround, this is handled by std cmake args now

### DIFF
--- a/Formula/cminpack.rb
+++ b/Formula/cminpack.rb
@@ -19,6 +19,7 @@ class Cminpack < Formula
   def install
     system "cmake", ".", "-DBUILD_SHARED_LIBS=ON",
                          "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                         "-DCMINPACK_LIB_INSTALL_DIR=lib",
                          *std_cmake_args
     system "make", "install"
 
@@ -26,16 +27,11 @@ class Cminpack < Formula
     doc.install Dir["doc/*"]
 
     pkgshare.install "examples/thybrdc.c"
-
-    unless OS.mac?
-      lib64 = Pathname.new "#{lib}64"
-      mv lib64, lib if lib64.directory?
-    end
   end
 
   test do
-    system ENV.cc, pkgshare/"thybrdc.c", "-o", "test",
-                   "-I#{include}/cminpack-1", "-L#{lib}", "-lcminpack", "-lm"
+    system ENV.cc, "-I#{include}/cminpack-1", pkgshare/"thybrdc.c",
+                   "-L#{lib}", "-lcminpack", "-lm", "-o", "test"
     assert_match "number of function evaluations", shell_output("./test")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
