### PR TITLE
terrascan 1.5: Updating source tarball checksum

### DIFF
--- a/Formula/terrascan.rb
+++ b/Formula/terrascan.rb
@@ -2,7 +2,7 @@ class Terrascan < Formula
   desc "Detect compliance and security violations across Infrastructure as Code"
   homepage "https://www.accurics.com/products/terrascan/"
   url "https://github.com/accurics/terrascan/archive/v1.5.0.tar.gz"
-  sha256 "fee8fc66a76e13e5a2f211b58bdc73745e0b97b29dcb272504fca5edd3c47b5c"
+  sha256 "e969960d9748e50125359097f5004c34ccf72e638dd06d10204a62468d57b260"
   license "Apache-2.0"
   head "https://github.com/accurics/terrascan.git"
 


### PR DESCRIPTION
While building the 1.5 release, the terrascan team ran into some issues with the build pipeline due to introduction of cgo as a
requirement. This resulted in a failed release, which we then rolled back and re-released. This commit has the correct SHA for the release.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
