### PR TITLE
yaws: fix linux build

### DIFF
--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -24,17 +24,29 @@ class Yaws < Formula
   depends_on "libtool" => :build
   depends_on "erlang"
 
+  on_linux do
+    depends_on "linux-pam"
+  end
+
   # the default config expects these folders to exist
   skip_clean "var/log/yaws"
   skip_clean "lib/yaws/examples/ebin"
   skip_clean "lib/yaws/examples/include"
 
   def install
+    extra_args = if OS.mac?
+      # Ensure pam headers are found on Xcode-only installs
+      %W[
+        --with-extrainclude=#{MacOS.sdk_path}/usr/include/security
+        SED=/usr/bin/sed
+      ]
+    else
+      %W[
+        --with-extrainclude=#{Formula["linux-pam"].opt_include}/security
+      ]
+    end
     system "autoreconf", "-fvi"
-    system "./configure", "--prefix=#{prefix}",
-                          # Ensure pam headers are found on Xcode-only installs
-                          "--with-extrainclude=#{MacOS.sdk_path}/usr/include/security",
-                          "SED=/usr/bin/sed"
+    system "./configure", "--prefix=#{prefix}", *extra_args
     system "make", "install", "WARNINGS_AS_ERRORS="
 
     cd "applications/yapp" do
@@ -45,6 +57,12 @@ class Yaws < Formula
     # the default config expects these folders to exist
     (lib/"yaws/examples/ebin").mkpath
     (lib/"yaws/examples/include").mkpath
+
+    # Remove Homebrew shims references
+    unless OS.mac?
+      inreplace Dir["#{prefix}/var/yaws/www/*/Makefile"], HOMEBREW_LIBRARY/"Homebrew/shims/linux/super/",
+        "/usr/bin/"
+    end
   end
 
   def post_install


### PR DESCRIPTION
It needs PAM headers and a non-macOS build config, otherwise...
```
==> autoreconf -fvi
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/yaws/2.0.9 --with-extrainclude=/usr/include/security SED=/usr/bin/sed
==> make install WARNINGS_AS_ERRORS=
Last 15 lines from /root/.cache/Homebrew/Logs/yaws/03.make:
  CC       epam-epam.o
  CC       setuid_drv_la-setuid_drv.lo
no acceptable sed could be found in $PATH
Makefile:589: recipe for target 'setuid_drv_la-setuid_drv.lo' failed
make[1]: *** [setuid_drv_la-setuid_drv.lo] Error 1
make[1]: *** Waiting for unfinished jobs....
epam.c:2:10: fatal error: pam_appl.h: No such file or directory
    2 | #include <pam_appl.h>
      |          ^~~~~~~~~~~~
compilation terminated.
Makefile:596: recipe for target 'epam-epam.o' failed
make[1]: *** [epam-epam.o] Error 1
make[1]: Leaving directory '/tmp/yaws-20210524-37856-ysdoit/yaws-yaws-2.0.9/c_src'
Makefile:555: recipe for target 'install-recursive' failed
make: *** [install-recursive] Error 1
```
Gist logs: https://gist.github.com/ad318ce3d3f9c61e2faed5d29356e974

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
