### PR TITLE
sc-im: fix Linux build

### DIFF
--- a/Formula/sc-im.rb
+++ b/Formula/sc-im.rb
@@ -15,6 +15,12 @@ class ScIm < Formula
 
   depends_on "ncurses"
 
+  uses_from_macos "bison" => :build
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
   def install
     cd "src" do
       system "make", "prefix=#{prefix}"


### PR DESCRIPTION
Needs `bison` (for `yacc` binary), else:
```
make: yacc: Command not found
```
Also needs `pkg-config` to build correctly with `ncurses`.

Gist logs: https://gist.github.com/60d5a89299c45eb94c47c9fc4a760654

Fixes https://github.com/Homebrew/discussions/discussions/1559.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
