### PR TITLE
vsts-cli: align test with core version, formula is deprecated

### DIFF
--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -279,11 +279,8 @@ class VstsCli < Formula
 
   test do
     system "#{bin}/vsts", "configure", "--help"
-    # ERROR: No recommended backend was available.
-    if OS.mac?
-      output = shell_output("#{bin}/vsts logout 2>&1", 1)
-      assert_equal "ERROR: The credential was not found", output.chomp
-    end
+    output = shell_output("#{bin}/vsts logout 2>&1", 1)
+    assert_equal "ERROR: The credential was not found", output.chomp
     output = shell_output("#{bin}/vsts work 2>&1", 2)
     assert_match "vsts work: error: the following arguments are required", output
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
