### PR TITLE
shunit2: reinstate 2.1.8 bottle

### DIFF
--- a/Formula/shunit2.rb
+++ b/Formula/shunit2.rb
@@ -5,6 +5,10 @@ class Shunit2 < Formula
   sha256 "b2fed28ba7282e4878640395284e43f08a029a6c27632df73267c8043c71b60c"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "82fc864cd6bb364a531df9a69168b8d8d8cc3df33bdba72308f43168ce32cd1d"
+  end
+
   def install
     bin.install "shunit2"
   end


### PR DESCRIPTION
Restoring bottle block from abb510453a0.

shunit2 is a single shell script file, so a single bottle can
used across all platforms.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
