### PR TITLE
crc32c: remove unneeded workaround

### DIFF
--- a/Formula/crc32c.rb
+++ b/Formula/crc32c.rb
@@ -18,7 +18,6 @@ class Crc32c < Formula
   depends_on "cmake" => :build
 
   def install
-    ENV.cxx11 unless OS.mac?
     system "cmake", ".", "-DCRC32C_BUILD_TESTS=0",
                           "-DCRC32C_BUILD_BENCHMARKS=0", "-DCRC32C_USE_GLOG=0",
                          *std_cmake_args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
