### PR TITLE
openshift-cli: remove workaround, does not build anymore

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -45,7 +45,7 @@ class OpenshiftCli < Formula
         system "make", "cross-build-darwin-amd64", "WHAT=staging/src/github.com/openshift/oc/cmd/oc"
       end
 
-      bin.install "_output//bin/#{OS.mac? ? "darwin" : "linux"}_amd64/oc"
+      bin.install "_output//bin/darwin_amd64/oc"
 
       bash_completion.install "contrib/completions/bash/oc"
       zsh_completion.install "contrib/completions/zsh/oc" => "_oc"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
