### PR TITLE
colormake: restore `install` and `test`, scala@2.11: fix spacing

### DIFF
--- a/Formula/colormake.rb
+++ b/Formula/colormake.rb
@@ -6,5 +6,26 @@ class Colormake < Formula
   license "GPL-2.0"
   head "https://github.com/pagekite/Colormake.git"
 
+  def install
+    inreplace "colormake", "colormake.pl", "#{libexec}/colormake.pl"
 
+    # Prefers symlinks than the original duplicate files
+    File.unlink "colormake-short", "clmake", "clmake-short"
+    File.symlink "colormake", "colormake-short"
+    File.symlink "colormake", "clmake"
+    File.symlink "colormake", "clmake-short"
+
+    # Adds missing clmake.1 referenced in colormake.1 itself
+    File.symlink "colormake.1", "clmake.1"
+
+    # Installs auxiliary script, commands and mans
+    libexec.install "colormake.pl"
+    bin.install "colormake", "clmake", "colormake-short", "clmake-short"
+    man1.install "colormake.1", "clmake.1"
+  end
+
+  test do
+    (testpath/"Makefile").write("all:\n\techo Hello World!\n")
+    assert_match "Hello World!", shell_output("#{bin}/colormake")
+  end
 end

--- a/Formula/scala@2.11.rb
+++ b/Formula/scala@2.11.rb
@@ -7,7 +7,6 @@ class ScalaAT211 < Formula
   sha256 "b11d7d33699ca4f60bc3b2b6858fd953e3de2b8522c943f4cda4b674316196a8"
   revision 1
 
-
   keg_only :versioned_formula
 
   deprecate! date: "2017-11-09", because: :unsupported


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes a CI failure in Homebrew/brew#11609.