### PR TITLE
postgresql: fix build with OpenLDAP 2.5

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -34,6 +34,13 @@ class Postgresql < Formula
   on_linux do
     depends_on "linux-pam"
     depends_on "util-linux"
+
+    # configure patch to deal with OpenLDAP 2.5
+    # (revisit on next release)
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/10fe8d35eb7323bb882c909a0ec065ae01401626/postgresql/openldap-2.5.patch"
+      sha256 "7b1e1a88752482c59f6971dfd17a2144ed60e6ecace8538200377ee9b1b7938c"
+    end
   end
 
   def install
@@ -69,6 +76,12 @@ class Postgresql < Formula
     # PostgreSQL by default uses xcodebuild internally to determine this,
     # which does not work on CLT-only installs.
     args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
+
+    on_linux do
+      # rebuild `configure` after patching
+      # (remove if patch block not needed)
+      system "autoreconf", "-ivf"
+    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Patch sent upstream (https://www.postgresql.org/message-id/17083-a19190d9591946a7%40postgresql.org).
Tested with both Homebrew (2.5) and system (2.4) OpenLDAP, by rebuilding with:
```
uses_from_macos "openldap"
```
commented out.

Closes https://github.com/Homebrew/homebrew-core/issues/80543.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
