### PR TITLE
Merge 2021-07-07 882ae25295f

### DIFF
--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -1,8 +1,8 @@
 class Hledger < Formula
   desc "Easy plain text accounting with command-line, terminal and web UIs"
   homepage "https://hledger.org/"
-  url "https://hackage.haskell.org/package/hledger-1.21/hledger-1.21.tar.gz"
-  sha256 "5a57b05b3b934c781a6bb443611236e92b0ba03c0c0b67a515c933b2eb74cc1d"
+  url "https://hackage.haskell.org/package/hledger-1.22/hledger-1.22.tar.gz"
+  sha256 "0c5f53bfb6c6e0fb8ac7c85a1592b3fd76318f1b989765ddd0e7d89b689beaf0"
   license "GPL-3.0-or-later"
 
   # A new version is sometimes present on Hackage before it's officially
@@ -14,11 +14,10 @@ class Hledger < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "c7c03fa909e3d54ff4efe598a40d1bcc3da9c10a307406658c26fa20fff1e402"
-    sha256 cellar: :any_skip_relocation, big_sur:       "83d91bd5847275c6e7089b71332015c71272bc24f562a55b595e8c192bfe7285"
-    sha256 cellar: :any_skip_relocation, catalina:      "5f812bbfa7a4409166716730edf3fda92bb6a6dcb99572440d926a56e47554b2"
-    sha256 cellar: :any_skip_relocation, mojave:        "0a379919ad9936b1b93b7af1103fd5c98656c43ed879eea8f2e0dcfdcccb2e0a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e82571c4b4003b9ed260f1a17ae565ff26ae5bcdebb182a31739ca31cda147"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "c154a3c65c8752826f89b3a3c226100c000dbc46df7175c60d470ce62f1b0a20"
+    sha256 cellar: :any_skip_relocation, big_sur:       "28545d37d7a0865c9558e54e7696afa35d308c6c31867654da34348ea90b9d2e"
+    sha256 cellar: :any_skip_relocation, catalina:      "62edd2f9008af2754bcf6a592d605107311c367907ea958ae1684e51fee655cc"
+    sha256 cellar: :any_skip_relocation, mojave:        "8898689adf32582f4c63a0b9ac4ece89286af7e5307fbe02653675a18b343da9"
   end
 
   depends_on "ghc" => :build
@@ -28,16 +27,18 @@ class Hledger < Formula
   uses_from_macos "zlib"
 
   resource "hledger-lib" do
-    url "https://hackage.haskell.org/package/hledger-lib-1.21/hledger-lib-1.21.tar.gz"
-    sha256 "be2cd8c4259da63a6cc2c5abf625ebc8ffaab405ec3284c6f7cb6e3431d5f902"
+    url "https://hackage.haskell.org/package/hledger-lib-1.22/hledger-lib-1.22.tar.gz"
+    sha256 "f54f257fd5fa7449d787da94311673097307c9ef0c0e1b0578034b68c56c0d1b"
   end
+
   resource "hledger-ui" do
-    url "https://hackage.haskell.org/package/hledger-ui-1.21/hledger-ui-1.21.tar.gz"
-    sha256 "14f4f5de87b69b05ca6040cb444cf2e6e8dc1ccae601740cde0c79f00d322dc1"
+    url "https://hackage.haskell.org/package/hledger-ui-1.22/hledger-ui-1.22.tar.gz"
+    sha256 "593e03188e98340dcb2146bf8478f39ae2c4927bfe9e3f18c0f03dcffb6df1c7"
   end
+
   resource "hledger-web" do
-    url "https://hackage.haskell.org/package/hledger-web-1.21/hledger-web-1.21.tar.gz"
-    sha256 "e2251687ed0c4dff9fea1767e3c30279df50713bdb9d4c2c1712f0eb19fe7a47"
+    url "https://hackage.haskell.org/package/hledger-web-1.22/hledger-web-1.22.tar.gz"
+    sha256 "7a11cbc94790d5e25156d7fe1c973bcc7e7aa30ac9ea8322e0d8a3ff43083e56"
   end
 
   def install

--- a/Formula/zssh.rb
+++ b/Formula/zssh.rb
@@ -12,6 +12,7 @@ class Zssh < Formula
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9b567d08589f3ba595994ca4906bfde9fe2651ef246bbd872f332e9cc8993a60"
+    sha256 cellar: :any_skip_relocation, big_sur:       "54bb3ff51405eda0900361c829fad63f988c21e685645fe5c8076c456567bd0b"
     sha256 cellar: :any_skip_relocation, catalina:      "6b9bce24c13dd2e979cdae57892e1b595bfcbd1d342bb81419dda378b8439495"
     sha256 cellar: :any_skip_relocation, mojave:        "0b1567c1d4aef681ff463f058a884eead039fb0c50a1c03820a03c9f67786b52"
     sha256 cellar: :any_skip_relocation, high_sierra:   "9cb26f1bd359977406fae945abd311b2cdc5770570e6350f2ac278bfbe458f5b"


### PR DESCRIPTION
Merge Homebrew/homebrew-core into Homebrew/linuxbrew-core

+ [ ] act
+ [ ] ahoy
+ [ ] akamai
+ [ ] algernon
+ [ ] aliddns
+ [ ] alp
+ [ ] amazon-ecs-cli
+ [ ] annie
+ [ ] antibody
+ [ ] apache-brooklyn-cli
+ [ ] aptly
+ [ ] arduino-cli
+ [ ] argocd-autopilot
+ [ ] argocd
+ [ ] armor
+ [ ] assh
+ [ ] aurora
+ [ ] aws-console
+ [ ] aws-es-proxy
+ [ ] aws-rotate-key
+ [ ] berglas
+ [ ] buildifier
+ [ ] buildkit
+ [ ] buildozer
+ [ ] camlp5
+ [ ] dune
+ [ ] hledger
+ [ ] mage
+ [ ] ocaml-findlib
+ [ ] ocaml
+ [ ] ocamlbuild
+ [ ] opam
+ [ ] restic
+ [ ] scdoc
+ [ ] zssh