### PR TITLE
Merge 2021-07-12 ba96ccb6a30

### DIFF
--- a/Formula/afsctool.rb
+++ b/Formula/afsctool.rb
@@ -17,6 +17,8 @@ class Afsctool < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "96437b04a2974c215979550d3d70b4c8e3f609e76954ca41059c6f246da452ee"
   end
 
+  depends_on :macos
+
   # Fixes Sierra "Unable to compress" issue; reported upstream on 24 July 2017
   patch :p2 do
     url "https://github.com/vfx01j/afsctool/commit/26293a3809c9ad1db5f9bff9dffaefb8e201a089.patch?full_index=1"

--- a/Formula/freediameter.rb
+++ b/Formula/freediameter.rb
@@ -6,6 +6,11 @@ class Freediameter < Formula
   license "BSD-3-Clause"
   head "http://www.freediameter.net/hg/freeDiameter", using: :hg
 
+  livecheck do
+    url "http://www.freediameter.net/hg/freeDiameter/json-tags"
+    regex(/["']tag["']:\s*?["']v?(\d+(?:\.\d+)+)["']/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a2fd2271af79fd86ec7162e0af3adbaf611f280563a84dc2a98af96b7b3a3a4d"
     sha256 cellar: :any, big_sur:       "2c99cc840e0daebf52793d55e91ec616416c7fc7c4f4a8c332c6fe8c52fd181d"

--- a/Formula/lsusb.rb
+++ b/Formula/lsusb.rb
@@ -15,6 +15,8 @@ class Lsusb < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "e696db36d09169064b3e97852d07464125e5bc6e400cb2a4cc186e6aa606574a"
   end
 
+  depends_on :macos
+
   def install
     bin.install "lsusb"
     man8.install "man/lsusb.8"

--- a/Formula/neopop-sdl.rb
+++ b/Formula/neopop-sdl.rb
@@ -5,6 +5,11 @@ class NeopopSdl < Formula
   sha256 "2df1b717faab9e7cb597fab834dc80910280d8abf913aa8b0dcfae90f472352e"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?NeoPop-SDL[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, big_sur:     "53e2a47e1f4e3bc4b35a31ea06f757ef62fc11de24347fcca5f4d1799f1adf94"
     sha256 cellar: :any, catalina:    "c4bd22db58945139a07d7c007c546e2edb3be1c3763f2d3f3008b575f30cef84"

--- a/Formula/rubberband.rb
+++ b/Formula/rubberband.rb
@@ -8,7 +8,7 @@ class Rubberband < Formula
 
   livecheck do
     url :homepage
-    regex(/Rubber Band Library v?(\d+(?:\.\d+)+) released/i)
+    regex(/href=.*?rubberband[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -1,6 +1,6 @@
 class SdlImage < Formula
   desc "Image file loading library"
-  homepage "https://www.libsdl.org/projects/SDL_image"
+  homepage "https://www.libsdl.org/projects/SDL_image/release-1.2.html"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
   license "Zlib"

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -1,6 +1,6 @@
 class SdlMixer < Formula
   desc "Sample multi-channel audio mixer library"
-  homepage "https://www.libsdl.org/projects/SDL_mixer/"
+  homepage "https://www.libsdl.org/projects/SDL_mixer/release-1.2.html"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz"
   sha256 "1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
   license "Zlib"

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -1,6 +1,6 @@
 class SdlTtf < Formula
   desc "Library for using TrueType fonts in SDL applications"
-  homepage "https://www.libsdl.org/projects/SDL_ttf/"
+  homepage "https://www.libsdl.org/projects/SDL_ttf/release-1.2.html"
   url "https://www.libsdl.org/projects/SDL_ttf/release/SDL_ttf-2.0.11.tar.gz"
   sha256 "724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7"
   revision 1


### PR DESCRIPTION
Merge Homebrew/homebrew-core into Homebrew/linuxbrew-core

+ [ ] autopep8
+ [ ] bup
+ [ ] cdk
+ [ ] comby
+ [ ] contentful-cli
+ [ ] dash
+ [ ] ddgr
+ [ ] elinks
+ [ ] elm
+ [ ] fio
+ [ ] git-remote-codecommit
+ [ ] goaccess
+ [ ] jdupes
+ [ ] libcouchbase
+ [ ] libxaw
+ [ ] nats-server
+ [ ] open-ocd
+ [ ] smartmontools
+ [ ] sqlite-utils
+ [ ] strace
+ [ ] tanka
+ [ ] toilet
+ [ ] ttyd
+ [ ] watson
+ [ ] zopfli
+ [ ] zsh-navigation-tools
+ [ ] afsctool
+ [ ] agda
+ [ ] docui
+ [ ] freediameter
+ [ ] lsusb
+ [ ] neopop-sdl
+ [ ] pig
+ [ ] rubberband
+ [ ] sdl_image
+ [ ] sdl_mixer
+ [ ] sdl_ttf