### PR TITLE
Merge 2021-09-07 dfa45b3a40d

### DIFF
--- a/Formula/a52dec.rb
+++ b/Formula/a52dec.rb
@@ -21,13 +21,11 @@ class A52dec < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix error ld: imdct.lo: relocation R_X86_64_32 against `.bss' can not be
       # used when making a shared object; recompile with -fPIC
       ENV.append_to_cflags "-fPIC"
-    end
-
-    on_macos do
+    else
       # Fixes duplicate symbols errors on arm64
       ENV.append_to_cflags "-std=gnu89"
     end

--- a/Formula/abuse.rb
+++ b/Formula/abuse.rb
@@ -71,7 +71,7 @@ class Abuse < Formula
                           "--with-assetdir=#{pkgshare}",
                           "--with-sdl-prefix=#{Formula["sdl"].opt_prefix}"
 
-    on_macos do
+    if OS.mac?
       # Use Framework OpenGL, not libGl
       %w[. src src/imlib src/lisp src/net src/sdlport].each do |p|
         inreplace "#{p}/Makefile", "-lGL", "-framework OpenGL"

--- a/Formula/activemq.rb
+++ b/Formula/activemq.rb
@@ -16,15 +16,13 @@ class Activemq < Formula
   depends_on "openjdk"
 
   def install
-    on_macos do
+    if OS.mac?
       rm_rf Dir["bin/linux-x86-*"]
 
       # Discard universal binaries without usable slices
       rm_f "bin/macosx/libwrapper.jnilib"
       rm_f "bin/macosx/wrapper" if Hardware::CPU.arm?
-    end
-
-    on_linux do
+    else
       rm_rf "bin/macosx"
     end
 

--- a/Formula/aescrypt-packetizer.rb
+++ b/Formula/aescrypt-packetizer.rb
@@ -38,9 +38,7 @@ class AescryptPacketizer < Formula
         prefix=#{prefix}
         --disable-gui
       ]
-      on_macos do
-        args << "--enable-iconv"
-      end
+      args << "--enable-iconv" if OS.mac?
 
       system "./configure", *args
       system "make", "install"

--- a/Formula/afl-fuzz.rb
+++ b/Formula/afl-fuzz.rb
@@ -38,8 +38,11 @@ class AflFuzz < Formula
       }
     EOS
 
-    cmd = "afl-clang++"
-    on_linux { cmd = "afl-g++" }
+    cmd = if OS.mac?
+      "afl-clang++"
+    else
+      "afl-g++"
+    end
     system bin/cmd, "-g", cpp_file, "-o", "test"
     assert_equal "Hello, world!", shell_output("./test")
   end

--- a/Formula/ahcpd.rb
+++ b/Formula/ahcpd.rb
@@ -22,11 +22,10 @@ class Ahcpd < Formula
   patch :DATA
 
   def install
-    on_macos do
+    if OS.mac?
       # LDLIBS='' fixes: ld: library not found for -lrt
       system "make", "LDLIBS=''"
-    end
-    on_linux do
+    else
       system "make"
     end
     system "make", "install", "PREFIX=", "TARGET=#{prefix}"

--- a/Formula/aide.rb
+++ b/Formula/aide.rb
@@ -41,11 +41,11 @@ class Aide < Formula
       --sysconfdir=#{etc}
       --prefix=#{prefix}
     ]
-    on_macos do
-      args << "--with-curl"
-    end
-    on_linux do
-      args << "--with-curl=" + Formula["curl"].prefix
+
+    args << if OS.mac?
+      "--with-curl"
+    else
+      "--with-curl=#{Formula["curl"].prefix}"
     end
 
     system "./configure", *args

--- a/Formula/ampl-mp.rb
+++ b/Formula/ampl-mp.rb
@@ -37,7 +37,7 @@ class AmplMp < Formula
   def install
     system "cmake", ".", *std_cmake_args, "-DBUILD_SHARED_LIBS=True"
     system "make", "all"
-    on_macos do
+    if OS.mac?
       MachO::Tools.change_install_name("bin/libasl.dylib", "@rpath/libmp.3.dylib",
                                        "#{opt_lib}/libmp.dylib")
     end

--- a/Formula/analog.rb
+++ b/Formula/analog.rb
@@ -32,11 +32,10 @@ class Analog < Formula
       %Q(DEFS='-DLANGDIR="#{pkgshare}/lang/"' -DHAVE_ZLIB),
       "LIBS=-lz -lm",
     ]
-    on_macos do
-      args << "OS=OSX"
-    end
-    on_linux do
-      args << "OS=UNIX"
+    args << if OS.mac?
+      "OS=OSX"
+    else
+      "OS=UNIX"
     end
     system "make", *args
 

--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -576,9 +576,9 @@ class Ansible < Formula
   def install
     ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
 
-    on_macos do
+    if OS.mac? && (MacOS.version <= :sierra)
       # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
 
     venv = virtualenv_create(libexec, "python3")

--- a/Formula/ansible@2.8.rb
+++ b/Formula/ansible@2.8.rb
@@ -602,9 +602,9 @@ class AnsibleAT28 < Formula
   def install
     ENV.prepend_path "PATH", Formula["python@3.7"].opt_libexec/"bin"
 
-    on_macos do
+    if OS.mac? && (MacOS.version <= :sierra)
       # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
 
     virtualenv_install_with_resources

--- a/Formula/ansible@2.9.rb
+++ b/Formula/ansible@2.9.rb
@@ -581,9 +581,9 @@ class AnsibleAT29 < Formula
   def install
     ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
 
-    on_macos do
+    if OS.mac? && (MacOS.version <= :sierra)
       # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
 
     virtualenv_install_with_resources

--- a/Formula/apcupsd.rb
+++ b/Formula/apcupsd.rb
@@ -34,7 +34,7 @@ class Apcupsd < Formula
       --enable-modbus-usb
     ]
 
-    on_macos do
+    if OS.mac?
       # Detecting the lack of gethostname_r() goes wrong on Xcode 12:
       args << "ac_cv_func_which_gethostbyname_r=no"
 
@@ -55,9 +55,7 @@ class Apcupsd < Formula
         # Use appropriate paths for launch daemon and launch script.
         inreplace %w[apcupsd-start.in org.apcupsd.apcupsd.plist.in], "/etc/apcupsd", sysconfdir
       end
-    end
-
-    on_linux do
+    else
       # Avoid Linux distro-specific paths
       args << "--with-distname=unknown"
       args << "--with-halpolicydir=#{share}/hal/fdi/policy/20thirdparty"

--- a/Formula/apidoc.rb
+++ b/Formula/apidoc.rb
@@ -28,7 +28,7 @@ class Apidoc < Formula
     term_size_vendor_dir = libexec/"lib/node_modules"/name/"node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -58,7 +58,7 @@ class Apr < Formula
     # No need for this to point to the versioned path.
     inreplace bin/"apr-#{version.major}-config", prefix, opt_prefix
 
-    on_linux do
+    if OS.linux?
       # Avoid references to the Homebrew shims directory
       inreplace prefix/"build-#{version.major}/libtool", HOMEBREW_SHIMS_PATH/"linux/super/", "/usr/bin/"
     end

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -35,9 +35,7 @@ class Arangodb < Formula
   end
 
   def install
-    on_macos do
-      ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
-    end
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version if OS.mac?
 
     resource("starter").stage do
       ENV["GO111MODULE"] = "on"

--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -35,11 +35,10 @@ class Aria2 < Formula
       --without-libnettle
       --without-libgcrypt
     ]
-    on_macos do
+    if OS.mac?
       args << "--with-appletls"
       args << "--without-openssl"
-    end
-    on_linux do
+    else
       args << "--without-appletls"
       args << "--with-openssl"
     end

--- a/Formula/arpoison.rb
+++ b/Formula/arpoison.rb
@@ -21,7 +21,7 @@ class Arpoison < Formula
   depends_on "libnet"
 
   def install
-    on_linux { inreplace "Makefile", /gcc -lnet (.*)/, "gcc \\1 -lnet" }
+    inreplace "Makefile", /gcc -lnet (.*)/, "gcc \\1 -lnet" if OS.linux?
     system "make"
     bin.install "arpoison"
     man8.install "arpoison.8"

--- a/Formula/artillery.rb
+++ b/Formula/artillery.rb
@@ -28,7 +28,7 @@ class Artillery < Formula
     term_size_vendor_dir = libexec/"lib/node_modules"/name/"node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/ask-cli.rb
+++ b/Formula/ask-cli.rb
@@ -28,7 +28,7 @@ class AskCli < Formula
     term_size_vendor_dir = libexec/"lib/node_modules"/name/"node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -48,7 +48,7 @@ class Augustus < Formula
     system "make", "clean"
 
     cd "src" do
-      on_macos do
+      if OS.mac?
         # Clang breaks proteinprofile on macOS. This issue has been first reported
         # to upstream in 2016 (see https://github.com/nextgenusfs/funannotate/issues/3).
         # See also https://github.com/Gaius-Augustus/Augustus/issues/64
@@ -56,8 +56,7 @@ class Augustus < Formula
         with_env("HOMEBREW_CC" => Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}") do
           system "make"
         end
-      end
-      on_linux do
+      else
         system "make"
       end
     end

--- a/Formula/autoconf.rb
+++ b/Formula/autoconf.rb
@@ -21,7 +21,7 @@ class Autoconf < Formula
   uses_from_macos "perl"
 
   def install
-    on_macos do
+    if OS.mac?
       ENV["PERL"] = "/usr/bin/perl"
 
       # force autoreconf to look for and use our glibtoolize

--- a/Formula/autoconf@2.69.rb
+++ b/Formula/autoconf@2.69.rb
@@ -23,7 +23,7 @@ class AutoconfAT269 < Formula
   uses_from_macos "perl"
 
   def install
-    on_macos do
+    if OS.mac?
       ENV["PERL"] = "/usr/bin/perl"
 
       # force autoreconf to look for and use our glibtoolize

--- a/Formula/automake.rb
+++ b/Formula/automake.rb
@@ -17,9 +17,7 @@ class Automake < Formula
   depends_on "autoconf"
 
   def install
-    on_macos do
-      ENV["PERL"] = "/usr/bin/perl"
-    end
+    ENV["PERL"] = "/usr/bin/perl" if OS.mac?
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -19,8 +19,7 @@ class AwsVault < Formula
     # Remove this line because we don't have a certificate to code sign with
     inreplace "Makefile",
       "codesign --options runtime --timestamp --sign \"$(CERT_ID)\" $(INSTALL_DIR)/aws-vault || true", ""
-    os = "darwin"
-    on_linux { os = "linux" }
+    os = OS.mac? ? "darwin" : "linux"
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
 
     system "make", "aws-vault-#{os}-#{arch}", "VERSION=#{version}-#{tap.user}"

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -123,7 +123,7 @@ class Awscli < Formula
     # This causes installation to fail while running `scripts/gen-ac-index` with error:
     # ImportError: _awscrt.cpython-39-x86_64-linux-gnu.so: undefined symbol: EVP_CIPHER_CTX_init
     # As workaround, add relative path to local libcrypto.a before openssl's so it gets picked.
-    on_linux do
+    if OS.linux?
       ENV.prepend "CFLAGS", "-I./build/deps/install/include"
       ENV.prepend "LDFLAGS", "-L./build/deps/install/lib"
     end

--- a/Formula/babeld.rb
+++ b/Formula/babeld.rb
@@ -20,11 +20,10 @@ class Babeld < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       # LDLIBS='' fixes: ld: library not found for -lrt
       system "make", "LDLIBS=''"
-    end
-    on_linux do
+    else
       system "make"
     end
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/bacula-fd.rb
+++ b/Formula/bacula-fd.rb
@@ -42,11 +42,10 @@ class BaculaFd < Formula
     system "make", "install"
 
     # Avoid references to the Homebrew shims directory
-    on_macos do
+    if OS.mac?
       inreplace Dir[prefix/"etc/bacula_config"],
                 HOMEBREW_SHIMS_PATH/"mac/super/", ""
-    end
-    on_linux do
+    else
       inreplace Dir[prefix/"etc/bacula_config"],
                 HOMEBREW_SHIMS_PATH/"linux/super/", ""
     end

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -43,7 +43,7 @@ class Bazel < Formula
     #
     # The workaround here is to disable the Linux shim for C/C++ compilers.
     # Remove this when a way to retain HOMEBREW_* variables is found.
-    on_linux do
+    if OS.linux?
       ENV["CC"] = "/usr/bin/cc"
       ENV["CXX"] = "/usr/bin/c++"
     end

--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -46,9 +46,7 @@ class Bear < Formula
   end
 
   def install
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
     args = std_cmake_args + %w[
       -DENABLE_UNIT_TESTS=OFF

--- a/Formula/beast.rb
+++ b/Formula/beast.rb
@@ -32,9 +32,7 @@ class Beast < Formula
     bin.install Dir[libexec/"bin/*"]
 
     env = Language::Java.overridable_java_home_env("11")
-    on_linux do
-      env["PATH"] = "$JAVA_HOME/bin:$PATH"
-    end
+    env["PATH"] = "$JAVA_HOME/bin:$PATH" if OS.linux?
     bin.env_script_all_files libexec/"bin", env
     inreplace libexec/"bin/beast", "/usr/local", HOMEBREW_PREFIX
   end

--- a/Formula/bento4.rb
+++ b/Formula/bento4.rb
@@ -31,7 +31,7 @@ class Bento4 < Formula
   conflicts_with "mp4v2", because: "both install `mp4extract` and `mp4info` binaries"
 
   def install
-    on_macos do
+    if OS.mac?
       cd "Build/Targets/universal-apple-macosx" do
         xcodebuild "-target", "All", "-configuration", "Release", "SYMROOT=build"
         programs = Dir["build/Release/*"].select do |f|
@@ -42,8 +42,7 @@ class Bento4 < Formula
         end
         bin.install programs
       end
-    end
-    on_linux do
+    else
       mkdir "cmakebuild" do
         system "cmake", "..", *std_cmake_args
         system "make"

--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -65,9 +65,7 @@ class Bind < Formula
       "--without-lmdb",
       "--with-libidn2=#{Formula["libidn2"].opt_prefix}",
     ]
-    on_linux do
-      args << "--disable-linux-caps"
-    end
+    args << "--disable-linux-caps" if OS.linux?
     system "./configure", *args
 
     system "make"

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -37,13 +37,11 @@ class Binutils < Formula
     system "make"
     system "make", "install"
     bin.install_symlink "ld.gold" => "gold"
-    on_macos do
+    if OS.mac?
       Dir["#{bin}/*"].each do |f|
         bin.install_symlink f => "g" + File.basename(f)
       end
-    end
-
-    on_linux do
+    else
       # Reduce the size of the bottle.
       system "strip", *Dir[bin/"*", lib/"*.a"]
     end

--- a/Formula/blahtexml.rb
+++ b/Formula/blahtexml.rb
@@ -32,11 +32,10 @@ class Blahtexml < Formula
 
   def install
     ENV.cxx11
-    on_macos do
+    if OS.mac?
       system "make", "blahtex-mac"
       system "make", "blahtexml-mac"
-    end
-    on_linux do
+    else
       # Parallel make has a race condition between mkdir and file write.
       # Fatal error: can't create bin-blahtex/main.o: No such file or directory
       ENV.deparallelize

--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -41,7 +41,7 @@ class Blast < Formula
                 --without-debug
                 --without-boost]
 
-      on_macos do
+      if OS.mac?
         args += ["OPENMP_FLAGS=-Xpreprocessor -fopenmp",
                  "LDFLAGS=-lomp"]
       end

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -42,10 +42,9 @@ class BoostMpi < Formula
     args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++" if ENV.compiler == :clang
 
     open("user-config.jam", "a") do |file|
-      on_macos do
+      if OS.mac?
         file.write "using darwin : : #{ENV.cxx} ;\n"
-      end
-      on_linux do
+      else
         file.write "using gcc : : #{ENV.cxx} ;\n"
       end
       file.write "using mpi ;\n"
@@ -61,7 +60,7 @@ class BoostMpi < Formula
     lib.install Dir["install-mpi/lib/*mpi*"]
     (lib/"cmake").install Dir["install-mpi/lib/cmake/*mpi*"]
 
-    on_macos do
+    if OS.mac?
       # libboost_mpi links to libboost_serialization, which comes from the main boost formula
       boost = Formula["boost"]
       MachO::Tools.change_install_name("#{lib}/libboost_mpi-mt.dylib",

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -46,14 +46,13 @@ class BoostPython3 < Formula
 
     pyver = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
     py_prefix = Formula["python@3.9"].opt_frameworks/"Python.framework/Versions/#{pyver}"
-    on_linux do
-      py_prefix = Formula["python@3.9"].opt_prefix
-    end
+    py_prefix = Formula["python@3.9"].opt_prefix if OS.linux?
 
     # Force boost to compile with the desired compiler
-    compiler_text = "using darwin : : #{ENV.cxx} ;"
-    on_linux do
-      compiler_text = "using gcc : : #{ENV.cxx} ;"
+    compiler_text = if OS.mac?
+      "using darwin : : #{ENV.cxx} ;"
+    else
+      "using gcc : : #{ENV.cxx} ;"
     end
     (buildpath/"user-config.jam").write <<~EOS
       #{compiler_text}

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -30,10 +30,9 @@ class Boost < Formula
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
-      on_macos do
+      if OS.mac?
         file.write "using darwin : : #{ENV.cxx} ;\n"
-      end
-      on_linux do
+      else
         file.write "using gcc : : #{ENV.cxx} ;\n"
       end
     end

--- a/Formula/browser.rb
+++ b/Formula/browser.rb
@@ -7,10 +7,8 @@ class Browser < Formula
   version "7"
 
   def install
-    on_linux do
-      # https://gist.github.com/defunkt/318247#gistcomment-3760018
-      inreplace "browser", "open", "xdg-open"
-    end
+    # https://gist.github.com/defunkt/318247#gistcomment-3760018
+    inreplace "browser", "open", "xdg-open" if OS.linux?
     bin.install "browser"
   end
 

--- a/Formula/bzip2.rb
+++ b/Formula/bzip2.rb
@@ -27,7 +27,7 @@ class Bzip2 < Formula
 
     system "make", "install", "PREFIX=#{prefix}"
 
-    on_linux do
+    if OS.linux?
       # Install shared libraries
       system "make", "-f", "Makefile-libbz2_so", "clean"
       system "make", "-f", "Makefile-libbz2_so"

--- a/Formula/cabocha.rb
+++ b/Formula/cabocha.rb
@@ -18,7 +18,7 @@ class Cabocha < Formula
   depends_on "mecab-ipadic"
 
   def install
-    on_macos { ENV["LIBS"] = "-liconv" }
+    ENV["LIBS"] = "-liconv" if OS.mac?
 
     inreplace "Makefile.in" do |s|
       s.change_make_var! "CFLAGS", ENV.cflags
@@ -37,8 +37,11 @@ class Cabocha < Formula
   end
 
   test do
-    md5 = "md5"
-    on_linux { md5 = "md5sum" }
+    md5 = if OS.mac?
+      "md5"
+    else
+      "md5sum"
+    end
     result = pipe_output(md5, pipe_output(bin/"cabocha", "CaboCha はフリーソフトウェアです。"))
     assert_equal "a5b8293e6ebcb3246c54ecd66d6e18ee", result.chomp.split.first
   end

--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -59,11 +59,7 @@ class Cairo < Formula
       --enable-xlib
       --enable-xlib-xrender
     ]
-    on_macos do
-      args += %w[
-        --enable-quartz-image
-      ]
-    end
+    args << "--enable-quartz-image" if OS.mac?
 
     if build.head?
       ENV["NOCONFIGURE"] = "1"

--- a/Formula/calc.rb
+++ b/Formula/calc.rb
@@ -35,9 +35,7 @@ class Calc < Formula
       "READLINE_LIB=-L#{Formula["readline"].opt_lib} -lreadline",
       "READLINE_EXTRAS=-lhistory -lncurses",
     ]
-    on_macos do
-      args << "INCDIR=#{MacOS.sdk_path}/usr/include"
-    end
+    args << "INCDIR=#{MacOS.sdk_path}/usr/include" if OS.mac?
     system "make", "install", *args
 
     libexec.install "#{bin}/cscript"

--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -31,7 +31,7 @@ class Cbmc < Formula
     args = []
 
     # Workaround borrowed from https://github.com/diffblue/cbmc/issues/4956
-    on_macos { args << "-DCMAKE_C_COMPILER=/usr/bin/clang" }
+    args << "-DCMAKE_C_COMPILER=/usr/bin/clang" if OS.mac?
     # Java front-end fails to build on ARM
     args << "-DWITH_JBMC=OFF" if Hardware::CPU.arm?
 

--- a/Formula/ccextractor.rb
+++ b/Formula/ccextractor.rb
@@ -38,10 +38,10 @@ class Ccextractor < Formula
     # Multiple source files reference these dependencies with non-standard #include paths
     ENV["EXTRA_INCLUDE"] = "-I#{Formula["leptonica"].include} -I#{Formula["protobuf-c"].include/"protobuf-c"}"
 
-    platform = "mac"
-    build_script = "./build.command"
-
-    on_linux do
+    if OS.mac?
+      platform = "mac"
+      build_script = "./build.command"
+    else
       platform = "linux"
       build_script = "./build"
     end

--- a/Formula/ccfits.rb
+++ b/Formula/ccfits.rb
@@ -26,10 +26,9 @@ class Ccfits < Formula
       --disable-silent-rules
       --prefix=#{prefix}
     ]
-    on_linux do
-      # Remove references to brew's shims
-      args << "pfk_cxx_lib_path=/usr/bin/g++"
-    end
+
+    # Remove references to brew's shims
+    args << "pfk_cxx_lib_path=/usr/bin/g++" if OS.linux?
 
     system "./configure", *args
     system "make"

--- a/Formula/cconv.rb
+++ b/Formula/cconv.rb
@@ -21,9 +21,7 @@ class Cconv < Formula
   depends_on "libtool" => :build
 
   def install
-    on_macos do
-      ENV.append "LDFLAGS", "-liconv"
-    end
+    ENV.append "LDFLAGS", "-liconv" if OS.mac?
 
     system "autoreconf", "-fvi"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/cfengine.rb
+++ b/Formula/cfengine.rb
@@ -41,9 +41,7 @@ class Cfengine < Formula
       --without-postgresql
     ]
 
-    on_linux do
-      args << "--with-systemd-service=no"
-    end
+    args << "--with-systemd-service=no" if OS.linux?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/chapel.rb
+++ b/Formula/chapel.rb
@@ -34,10 +34,12 @@ class Chapel < Formula
     prefix.install_metafiles
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.
-    platform = "darwin-x86_64"
-
-    on_linux do
-      platform = Hardware::CPU.is_64_bit? ? "linux64-x86_64" : "linux-x86_64"
+    platform = if OS.mac?
+      "darwin-x86_64"
+    elsif Hardware::CPU.is_64_bit?
+      "linux64-x86_64"
+    else
+      "linux-x86_64"
     end
 
     bin.install Dir[libexec/"bin/#{platform}/*"]

--- a/Formula/chicken.rb
+++ b/Formula/chicken.rb
@@ -30,12 +30,10 @@ class Chicken < Formula
       ARCH=x86-64
     ]
 
-    on_macos do
+    if OS.mac?
       args << "POSTINSTALL_PROGRAM=install_name_tool"
       args << "PLATFORM=macosx"
-    end
-
-    on_linux do
+    else
       args << "PLATFORM=linux"
     end
 

--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -48,9 +48,7 @@ class Clamav < Formula
       -DENABLE_TESTS=OFF
     ]
 
-    on_linux do
-      args << "-DENABLE_MILTER=OFF"
-    end
+    args << "-DENABLE_MILTER=OFF" if OS.linux?
 
     system "cmake", "-S", ".", "-B", "build", *args
     system "cmake", "--build", "build"

--- a/Formula/clozure-cl.rb
+++ b/Formula/clozure-cl.rb
@@ -40,15 +40,13 @@ class ClozureCl < Formula
     tmpdir = Pathname.new(Dir.mktmpdir)
     tmpdir.install resource("bootstrap")
 
-    on_macos do
+    if OS.mac?
       buildpath.install tmpdir/"dx86cl64.image"
       buildpath.install tmpdir/"darwin-x86-headers64"
       cd "lisp-kernel/darwinx8664" do
         system "make"
       end
-    end
-
-    on_linux do
+    else
       buildpath.install tmpdir/"lx86cl64"
       buildpath.install tmpdir/"lx86cl64.image"
       buildpath.install tmpdir/"x86-headers64"
@@ -56,16 +54,14 @@ class ClozureCl < Formula
 
     ENV["CCL_DEFAULT_DIRECTORY"] = buildpath
 
-    on_macos do
+    if OS.mac?
       system "./dx86cl64", "-n", "-l", "lib/x8664env.lisp",
             "-e", "(ccl:xload-level-0)",
             "-e", "(ccl:compile-ccl)",
             "-e", "(quit)"
       (buildpath/"image").write('(ccl:save-application "dx86cl64.image")\n(quit)\n')
       system "cat image | ./dx86cl64 -n --image-name x86-boot64.image"
-    end
-
-    on_linux do
+    else
       system "./lx86cl64", "-n", "-l", "lib/x8664env.lisp",
             "-e", "(ccl:rebuild-ccl :full t)",
             "-e", "(quit)"

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -47,7 +47,7 @@ class Cmake < Formula
       --sphinx-html
       --sphinx-man
     ]
-    on_macos do
+    if OS.mac?
       args += %w[
         --system-zlib
         --system-bzip2

--- a/Formula/cmigemo.rb
+++ b/Formula/cmigemo.rb
@@ -29,9 +29,10 @@ class Cmigemo < Formula
   def install
     chmod 0755, "./configure"
     system "./configure", "--prefix=#{prefix}"
-    os = "osx"
-    on_linux do
-      os = "gcc"
+    os = if OS.mac?
+      "osx"
+    else
+      "gcc"
     end
     system "make", os
     system "make", "#{os}-dict"

--- a/Formula/cogl.rb
+++ b/Formula/cogl.rb
@@ -42,12 +42,10 @@ class Cogl < Formula
       --enable-introspection=yes
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--disable-glx"
       args << "--without-x"
-    end
-
-    on_linux do
+    else
       args << "--enable-xlib-egl-platform=yes"
     end
 

--- a/Formula/color-code.rb
+++ b/Formula/color-code.rb
@@ -31,12 +31,10 @@ class ColorCode < Formula
     system "#{qt5}/bin/qmake"
     system "make"
 
-    on_macos do
+    if OS.mac?
       prefix.install "ColorCode.app"
       bin.write_exec_script "#{prefix}/ColorCode.app/Contents/MacOS/colorcode"
-    end
-
-    on_linux do
+    else
       bin.install "colorcode"
     end
   end

--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -71,9 +71,7 @@ class Coreutils < Formula
       b2sum base32 chcon hostid md5sum nproc numfmt pinky ptx realpath runcon
       sha1sum sha224sum sha256sum sha384sum sha512sum shred shuf stdbuf tac timeout truncate
     ]
-    on_linux do
-      no_conflict += ["dir", "dircolors", "vdir"]
-    end
+    no_conflict += ["dir", "dircolors", "vdir"] if OS.linux?
     no_conflict.each do |cmd|
       bin.install_symlink "g#{cmd}" => cmd
       man1.install_symlink "g#{cmd}.1" => "#{cmd}.1"

--- a/Formula/csvprintf.rb
+++ b/Formula/csvprintf.rb
@@ -18,9 +18,7 @@ class Csvprintf < Formula
   uses_from_macos "libxslt"
 
   def install
-    on_macos do
-      ENV.append "LDFLAGS", "-liconv"
-    end
+    ENV.append "LDFLAGS", "-liconv" if OS.mac?
 
     system "./autogen.sh"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -61,12 +61,10 @@ class Curl < Formula
       --without-libpsl
     ]
 
-    on_macos do
-      args << "--with-gssapi"
-    end
-
-    on_linux do
-      args << "--with-gssapi=#{Formula["krb5"].opt_prefix}"
+    args << if OS.mac?
+      "--with-gssapi"
+    else
+      "--with-gssapi=#{Formula["krb5"].opt_prefix}"
     end
 
     system "./configure", *args

--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -32,7 +32,7 @@ class Dartsim < Formula
     ENV.cxx11
     args = std_cmake_args
 
-    on_macos do
+    if OS.mac?
       # Force to link to system GLUT (see: https://cmake.org/Bug/view.php?id=16045)
       glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"
       args << "-DGLUT_glut_LIBRARY=#{glut_lib}"

--- a/Formula/dbdeployer.rb
+++ b/Formula/dbdeployer.rb
@@ -17,11 +17,10 @@ class Dbdeployer < Formula
   depends_on "go" => :build
 
   def install
-    on_macos do
+    if OS.mac?
       system "./scripts/build.sh", "OSX"
       bin.install "dbdeployer-#{version}.osx" => "dbdeployer"
-    end
-    on_linux do
+    else
       system "./scripts/build.sh", "linux"
       bin.install "dbdeployer-#{version}.linux" => "dbdeployer"
     end

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -62,7 +62,7 @@ class Dbus < Formula
       "--disable-tests",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-launchd"
       args << "--with-launchd-agent-dir=#{prefix}"
     end

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -31,14 +31,10 @@ class Dcmtk < Formula
       system "cmake", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args, ".."
       system "make", "install"
 
-      on_macos do
+      if OS.mac?
         inreplace lib/"cmake/dcmtk/DCMTKConfig.cmake", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
-      end
-
-      on_linux do
-        if File.readlines(lib/"cmake/dcmtk/DCMTKConfig.cmake").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
-          inreplace lib/"cmake/dcmtk/DCMTKConfig.cmake", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
-        end
+      elsif File.readlines(lib/"cmake/dcmtk/DCMTKConfig.cmake").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
+        inreplace lib/"cmake/dcmtk/DCMTKConfig.cmake", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
       end
     end
   end

--- a/Formula/dcos-cli.rb
+++ b/Formula/dcos-cli.rb
@@ -26,11 +26,10 @@ class DcosCli < Formula
     ENV["NO_DOCKER"] = "1"
     ENV["VERSION"] = version.to_s
 
-    on_macos do
+    if OS.mac?
       system "make", "darwin"
       bin.install "build/darwin/dcos"
-    end
-    on_linux do
+    else
       system "make", "linux"
       bin.install "build/linux/dcos"
     end

--- a/Formula/ddd.rb
+++ b/Formula/ddd.rb
@@ -49,7 +49,7 @@ class Ddd < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Patch to fix compilation error
       # https://savannah.gnu.org/bugs/?33960
       # Remove with next release

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -42,9 +42,9 @@ class Deno < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac? && (MacOS.version < :mojave)
       # Overwrite Chromium minimum SDK version of 10.15
-      ENV["FORCE_MAC_SDK_MIN"] = MacOS.version if MacOS.version < :mojave
+      ENV["FORCE_MAC_SDK_MIN"] = MacOS.version
     end
 
     # env args for building a release build with our python3, ninja and gn

--- a/Formula/dep.rb
+++ b/Formula/dep.rb
@@ -27,9 +27,10 @@ class Dep < Formula
 
   def install
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    platform = "darwin"
-    on_linux do
-      platform = "linux"
+    platform = if OS.mac?
+      "darwin"
+    else
+      "linux"
     end
 
     ENV["GOPATH"] = buildpath

--- a/Formula/depqbf.rb
+++ b/Formula/depqbf.rb
@@ -34,10 +34,9 @@ class Depqbf < Formula
     system "./compile.sh"
     bin.install "depqbf"
     lib.install "libqdpll.a"
-    on_macos do
+    if OS.mac?
       lib.install "libqdpll.1.0.dylib"
-    end
-    on_linux do
+    else
       lib.install "libqdpll.so.1.0"
     end
   end

--- a/Formula/djview4.rb
+++ b/Formula/djview4.rb
@@ -39,11 +39,10 @@ class Djview4 < Formula
     # From the djview4.8 README:
     # NOTE: Do not use command "make install".
     # Simply copy the application bundle where you want it.
-    on_macos do
+    if OS.mac?
       prefix.install "src/djview.app"
       bin.write_exec_script prefix/"djview.app/Contents/MacOS/djview"
-    end
-    on_linux do
+    else
       prefix.install "src/djview"
     end
   end

--- a/Formula/dmd.rb
+++ b/Formula/dmd.rb
@@ -84,10 +84,9 @@ class Dmd < Formula
       system "make", "install", *make_args
     end
 
-    on_macos do
+    if OS.mac?
       bin.install "generated/osx/release/64/dmd"
-    end
-    on_linux do
+    else
       bin.install "generated/linux/release/64/dmd"
     end
     pkgshare.install "samples"

--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -47,7 +47,7 @@ class Docbook2x < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
       resources.each do |res|
         res.stage do
@@ -64,9 +64,7 @@ class Docbook2x < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
 
-    on_linux do
-      bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"]
-    end
+    bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"] if OS.linux?
   end
 
   test do

--- a/Formula/docker-credential-helper.rb
+++ b/Formula/docker-credential-helper.rb
@@ -27,12 +27,11 @@ class DockerCredentialHelper < Formula
     dir.install buildpath.children - [buildpath/".brew_home"]
 
     cd dir do
-      on_macos do
+      if OS.mac?
         system "make", "vet_osx"
         system "make", "osxkeychain"
         bin.install "bin/docker-credential-osxkeychain"
-      end
-      on_linux do
+      else
         system "make", "vet_linux"
         system "make", "pass"
         system "make", "secretservice"

--- a/Formula/dockerize.rb
+++ b/Formula/dockerize.rb
@@ -24,10 +24,9 @@ class Dockerize < Formula
     ENV.append_path "PATH", buildpath/"bin"
     cd "src/github.com/jwilder/dockerize" do
       system "make", "dist"
-      on_macos do
+      if OS.mac?
         bin.install "dist/darwin/amd64/dockerize"
-      end
-      on_linux do
+      else
         bin.install "dist/linux/amd64/dockerize"
       end
     end

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -38,9 +38,7 @@ class Dotnet < Formula
   fails_with :gcc
 
   def install
-    on_linux do
-      ENV.append_path "LD_LIBRARY_PATH", Formula["icu4c"].opt_lib
-    end
+    ENV.append_path "LD_LIBRARY_PATH", Formula["icu4c"].opt_lib if OS.linux?
 
     # Arguments needed to not artificially time-limit downloads from Azure.
     # See the following GitHub issue comment for details:

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -41,11 +41,10 @@ class Dpkg < Formula
   def install
     # We need to specify a recent gnutar, otherwise various dpkg C programs will
     # use the system "tar", which will fail because it lacks certain switches.
-    on_macos do
-      ENV["TAR"] = Formula["gnu-tar"].opt_bin/"gtar"
-    end
-    on_linux do
-      ENV["TAR"] = Formula["gnu-tar"].opt_bin/"tar"
+    ENV["TAR"] = if OS.mac?
+      Formula["gnu-tar"].opt_bin/"gtar"
+    else
+      Formula["gnu-tar"].opt_bin/"tar"
     end
 
     # Since 1.18.24 dpkg mandates the use of GNU patch to prevent occurrences

--- a/Formula/dsvpn.rb
+++ b/Formula/dsvpn.rb
@@ -29,8 +29,11 @@ class Dsvpn < Formula
   end
 
   test do
-    expected = "tun device creation: Operation not permitted"
-    on_linux { expected = "Unable to automatically determine the gateway IP" }
+    expected = if OS.mac?
+      "tun device creation: Operation not permitted"
+    else
+      "Unable to automatically determine the gateway IP"
+    end
     assert_match expected, shell_output("#{sbin}/dsvpn client /dev/zero 127.0.0.1 0 2>&1", 1)
   end
 end

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -54,18 +54,17 @@ class Duck < Formula
   def install
     # Consider creating a formula for this if other formulae need the same library
     resource("jna").stage do
-      os = "mac"
       arch = "x86-64"
-      on_linux do
-        os = "Linux"
-      end
-
-      on_macos do
+      os = if OS.linux?
+        "Linux"
+      else
         # Add linker flags for libffi because Makefile call to pkg-config doesn't seem to work properly.
         inreplace "native/Makefile", "LIBS=", "LIBS=-L#{Formula["libffi"].opt_lib} -lffi"
         # Force shared library to have dylib extension on macOS instead of jnilib
         inreplace "native/Makefile", "LIBRARY=$(BUILD)/$(LIBPFX)jnidispatch$(JNISFX)",
 "LIBRARY=$(BUILD)/$(LIBPFX)jnidispatch$(LIBSFX)"
+
+        "mac"
       end
 
       # Don't include directory with JNA headers in zip archive.  If we don't do this, they will be deleted
@@ -82,7 +81,7 @@ class Duck < Formula
         ENV["JAVA_HOME"] = Language::Java.java_home(Formula["openjdk"].version.major.to_s)
 
         # Fix zip error on macOS because libjnidispatch.dylib is not in file list
-        on_macos { inreplace "build.sh", "libjnidispatch.so", "libjnidispatch.so libjnidispatch.dylib" }
+        inreplace "build.sh", "libjnidispatch.so", "libjnidispatch.so libjnidispatch.dylib" if OS.mac?
         # Fix relative path in build script, which is designed to be run out extracted zip archive
         inreplace "build.sh", "cd native", "cd ../native"
 
@@ -92,7 +91,7 @@ class Duck < Formula
     end
 
     resource("JavaNativeFoundation").stage do
-      on_macos do
+      if OS.mac?
         cd "apple/JavaNativeFoundation" do
           xcodebuild "VALID_ARCHS=x86_64", "-project", "JavaNativeFoundation.xcodeproj"
           buildpath.install "build/Release/JavaNativeFoundation.framework"
@@ -100,7 +99,7 @@ class Duck < Formula
       end
     end
 
-    on_macos do
+    if OS.mac?
       xcconfig = buildpath/"Overrides.xcconfig"
       xcconfig.write <<~EOS
         OTHER_LDFLAGS = -headerpad_max_install_names
@@ -108,10 +107,9 @@ class Duck < Formula
       ENV["XCODE_XCCONFIG_FILE"] = xcconfig
     end
 
-    os = "osx"
-    on_linux do
-      os = "linux"
-
+    os = if OS.mac?
+      "osx"
+    else
       # This changes allow maven to build the cli/linux project as an appimage instead of an RPM/DEB.
       # This has been reported upstream at https://trac.cyberduck.io/ticket/11762#ticket.
       # It has been added the version 8 milestone.
@@ -122,6 +120,8 @@ class Duck < Formula
       inreplace "cli/linux/build.xml", "<arg value=\"&lt;feedback@cyberduck.io&gt;\"/>", ""
       inreplace "cli/linux/build.xml", "<arg value=\"--linux-rpm-license-type\"/>", ""
       inreplace "cli/linux/build.xml", "<arg value=\"GPL\"/>", ""
+
+      "linux"
     end
 
     system "mvn", "-DskipTests", "-Dgit.commitsCount=#{revision}",
@@ -129,13 +129,13 @@ class Duck < Formula
 
     libdir = libexec/"Contents/Frameworks"
     bindir = libexec/"Contents/MacOS"
-    on_macos do
+    if OS.mac?
       libexec.install Dir["cli/osx/target/duck.bundle/*"]
       rm_rf libdir/"JavaNativeFoundation.framework"
       libdir.install buildpath/"JavaNativeFoundation.framework"
     end
 
-    on_linux do
+    if OS.linux?
       libdir = libexec/"lib/app"
       bindir = libexec/"bin"
       libexec.install Dir["cli/linux/target/release/duck/*"]

--- a/Formula/duckdb.rb
+++ b/Formula/duckdb.rb
@@ -19,9 +19,7 @@ class Duckdb < Formula
   depends_on "utf8proc"
 
   def install
-    on_linux do
-      ENV.deparallelize # amalgamation builds take GBs of RAM
-    end
+    ENV.deparallelize if OS.linux? # amalgamation builds take GBs of RAM
     mkdir "build/amalgamation"
     system Formula["python@3.9"].opt_bin/"python3", "scripts/amalgamation.py", "--extended"
     cd "build/amalgamation" do

--- a/Formula/dwdiff.rb
+++ b/Formula/dwdiff.rb
@@ -27,7 +27,7 @@ class Dwdiff < Formula
     icu4c = Formula["icu4c"]
     ENV.append "CFLAGS", "-I#{gettext.include} -I#{icu4c.include}"
     ENV.append "LDFLAGS", "-L#{gettext.lib} -L#{icu4c.lib}"
-    on_macos { ENV.append "LDFLAGS", "-lintl" }
+    ENV.append "LDFLAGS", "-lintl" if OS.mac?
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/e2fsprogs.rb
+++ b/Formula/e2fsprogs.rb
@@ -43,11 +43,10 @@ class E2fsprogs < Formula
       "--disable-e2initrd-helper",
       "MKDIR_P=mkdir -p",
     ]
-    on_macos do
-      args << "--enable-bsd-shlibs" unless Hardware::CPU.arm?
-    end
-    on_linux do
-      args << "--enable-elf-shlibs"
+    args << if OS.linux?
+      "--enable-elf-shlibs"
+    elsif !Hardware::CPU.arm?
+      "--enable-bsd-shlibs"
     end
 
     system "./configure", *args

--- a/Formula/ed.rb
+++ b/Formula/ed.rb
@@ -20,15 +20,13 @@ class Ed < Formula
     ENV.deparallelize
 
     args = ["--prefix=#{prefix}"]
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
 
     system "./configure", *args
     system "make"
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       %w[ed red].each do |prog|
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"

--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -25,8 +25,11 @@ class Elasticsearch < Formula
   end
 
   def install
-    os = "darwin"
-    on_linux { os = "linux" }
+    os = if OS.mac?
+      "darwin"
+    else
+      "linux"
+    end
     system "gradle", ":distribution:archives:oss-no-jdk-#{os}-tar:assemble"
 
     mkdir "tar" do

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -136,15 +136,17 @@ class Emscripten < Formula
       system "npm", "install", *Language::Node.local_npm_install_args
       rm_f "node_modules/ws/builderror.log" # Avoid references to Homebrew shims
       # Delete native GraalVM image in incompatible platforms.
-      on_macos { rm_rf "node_modules/google-closure-compiler-osx" if Hardware::CPU.arm? }
-      on_linux { rm_rf "node_modules/google-closure-compiler-linux" }
+      if OS.linux?
+        rm_rf "node_modules/google-closure-compiler-linux"
+      elsif Hardware::CPU.arm?
+        rm_rf "node_modules/google-closure-compiler-osx"
+      end
     end
 
     # Add JAVA_HOME to env_script on ARM64 macOS and Linux, so that google-closure-compiler
     # can find OpenJDK
     emscript_env = { PYTHON: Formula["python@3.9"].opt_bin/"python3" }
-    on_macos { emscript_env.merge! Language::Java.overridable_java_home_env if Hardware::CPU.arm? }
-    on_linux { emscript_env.merge! Language::Java.overridable_java_home_env }
+    emscript_env.merge! Language::Java.overridable_java_home_env if OS.linux? || Hardware::CPU.arm?
 
     %w[em++ em-config emar emcc emcmake emconfigure emlink.py emmake
        emranlib emrun emscons].each do |emscript|

--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -48,9 +48,10 @@ class Envoy < Formula
   end
 
   def install
-    env_path = "#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin"
-    on_linux do
-      env_path = "#{Formula["python@3.9"].opt_libexec}/bin:#{env_path}"
+    env_path = if OS.mac?
+      "#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin"
+    else
+      "#{Formula["python@3.9"].opt_libexec}/bin:#{env_path}"
     end
     args = %W[
       --compilation_mode=opt

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -58,7 +58,7 @@ class Erlang < Formula
       --without-javac
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-darwin-64bit"
       args << "--enable-kernel-poll" if MacOS.version > :el_capitan
       args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -66,7 +66,7 @@ class ErlangAT21 < Formula
       --without-javac
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-darwin-64bit"
       args << "--enable-kernel-poll" if MacOS.version > :el_capitan
       args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?

--- a/Formula/erlang@22.rb
+++ b/Formula/erlang@22.rb
@@ -53,7 +53,7 @@ class ErlangAT22 < Formula
       --without-javac
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-darwin-64bit"
       args << "--enable-kernel-poll" if MacOS.version > :el_capitan
       args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?

--- a/Formula/erlang@23.rb
+++ b/Formula/erlang@23.rb
@@ -49,7 +49,7 @@ class ErlangAT23 < Formula
       --without-javac
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-darwin-64bit"
       args << "--enable-kernel-poll" if MacOS.version > :el_capitan
       args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?

--- a/Formula/espeak.rb
+++ b/Formula/espeak.rb
@@ -30,7 +30,7 @@ class Espeak < Formula
     doc.install Dir["docs/*"]
     cd "src" do
       rm "portaudio.h"
-      on_macos do
+      if OS.mac?
         # macOS does not use -soname so replacing with -install_name to compile for macOS.
         # See https://stackoverflow.com/questions/4580789/ld-unknown-option-soname-on-os-x/32280483#32280483
         inreplace "Makefile", "SONAME_OPT=-Wl,-soname,", "SONAME_OPT=-Wl,-install_name,"
@@ -50,7 +50,7 @@ class Espeak < Formula
       lib.install "libespeak.so.1.#{version.major_minor}" => libespeak
       lib.install_symlink libespeak => shared_library("libespeak", 1)
       lib.install_symlink libespeak => shared_library("libespeak")
-      on_macos { MachO::Tools.change_dylib_id("#{lib}/libespeak.dylib", "#{lib}/libespeak.dylib") }
+      MachO::Tools.change_dylib_id("#{lib}/libespeak.dylib", "#{lib}/libespeak.dylib") if OS.mac?
     end
   end
 

--- a/Formula/ethereum.rb
+++ b/Formula/ethereum.rb
@@ -22,10 +22,9 @@ class Ethereum < Formula
   depends_on "go" => :build
 
   def install
-    on_linux do
-      # See https://github.com/golang/go/issues/26487
-      ENV.O0
-    end
+    # See https://github.com/golang/go/issues/26487
+    ENV.O0 if OS.linux?
+
     system "make", "all"
     bin.install Dir["build/bin/*"]
   end

--- a/Formula/ettercap.rb
+++ b/Formula/ettercap.rb
@@ -34,7 +34,7 @@ class Ettercap < Formula
     ENV.append_to_cflags "-I#{Formula["harfbuzz"].opt_include}/harfbuzz"
 
     # Fix build error on wdg_file.c: fatal error: menu.h: No such file or directory
-    on_linux { ENV.append_to_cflags "-I#{Formula["ncurses"].opt_include}/ncursesw" }
+    ENV.append_to_cflags "-I#{Formula["ncurses"].opt_include}/ncursesw" if OS.linux?
 
     args = std_cmake_args + %W[
       -DBUNDLED_LIBS=OFF
@@ -49,7 +49,7 @@ class Ettercap < Formula
       -DINSTALL_DESKTOP=ON
       -DINSTALL_SYSCONFDIR=#{etc}
     ]
-    on_linux { args << "-DPOLKIT_DIR=#{share}/polkit-1/actions/" }
+    args << "-DPOLKIT_DIR=#{share}/polkit-1/actions/" if OS.linux?
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -23,11 +23,11 @@ class FaasCli < Formula
   depends_on "go" => :build
 
   def install
-    os = "darwin"
-    on_linux do
-      os = "linux"
+    ENV["XC_OS"] = if OS.mac?
+      "darwin"
+    else
+      "linux"
     end
-    ENV["XC_OS"] = os
     ENV["XC_ARCH"] = "amd64"
     project = "github.com/openfaas/faas-cli"
     ldflags = %W[

--- a/Formula/fanyi.rb
+++ b/Formula/fanyi.rb
@@ -27,7 +27,7 @@ class Fanyi < Formula
     term_size_vendor_dir = libexec/"lib/node_modules"/name/"node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -42,7 +42,7 @@ class Fastlane < Formula
     terminal_notifier_dir = libexec.glob("gems/terminal-notifier-*/vendor/terminal-notifier").first
     (terminal_notifier_dir/"terminal-notifier.app").rmtree
 
-    on_macos do
+    if OS.mac?
       ln_sf(
         (Formula["terminal-notifier"].opt_prefix/"terminal-notifier.app").relative_path_from(terminal_notifier_dir),
         terminal_notifier_dir,

--- a/Formula/fetch-crl.rb
+++ b/Formula/fetch-crl.rb
@@ -49,7 +49,7 @@ class FetchCrl < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
       resources.each do |r|
         r.stage do
@@ -62,7 +62,7 @@ class FetchCrl < Formula
 
     system "make", "install", "PREFIX=#{prefix}", "ETC=#{etc}", "CACHE=#{var}/cache"
 
-    on_linux do
+    if OS.linux?
       bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"]
       sbin.env_script_all_files libexec/"sbin", PERL5LIB: ENV["PERL5LIB"]
     end

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -115,10 +115,8 @@ class Ffmpeg < Formula
     # Remove in the next release
     args << "--enable-avresample" unless build.head?
 
-    on_macos do
-      # Needs corefoundation, coremedia, corevideo
-      args << "--enable-videotoolbox"
-    end
+    # Needs corefoundation, coremedia, corevideo
+    args << "--enable-videotoolbox" if OS.mac?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/fibjs.rb
+++ b/Formula/fibjs.rb
@@ -30,7 +30,7 @@ class Fibjs < Formula
 
   def install
     # help find X11 headers: fatal error: 'X11/Xlib.h' file not found
-    on_linux { ENV.append "CXXFLAGS", "-I#{HOMEBREW_PREFIX}/include" }
+    ENV.append "CXXFLAGS", "-I#{HOMEBREW_PREFIX}/include" if OS.linux?
 
     # the build script breaks when CI is set by Homebrew
     with_env(CI: nil) do

--- a/Formula/findutils.rb
+++ b/Formula/findutils.rb
@@ -39,13 +39,11 @@ class Findutils < Formula
       --with-packager-bug-reports=#{tap.issues_url}
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       [[prefix, bin], [share, man/"*"]].each do |base, path|
         Dir[path/"g*"].each do |p|
           f = Pathname.new(p)

--- a/Formula/firebase-cli.rb
+++ b/Formula/firebase-cli.rb
@@ -31,7 +31,7 @@ class FirebaseCli < Formula
     term_size_vendor_dir = libexec/"lib/node_modules/firebase-tools/node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/flex.rb
+++ b/Formula/flex.rb
@@ -44,9 +44,7 @@ class Flex < Formula
 
     # Fix segmentation fault during install on Ubuntu 18.04 (caused by glibc 2.26+),
     # remove with the next release
-    on_linux do
-      ENV.append "CPPFLAGS", "-D_GNU_SOURCE"
-    end
+    ENV.append "CPPFLAGS", "-D_GNU_SOURCE" if OS.linux?
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -48,9 +48,7 @@ class Folly < Formula
   fails_with gcc: "5"
 
   def install
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
     mkdir "_build" do
       args = std_cmake_args + %w[
@@ -70,7 +68,7 @@ class Folly < Formula
 
   test do
     # Force use of Clang rather than LLVM Clang
-    on_macos { ENV.clang }
+    ENV.clang if OS.mac?
 
     (testpath/"test.cc").write <<~EOS
       #include <folly/FBVector.h>

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -61,9 +61,7 @@ class Fontconfig < Formula
     font_dirs << Dir["/System/Library/Assets{,V2}/com_apple_MobileAsset_Font*"].max if MacOS.version >= :sierra
 
     system "autoreconf", "-iv" if build.head?
-    on_linux do
-      ENV["UUID_CFLAGS"] = "-I#{Formula["util-linux"].include}"
-    end
+    ENV["UUID_CFLAGS"] = "-I#{Formula["util-linux"].include}" if OS.linux?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--enable-static",

--- a/Formula/foremost.rb
+++ b/Formula/foremost.rb
@@ -31,10 +31,9 @@ class Foremost < Formula
     # move it to etc instead
     inreplace "config.c", "/usr/local/etc/", "#{etc}/"
 
-    on_macos do
+    if OS.mac?
       system "make", "mac"
-    end
-    on_linux do
+    else
       system "make"
     end
 

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -153,9 +153,7 @@ class Freeswitch < Formula
   def install
     # Fix build error "use of undeclared identifier 'NSIG'"
     # Remove when fixed upstream: https://github.com/signalwire/freeswitch/issues/1145
-    on_macos do
-      ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
-    end
+    ENV.append_to_cflags "-D_DARWIN_C_SOURCE" if OS.mac?
 
     resource("spandsp").stage do
       system "./bootstrap.sh"

--- a/Formula/ftgl.rb
+++ b/Formula/ftgl.rb
@@ -44,9 +44,7 @@ class Ftgl < Formula
       --with-glut-lib=/dev/null
     ]
 
-    on_linux do
-      args << "--with-gl-inc=#{Formula["mesa-glu"].opt_include}"
-    end
+    args << "--with-gl-inc=#{Formula["mesa-glu"].opt_include}" if OS.linux?
 
     system "./configure", *args
 

--- a/Formula/gatsby-cli.rb
+++ b/Formula/gatsby-cli.rb
@@ -35,7 +35,7 @@ class GatsbyCli < Formula
 
     term_size_vendor_dir = libexec/"lib/node_modules/#{name}/node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves
@@ -44,7 +44,7 @@ class GatsbyCli < Formula
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/#{name}/node_modules/clipboardy/fallbacks"
     clipboardy_fallbacks_dir.rmtree # remove pre-built binaries
-    on_linux do
+    if OS.linux?
       linux_dir = clipboardy_fallbacks_dir/"linux"
       linux_dir.mkpath
       # Replace the vendored pre-built xsel with one we build ourselves

--- a/Formula/gcc@10.rb
+++ b/Formula/gcc@10.rb
@@ -74,7 +74,7 @@ class GccAT10 < Formula
       --with-bugurl=#{tap.issues_url}
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version.major}"
       args << "--with-system-zlib"
 
@@ -91,9 +91,7 @@ class GccAT10 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/legacy-homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       # Fix cc1: error while loading shared libraries: libisl.so.15
       args << "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV["LDFLAGS"]}"
 
@@ -108,15 +106,13 @@ class GccAT10 < Formula
     mkdir "build" do
       system "../configure", *args
 
-      on_macos do
+      if OS.mac?
         # Use -headerpad_max_install_names in the build,
         # otherwise updated load commands won't fit in the Mach-O header.
         # This is needed because `gcc` avoids the superenv shim.
         system "make", "BOOT_LDFLAGS=-Wl,-headerpad_max_install_names"
         system "make", "install"
-      end
-
-      on_linux do
+      else
         system "make"
         system "make", "install-strip"
       end
@@ -138,7 +134,7 @@ class GccAT10 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = bin/"gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -119,7 +119,7 @@ class GccAT49 < Formula
       "--enable-multilib",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version}"
       args << "--with-system-zlib"
 
@@ -133,9 +133,7 @@ class GccAT49 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       args << "--disable-multilib"
 
       # Change the default directory name for 64-bit libraries to `lib`
@@ -167,7 +165,7 @@ class GccAT49 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = bin/"gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -105,7 +105,7 @@ class GccAT5 < Formula
       "--with-bugurl=#{tap.issues_url}",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version}"
       args << "--enable-multilib"
       args << "--with-system-zlib"
@@ -120,9 +120,7 @@ class GccAT5 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       # Fix cc1: error while loading shared libraries: libisl.so.15
       args << "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV["LDFLAGS"]}"
       args << "--disable-multilib"
@@ -142,17 +140,16 @@ class GccAT5 < Formula
       system "../configure", *args
       system "make", "bootstrap"
 
-      on_macos do
+      if OS.mac?
         system "make", "install"
-      end
+      else
 
-      on_linux do
         system "make", "install-strip"
       end
 
       # Add symlinks for libgcc, libgomp, libquadmath and libstdc++ so that bottles
       # built in CI can find these libraries when using brewed gcc@5
-      on_linux do
+      if OS.linux?
         lib.install_symlink lib/"gcc/#{version_suffix}/libgcc_s.so"
         lib.install_symlink lib/"gcc/#{version_suffix}/libgcc_s.a"
         lib.install_symlink lib/"gcc/#{version_suffix}/libgcc_s.so.1"
@@ -183,7 +180,7 @@ class GccAT5 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = "#{bin}/gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -89,7 +89,7 @@ class GccAT6 < Formula
       "--disable-nls",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version}"
       args << "--with-system-zlib"
 
@@ -106,9 +106,7 @@ class GccAT6 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
@@ -121,11 +119,9 @@ class GccAT6 < Formula
       system "../configure", *args
       system "make", "bootstrap"
 
-      on_macos do
+      if OS.mac?
         system "make", "install"
-      end
-
-      on_linux do
+      else
         system "make", "install-strip"
       end
     end
@@ -146,7 +142,7 @@ class GccAT6 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = bin/"gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -76,7 +76,7 @@ class GccAT7 < Formula
       "--disable-nls",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version}"
       args << "--with-system-zlib"
 
@@ -93,9 +93,7 @@ class GccAT7 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
@@ -108,11 +106,9 @@ class GccAT7 < Formula
       system "../configure", *args
 
       system "make"
-      on_macos do
+      if OS.mac?
         system "make", "install"
-      end
-
-      on_linux do
+      else
         system "make", "install-strip"
       end
     end
@@ -133,7 +129,7 @@ class GccAT7 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = bin/"gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -76,7 +76,7 @@ class GccAT8 < Formula
       --with-bugurl=#{tap.issues_url}
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version.major}"
       args << "--with-system-zlib"
 
@@ -97,9 +97,7 @@ class GccAT8 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/legacy-homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
@@ -111,15 +109,13 @@ class GccAT8 < Formula
     mkdir "build" do
       system "../configure", *args
 
-      on_macos do
+      if OS.mac?
         # Use -headerpad_max_install_names in the build,
         # otherwise updated load commands won't fit in the Mach-O header.
         # This is needed because `gcc` avoids the superenv shim.
         system "make", "BOOT_LDFLAGS=-Wl,-headerpad_max_install_names"
         system "make", "install"
-      end
-
-      on_linux do
+      else
         system "make"
         system "make", "install-strip"
       end
@@ -141,7 +137,7 @@ class GccAT8 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = bin/"gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -73,7 +73,7 @@ class GccAT9 < Formula
       --with-bugurl=#{tap.issues_url}
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--build=x86_64-apple-darwin#{OS.kernel_version.major}"
       args << "--with-system-zlib"
 
@@ -94,9 +94,7 @@ class GccAT9 < Formula
       # Ensure correct install names when linking against libgcc_s;
       # see discussion in https://github.com/Homebrew/legacy-homebrew/pull/34303
       inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
-    end
-
-    on_linux do
+    else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
@@ -108,15 +106,13 @@ class GccAT9 < Formula
     mkdir "build" do
       system "../configure", *args
 
-      on_macos do
+      if OS.mac?
         # Use -headerpad_max_install_names in the build,
         # otherwise updated load commands won't fit in the Mach-O header.
         # This is needed because `gcc` avoids the superenv shim.
         system "make", "BOOT_LDFLAGS=-Wl,-headerpad_max_install_names"
         system "make", "install"
-      end
-
-      on_linux do
+      else
         system "make"
         system "make", "install-strip"
       end
@@ -131,7 +127,7 @@ class GccAT9 < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       gcc = bin/"gcc-#{version_suffix}"
       libgcc = Pathname.new(Utils.safe_popen_read(gcc, "-print-libgcc-file-name")).parent
       raise "command failed: #{gcc} -print-libgcc-file-name" if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -145,11 +145,10 @@ class Gdal < Formula
       "--without-sosi",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--with-curl=/usr/bin/curl-config"
       args << "--with-opencl"
-    end
-    on_linux do
+    else
       args << "--with-curl=#{Formula["curl"].opt_bin}/curl-config"
 
       # The python build needs libgdal.so, which is located in .libs

--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -75,9 +75,7 @@ class Gdcm < Formula
     ]
 
     mkdir "build" do
-      on_macos do
-        ENV.append "LDFLAGS", "-undefined dynamic_lookup"
-      end
+      ENV.append "LDFLAGS", "-undefined dynamic_lookup" if OS.mac?
 
       system "cmake", "..", *args
       system "ninja"

--- a/Formula/gdl.rb
+++ b/Formula/gdl.rb
@@ -20,7 +20,7 @@ class Gdl < Formula
   depends_on "libxml2"
 
   def install
-    on_linux do
+    if OS.linux?
       # Needed to find intltool (xml::parser)
       ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5"
       ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"
@@ -94,9 +94,7 @@ class Gdl < Formula
       -lpango-1.0
       -lpangocairo-1.0
     ]
-    on_macos do
-      flags << "-lintl"
-    end
+    flags << "-lintl" if OS.mac?
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end

--- a/Formula/gedit.rb
+++ b/Formula/gedit.rb
@@ -36,7 +36,7 @@ class Gedit < Formula
 
   def install
     ENV["DESTDIR"] = "/"
-    on_linux { ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/gedit" }
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/gedit" if OS.linux?
 
     mkdir "build" do
       system "meson", *std_meson_args, ".."
@@ -132,11 +132,10 @@ class Gedit < Formula
       -lpeas-1.0
       -lpeas-gtk-1.0
     ]
-    on_macos do
-      flags << "-lintl"
-    end
-    on_linux do
-      flags << "-Wl,-rpath,#{lib}/gedit"
+    flags << if OS.mac?
+      "-lintl"
+    else
+      "-Wl,-rpath,#{lib}/gedit"
     end
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/geographiclib.rb
+++ b/Formula/geographiclib.rb
@@ -18,9 +18,7 @@ class Geographiclib < Formula
   def install
     mkdir "build" do
       args = std_cmake_args
-      on_macos do
-        args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}"
-      end
+      args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}" if OS.mac?
       system "cmake", "..", *args
       system "make", "install"
     end

--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -38,16 +38,15 @@ class Gettext < Formula
       "--without-cvs",
       "--without-xz",
     ]
-    on_macos do
+    args << if OS.mac?
       # Ship libintl.h. Disabled on linux as libintl.h is provided by glibc
       # https://gcc-help.gcc.gnu.narkive.com/CYebbZqg/cc1-undefined-reference-to-libintl-textdomain
       # There should never be a need to install gettext's libintl.h on
       # GNU/Linux systems using glibc. If you have it installed you've borked
       # your system somehow.
-      args << "--with-included-gettext"
-    end
-    on_linux do
-      args << "--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}"
+      "--with-included-gettext"
+    else
+      "--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}"
     end
     system "./configure", *args
     system "make"

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -68,7 +68,7 @@ class Ghc < Formula
     ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
 
     args = %w[--enable-numa=no]
-    on_macos do
+    if OS.mac?
       # Build a static gmp rather than in-tree gmp, otherwise all ghc-compiled
       # executables link to Homebrew's GMP.
       gmp = libexec/"integer-gmp"
@@ -91,7 +91,7 @@ class Ghc < Formula
       binary = buildpath/"binary"
 
       binary_args = args
-      on_linux do
+      if OS.linux?
         binary_args << "--with-gmp-includes=#{Formula["gmp"].opt_include}"
         binary_args << "--with-gmp-libraries=#{Formula["gmp"].opt_lib}"
       end
@@ -102,9 +102,7 @@ class Ghc < Formula
       ENV.prepend_path "PATH", binary/"bin"
     end
 
-    on_linux do
-      args << "--with-intree-gmp"
-    end
+    args << "--with-intree-gmp" if OS.linux?
 
     system "./configure", "--prefix=#{prefix}", *args
     system "make"

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -62,7 +62,7 @@ class GhcAT86 < Formula
     ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
 
     args = %w[--enable-numa=no]
-    on_macos do
+    if OS.mac?
       # Build a static gmp rather than in-tree gmp, otherwise all ghc-compiled
       # executables link to Homebrew's GMP.
       gmp = libexec/"integer-gmp"
@@ -84,7 +84,7 @@ class GhcAT86 < Formula
       binary = buildpath/"binary"
 
       binary_args = args
-      on_linux do
+      if OS.linux?
         binary_args << "--with-gmp-includes=#{Formula["gmp"].opt_include}"
         binary_args << "--with-gmp-libraries=#{Formula["gmp"].opt_lib}"
       end

--- a/Formula/ghc@8.8.rb
+++ b/Formula/ghc@8.8.rb
@@ -59,7 +59,7 @@ class GhcAT88 < Formula
     ENV["LD"] = "ld"
 
     args = %w[--enable-numa=no]
-    on_macos do
+    if OS.mac?
       # Build a static gmp rather than in-tree gmp, otherwise all ghc-compiled
       # executables link to Homebrew's GMP.
       gmp = libexec/"integer-gmp"
@@ -81,7 +81,7 @@ class GhcAT88 < Formula
       binary = buildpath/"binary"
 
       binary_args = args
-      on_linux do
+      if OS.linux?
         binary_args << "--with-gmp-includes=#{Formula["gmp"].opt_include}"
         binary_args << "--with-gmp-libraries=#{Formula["gmp"].opt_lib}"
       end
@@ -92,9 +92,7 @@ class GhcAT88 < Formula
       ENV.prepend_path "PATH", binary/"bin"
     end
 
-    on_linux do
-      args << "--with-intree-gmp"
-    end
+    args << "--with-intree-gmp" if OS.linux?
 
     # Disable PDF document generation (fails with newest sphinx)
     (buildpath/"mk/build.mk").write <<-EOS

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -60,7 +60,7 @@ class Git < Formula
 
     perl_version = Utils.safe_popen_read("perl", "--version")[/v(\d+\.\d+)(?:\.\d+)?/, 1]
 
-    on_macos do
+    if OS.mac?
       ENV["PERLLIB_EXTRA"] = %W[
         #{MacOS.active_developer_dir}
         /Library/Developer/CommandLineTools
@@ -90,12 +90,12 @@ class Git < Formula
       NO_TCLTK=1
     ]
 
-    on_macos do
-      args += %w[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1]
-    end
-    on_linux do
+    args += if OS.mac?
+      %w[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1]
+    else
       openssl_prefix = Formula["openssl@1.1"].opt_prefix
-      args += %W[NO_APPLE_COMMON_CRYPTO=1 OPENSSLDIR=#{openssl_prefix}]
+
+      %W[NO_APPLE_COMMON_CRYPTO=1 OPENSSLDIR=#{openssl_prefix}]
     end
 
     system "make", "install", *args
@@ -103,7 +103,7 @@ class Git < Formula
     git_core = libexec/"git-core"
 
     # Install the macOS keychain credential helper
-    on_macos do
+    if OS.mac?
       cd "contrib/credential/osxkeychain" do
         system "make", "CC=#{ENV.cc}",
                        "CFLAGS=#{ENV.cflags}",
@@ -163,7 +163,7 @@ class Git < Formula
 
     # Set the macOS keychain credential helper by default
     # (as Apple's CLT's git also does this).
-    on_macos do
+    if OS.mac?
       (buildpath/"gitconfig").write <<~EOS
         [credential]
         \thelper = osxkeychain

--- a/Formula/gitversion.rb
+++ b/Formula/gitversion.rb
@@ -16,9 +16,10 @@ class Gitversion < Formula
   depends_on "dotnet"
 
   def install
-    os = "osx"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "osx"
+    else
+      "linux"
     end
 
     system "dotnet", "publish", "src/GitVersion.App/GitVersion.App.csproj",

--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -17,7 +17,7 @@ class Glab < Formula
   depends_on "go" => :build
 
   def install
-    on_macos { ENV["CGO_ENABLED"] = "1" }
+    ENV["CGO_ENABLED"] = "1" if OS.mac?
 
     system "make", "GLAB_VERSION=#{version}"
     bin.install "bin/glab"

--- a/Formula/glade.rb
+++ b/Formula/glade.rb
@@ -52,7 +52,7 @@ class Glade < Formula
   test do
     # executable test (GUI)
     # fails in Linux CI with (glade:20337): Gtk-WARNING **: 21:45:31.876: cannot open display:
-    on_macos { system "#{bin}/glade", "--version" }
+    system "#{bin}/glade", "--version" if OS.mac?
     # API test
     (testpath/"test.c").write <<~EOS
       #include <gladeui/glade.h>

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -61,7 +61,7 @@ class Glib < Formula
               "giomoduledir=#{HOMEBREW_PREFIX}/lib/gio/modules",
               "giomoduledir=${libdir}/gio/modules"
 
-    on_macos do
+    if OS.mac?
       # `pkg-config --libs glib-2.0` includes -lintl, and gettext itself does not
       # have a pkgconfig file, so we add gettext lib and include paths here.
       gettext = Formula["gettext"].opt_prefix

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -29,12 +29,10 @@ class Gmp < Formula
     # Enable --with-pic to avoid linking issues with the static library
     args << "--with-pic"
 
-    on_macos do
+    if OS.mac?
       cpu = Hardware::CPU.arm? ? "aarch64" : Hardware.oldest_cpu
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
-    end
-
-    on_linux do
+    else
       args << "--build=core2-linux-gnu"
       args << "ABI=32" if Hardware::CPU.is_32_bit?
     end

--- a/Formula/gnome-themes-standard.rb
+++ b/Formula/gnome-themes-standard.rb
@@ -21,7 +21,7 @@ class GnomeThemesStandard < Formula
   depends_on "gtk+"
 
   def install
-    on_linux do
+    if OS.linux?
       # Needed to find intltool (xml::parser)
       ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5"
       ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"

--- a/Formula/gnu-indent.rb
+++ b/Formula/gnu-indent.rb
@@ -29,13 +29,11 @@ class GnuIndent < Formula
       --mandir=#{man}
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gindent" => "indent"
       (libexec/"gnuman/man1").install_symlink man1/"gindent.1" => "indent.1"
     end

--- a/Formula/gnu-sed.rb
+++ b/Formula/gnu-sed.rb
@@ -23,16 +23,15 @@ class GnuSed < Formula
       --disable-dependency-tracking
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
-    on_linux do
-      args << "--without-selinux"
+    args << if OS.mac?
+      "--program-prefix=g"
+    else
+      "--without-selinux"
     end
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gsed" =>"sed"
       (libexec/"gnuman/man1").install_symlink man1/"gsed.1" => "sed.1"
     end

--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -40,17 +40,16 @@ class GnuTar < Formula
       --mandir=#{man}
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
-    on_linux do
-      args << "--without-selinux"
+    args << if OS.mac?
+      "--program-prefix=g"
+    else
+      "--without-selinux"
     end
     system "./bootstrap" if build.head?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       # Symlink the executable into libexec/gnubin as "tar"
       (libexec/"gnubin").install_symlink bin/"gtar" =>"tar"
       (libexec/"gnuman/man1").install_symlink man1/"gtar.1" => "tar.1"

--- a/Formula/gnu-time.rb
+++ b/Formula/gnu-time.rb
@@ -25,15 +25,11 @@ class GnuTime < Formula
       --info=#{info}
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
-      (libexec/"gnubin").install_symlink bin/"gtime" => "time"
-    end
+    (libexec/"gnubin").install_symlink bin/"gtime" => "time" if OS.mac?
   end
 
   def caveats

--- a/Formula/gnu-typist.rb
+++ b/Formula/gnu-typist.rb
@@ -26,10 +26,8 @@ class GnuTypist < Formula
   end
 
   def install
-    on_macos do
-      # libiconv is not linked properly without this
-      ENV.append "LDFLAGS", "-liconv"
-    end
+    # libiconv is not linked properly without this
+    ENV.append "LDFLAGS", "-liconv" if OS.mac?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/gnu-units.rb
+++ b/Formula/gnu-units.rb
@@ -22,13 +22,11 @@ class GnuUnits < Formula
       --with-installed-readline
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gunits" => "units"
       (libexec/"gnubin").install_symlink bin/"gunits_cur" => "units_cur"
       (libexec/"gnuman/man1").install_symlink man1/"gunits.1" => "units.1"

--- a/Formula/gnu-which.rb
+++ b/Formula/gnu-which.rb
@@ -24,13 +24,11 @@ class GnuWhich < Formula
       --disable-dependency-tracking
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gwhich" => "which"
       (libexec/"gnuman/man1").install_symlink man1/"gwhich.1" => "which.1"
     end

--- a/Formula/gnumeric.rb
+++ b/Formula/gnumeric.rb
@@ -34,7 +34,7 @@ class Gnumeric < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
       resources.each do |res|

--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -49,7 +49,7 @@ class Gnupg < Formula
 
     # Configure scdaemon as recommended by upstream developers
     # https://dev.gnupg.org/T5415#145864
-    on_macos do
+    if OS.mac?
       # write to buildpath then install to ensure existing files are not clobbered
       (buildpath/"scdaemon.conf").write <<~EOS
         disable-ccid

--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -69,8 +69,11 @@ class Gnutls < Formula
   end
 
   def post_install
-    on_macos(&method(:macos_post_install))
-    on_linux(&method(:linux_post_install))
+    if OS.mac?
+      macos_post_install
+    else
+      linux_post_install
+    end
   end
 
   def macos_post_install

--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -48,7 +48,7 @@ class GoAT110 < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fixes: Error: Failure while executing: ../bin/ldd ../line-clang.elf: Permission denied
       chmod "+x", Dir.glob("src/debug/dwarf/testdata/*.elf")
       chmod "+x", Dir.glob("src/debug/elf/testdata/*-exec")

--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -36,7 +36,7 @@ class Goffice < Formula
   uses_from_macos "libxslt"
 
   def install
-    on_linux do
+    if OS.linux?
       # Needed to find intltool (xml::parser)
       ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5"
       ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"

--- a/Formula/gource.rb
+++ b/Formula/gource.rb
@@ -37,9 +37,7 @@ class Gource < Formula
     # clang on Mt. Lion will try to build against libstdc++,
     # despite -std=gnu++0x
     ENV.libcxx
-    on_linux do
-      ENV.append "LDFLAGS", "-lpthread"
-    end
+    ENV.append "LDFLAGS", "-lpthread" if OS.linux?
 
     system "autoreconf", "-f", "-i" if build.head?
 

--- a/Formula/gperftools.rb
+++ b/Formula/gperftools.rb
@@ -40,9 +40,7 @@ class Gperftools < Formula
     # Fix "error: unknown type name 'mach_port_t'"
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
 
-    on_macos do
-      ENV.append_to_cflags "-D_XOPEN_SOURCE"
-    end
+    ENV.append_to_cflags "-D_XOPEN_SOURCE" if OS.mac?
 
     system "autoreconf", "-fiv" if build.head?
 
@@ -50,9 +48,7 @@ class Gperftools < Formula
       "--disable-dependency-tracking",
       "--prefix=#{prefix}",
     ]
-    on_linux do
-      args << "--enable-libunwind"
-    end
+    args << "--enable-libunwind" if OS.linux?
 
     system "./configure", *args
     system "make"

--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -35,7 +35,7 @@ class Gpredict < Formula
 
   def install
     # Needed by intltool (xml::parser)
-    on_linux { ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" }
+    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" if OS.linux?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -21,16 +21,14 @@ class Gptfdisk < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       inreplace "Makefile.mac" do |s|
         s.gsub! "/usr/local/Cellar/ncurses/6.2/lib/libncurses.dylib", "-L/usr/lib -lncurses"
         s.gsub! "-L/usr/local/lib -lpopt", "-L#{Formula["popt"].opt_lib} -lpopt"
       end
 
       system "make", "-f", "Makefile.mac"
-    end
-
-    on_linux do
+    else
       %w[ncurses popt util-linux].each do |dep|
         ENV.append_to_cflags "-I#{Formula[dep].opt_include}"
         ENV.append "LDFLAGS", "-L#{Formula[dep].opt_lib}"

--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -32,11 +32,10 @@ class Grafana < Formula
 
     system "node_modules/webpack/bin/webpack.js", "--config", "scripts/webpack/webpack.prod.js"
 
-    on_macos do
+    if OS.mac?
       bin.install Dir["bin/darwin-*/grafana-cli"]
       bin.install Dir["bin/darwin-*/grafana-server"]
-    end
-    on_linux do
+    else
       bin.install "bin/linux-amd64/grafana-cli"
       bin.install "bin/linux-amd64/grafana-server"
     end

--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -27,14 +27,12 @@ class Grep < Formula
       --with-packager=Homebrew
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make"
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       %w[grep egrep fgrep].each do |prog|
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"

--- a/Formula/grin-wallet.rb
+++ b/Formula/grin-wallet.rb
@@ -25,9 +25,7 @@ class GrinWallet < Formula
   patch :DATA
 
   def install
-    on_linux do
-      ENV["CLANG_PATH"] = Formula["llvm"].opt_bin/"clang"
-    end
+    ENV["CLANG_PATH"] = Formula["llvm"].opt_bin/"clang" if OS.linux?
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -44,9 +44,7 @@ class Grpc < Formula
 
   def install
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
     mkdir "cmake/build" do
       args = %W[
         ../..
@@ -78,7 +76,7 @@ class Grpc < Formula
       bin.install "grpc_cli"
       lib.install Dir[shared_library("libgrpc++_test_config", "*")]
 
-      on_macos do
+      if OS.mac?
         # These are installed manually, so need to be relocated manually as well
         MachO::Tools.add_rpath(bin/"grpc_cli", rpath)
         MachO::Tools.add_rpath(lib/shared_library("libgrpc++_test_config"), rpath)

--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -51,7 +51,7 @@ class Gtkx3 < Formula
       -Dintrospection=true
     ]
 
-    on_macos do
+    if OS.mac?
       args << "-Dquartz_backend=true"
       args << "-Dx11_backend=false"
     end

--- a/Formula/gtk4.rb
+++ b/Formula/gtk4.rb
@@ -47,7 +47,7 @@ class Gtk4 < Formula
       -Dbuild-tests=false
     ]
 
-    on_macos do
+    if OS.mac?
       args << "-Dx11-backend=false"
       args << "-Dmacos-backend=true"
       args << "-Dprint-cups=disabled" if MacOS.version <= :mojave

--- a/Formula/gtksourceview3.rb
+++ b/Formula/gtksourceview3.rb
@@ -34,9 +34,7 @@ class Gtksourceview3 < Formula
   end
 
   def install
-    on_macos do
-      system "autoreconf", "--verbose", "--install", "--force"
-    end
+    system "autoreconf", "--verbose", "--install", "--force" if OS.mac?
     system "./configure", "--disable-dependency-tracking",
                           "--enable-vala=yes",
                           "--enable-introspection=yes",

--- a/Formula/gwenhywfar.rb
+++ b/Formula/gwenhywfar.rb
@@ -43,7 +43,7 @@ class Gwenhywfar < Formula
     inreplace "gwenhywfar-config.in.in", "@PKG_CONFIG@", "pkg-config"
     system "autoreconf", "-fiv" # needed because of the patch. Otherwise only needed for head build (if build.head?)
     guis = ["cpp", "qt5"]
-    on_macos { guis << "cocoa" }
+    guis << "cocoa" if OS.mac?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/hackrf.rb
+++ b/Formula/hackrf.rb
@@ -28,7 +28,7 @@ class Hackrf < Formula
     cd "host" do
       args = std_cmake_args
 
-      on_linux do
+      if OS.linux?
         args << "-DUDEV_RULES_GROUP=plugdev"
         args << "-DUDEV_RULES_PATH=#{lib}/udev/rules.d"
       end

--- a/Formula/handbrake.rb
+++ b/Formula/handbrake.rb
@@ -41,9 +41,7 @@ class Handbrake < Formula
   def install
     inreplace "contrib/ffmpeg/module.defs", "$(FFMPEG.GCC.gcc)", "cc"
 
-    on_linux do
-      ENV.append "CFLAGS", "-I#{Formula["libxml2"].opt_include}/libxml2"
-    end
+    ENV.append "CFLAGS", "-I#{Formula["libxml2"].opt_include}/libxml2" if OS.linux?
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-xcode",

--- a/Formula/haproxy.rb
+++ b/Formula/haproxy.rb
@@ -32,12 +32,11 @@ class Haproxy < Formula
       USE_ZLIB=1
       ADDLIB=-lcrypto
     ]
-    on_macos do
+    if OS.mac?
       args << "TARGET=generic"
       # BSD only:
       args << "USE_KQUEUE=1"
-    end
-    on_linux do
+    else
       args << "TARGET=linux-glibc"
     end
 

--- a/Formula/hasura-cli.rb
+++ b/Formula/hasura-cli.rb
@@ -36,9 +36,10 @@ class HasuraCli < Formula
 
     cd "cli" do
       arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-      os = "darwin"
-      on_linux do
-        os = "linux"
+      os = if OS.mac?
+        "darwin"
+      else
+        "linux"
       end
 
       cp "../cli-ext/bin/cli-ext-hasura", "./internal/cliext/static-bin/#{os}/#{arch}/cli-ext"

--- a/Formula/hdf5-mpi.rb
+++ b/Formula/hdf5-mpi.rb
@@ -37,11 +37,10 @@ class Hdf5Mpi < Formula
               "settingsdir=$(libdir)",
               "settingsdir=#{pkgshare}"
 
-    on_macos do
+    if OS.mac?
       system "autoreconf", "-fiv"
-    end
+    else
 
-    on_linux do
       system "./autogen.sh"
     end
 
@@ -60,9 +59,7 @@ class Hdf5Mpi < Formula
       F90=mpif90
     ]
 
-    on_linux do
-      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
-    end
+    args << "--with-zlib=#{Formula["zlib"].opt_prefix}" if OS.linux?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -51,15 +51,13 @@ class Hdf5 < Formula
       --enable-fortran
       --enable-cxx
     ]
-    on_linux do
-      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
-    end
+    args << "--with-zlib=#{Formula["zlib"].opt_prefix}" if OS.linux?
 
     system "./configure", *args
 
     # Avoid shims in settings file
     inreplace "src/libhdf5.settings", %r{#{HOMEBREW_SHIMS_PATH}/[^/]+/super/#{ENV.cc}}, ENV.cc
-    on_linux do
+    if OS.linux?
       inreplace "src/libhdf5.settings", %r{#{HOMEBREW_SHIMS_PATH}/[^/]+/super/#{Regexp.escape(ENV.cxx)}}, ENV.cxx
     end
 

--- a/Formula/hidapi.rb
+++ b/Formula/hidapi.rb
@@ -33,9 +33,7 @@ class Hidapi < Formula
     system "make", "install"
 
     # hidtest/.libs/hidtest does not exist for Linux, install it for macOS only
-    on_macos do
-      bin.install "hidtest/.libs/hidtest"
-    end
+    bin.install "hidtest/.libs/hidtest" if OS.mac?
   end
 
   test do

--- a/Formula/homebank.rb
+++ b/Formula/homebank.rb
@@ -30,7 +30,7 @@ class Homebank < Formula
   depends_on "libsoup"
 
   def install
-    on_linux do
+    if OS.linux?
       # Needed to find intltool (xml::parser)
       ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5"
       ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"

--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -35,7 +35,7 @@ class Htop < Formula
   def install
     system "./autogen.sh"
     args = ["--prefix=#{prefix}"]
-    on_linux { args << "--enable-sensors" }
+    args << "--enable-sensors" if OS.linux?
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -47,9 +47,12 @@ class Httpd < Formula
     end
 
     libxml2 = "#{MacOS.sdk_path_if_needed}/usr"
-    on_linux { libxml2 = Formula["libxml2"].opt_prefix }
-    zlib = "#{MacOS.sdk_path_if_needed}/usr"
-    on_linux { zlib = Formula["zlib"].opt_prefix }
+    libxml2 = Formula["libxml2"].opt_prefix if OS.linux?
+    zlib = if OS.mac?
+      "#{MacOS.sdk_path_if_needed}/usr"
+    else
+      Formula["zlib"].opt_prefix
+    end
     system "./configure", "--enable-layout=Slackware-FHS",
                           "--prefix=#{prefix}",
                           "--sbindir=#{bin}",
@@ -79,7 +82,7 @@ class Httpd < Formula
                           "--disable-lua",
                           "--disable-luajit"
     system "make"
-    on_linux { ENV.deparallelize }
+    ENV.deparallelize if OS.linux?
     system "make", "install"
 
     # suexec does not install without root
@@ -108,8 +111,11 @@ class Httpd < Formula
       s.gsub! prefix, opt_prefix
     end
 
-    os = "mac"
-    on_linux { os = "linux" }
+    os = if OS.mac?
+      "mac"
+    else
+      "linux"
+    end
     inreplace "#{lib}/httpd/build/config_vars.mk" do |s|
       pcre = Formula["pcre"]
       s.gsub! pcre.prefix.realpath, pcre.opt_prefix

--- a/Formula/hydra.rb
+++ b/Formula/hydra.rb
@@ -49,9 +49,7 @@ class Hydra < Formula
     bin.mkpath
     # remove unsupported ld flags on mac
     # related to https://github.com/vanhauser-thc/thc-hydra/issues/622
-    on_macos do
-      inreplace "Makefile", "-Wl,--allow-multiple-definition", ""
-    end
+    inreplace "Makefile", "-Wl,--allow-multiple-definition", "" if OS.mac?
     system "make", "all", "install"
     share.install prefix/"man" # Put man pages in correct place
   end

--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -23,10 +23,9 @@ class Hyperscan < Formula
 
   def install
     cmake_args = std_cmake_args + ["-DBUILD_STATIC_AND_SHARED=ON"]
-    on_linux do
-      # Linux CI cannot guarantee AVX2 support needed to build fat runtime.
-      cmake_args << "-DFAT_RUNTIME=OFF"
-    end
+
+    # Linux CI cannot guarantee AVX2 support needed to build fat runtime.
+    cmake_args << "-DFAT_RUNTIME=OFF" if OS.linux?
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -76,9 +76,7 @@ class Imagemagick < Formula
       "LDFLAGS=-lomp -lz",
     ]
 
-    on_macos do
-      args << "--without-x"
-    end
+    args << "--without-x" if OS.mac?
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_BASE_VERSION}", "${PACKAGE_NAME}"

--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -56,8 +56,11 @@ class ImapUw < Formula
     # Skip IPv6 warning on Linux as libc should be IPv6 safe.
     touch "ip6"
 
-    target = "oxp"
-    on_linux { target = "ldb" }
+    target = if OS.mac?
+      "oxp"
+    else
+      "ldb"
+    end
     system "make", target
 
     # email servers:

--- a/Formula/inetutils.rb
+++ b/Formula/inetutils.rb
@@ -34,13 +34,11 @@ class Inetutils < Formula
       --with-idn
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "SUIDMODE=", "install"
 
-    on_macos do
+    if OS.mac?
       # Binaries not shadowing macOS utils symlinked without 'g' prefix
       noshadow.each do |cmd|
         bin.install_symlink "g#{cmd}" => cmd

--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -81,9 +81,7 @@ class Infer < Formula
     ENV["OPAMROOT"] = opamroot
     ENV["OPAMYES"] = "1"
     ENV["OPAMVERBOSE"] = "1"
-    on_linux do
-      ENV["PATCHELF"] = Formula["patchelf"].opt_bin/"patchelf"
-    end
+    ENV["PATCHELF"] = Formula["patchelf"].opt_bin/"patchelf" if OS.linux?
 
     system "opam", "init", "--no-setup", "--disable-sandboxing"
 
@@ -98,7 +96,7 @@ class Infer < Formula
 
     # Disable handling external dependencies as opam is not aware of Homebrew on Linux.
     # Error:  Package conflict!  * Missing dependency:  - conf-autoconf
-    on_linux { inreplace "build-infer.sh", "infer \"$INFER_ROOT\" $locked", "\\0 --no-depexts" }
+    inreplace "build-infer.sh", "infer \"$INFER_ROOT\" $locked", "\\0 --no-depexts" if OS.linux?
 
     system "./build-infer.sh", "all", "--yes"
     system "make", "install-with-libs"

--- a/Formula/intltool.rb
+++ b/Formula/intltool.rb
@@ -29,7 +29,7 @@ class Intltool < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
       resources.each do |res|
         res.stage do

--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -23,10 +23,9 @@ class Iozone < Formula
 
   def install
     cd "src/current" do
-      on_macos do
+      if OS.mac?
         system "make", "macosx", "CC=#{ENV.cc}"
-      end
-      on_linux do
+      else
         system "make", "linux", "CC=#{ENV.cc}"
       end
       bin.install "iozone"

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -50,7 +50,7 @@ class Ipopt < Formula
 
     resource("mumps").stage do
       cp "Make.inc/Makefile.inc.generic.SEQ", "Makefile.inc"
-      on_macos { inreplace "Makefile.inc", "@rpath/", "#{opt_lib}/" }
+      inreplace "Makefile.inc", "@rpath/", "#{opt_lib}/" if OS.mac?
 
       # Fix for GCC 10
       inreplace "Makefile.inc", "OPTF    = -fPIC",

--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -143,9 +143,7 @@ class Ipython < Formula
     # install other resources
     ipykernel = resource("ipykernel")
     res = resources - [ipykernel]
-    on_linux do
-      res -= [resource("appnope")]
-    end
+    res -= [resource("appnope")] if OS.linux?
     res.each do |r|
       r.stage do
         system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")

--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -31,7 +31,7 @@ class Irrlicht < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       # Fix "error: cannot initialize a parameter of type
       # 'id<NSApplicationDelegate> _Nullable' with an rvalue of type
       # 'id<NSFileManagerDelegate>'"
@@ -68,9 +68,7 @@ class Irrlicht < Formula
       lib.install_symlink frameworks/"IrrFramework.framework/Versions/A/IrrFramework" => "libIrrlicht.dylib"
       lib.install "source/Irrlicht/MacOSX/build/Release/libIrrlicht.a"
       include.install "include" => "irrlicht"
-    end
-
-    on_linux do
+    else
       cd "source/Irrlicht" do
         inreplace "Makefile" do |s|
           s.gsub! "/usr/X11R6/lib$(LIBSELECT)", Formula["libx11"].opt_lib

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -49,11 +49,10 @@ class Irssi < Formula
       --with-perl-lib=#{lib}/perl5/site_perl
     ]
 
-    on_macos do
-      args << "--with-ncurses=#{MacOS.sdk_path/"usr"}"
-    end
-    on_linux do
-      args << "--with-ncurses=#{Formula["ncurses"].prefix}"
+    args << if OS.mac?
+      "--with-ncurses=#{MacOS.sdk_path/"usr"}"
+    else
+      "--with-ncurses=#{Formula["ncurses"].prefix}"
     end
 
     if build.head?

--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -26,20 +26,16 @@ class Istioctl < Formula
     ENV["HUB"] = "docker.io/istio"
     ENV["BUILD_WITH_CONTAINER"] = "0"
 
-    dirpath = nil
-    on_macos do
-      if Hardware::CPU.arm?
-        # Fix missing "amd64" for macOS ARM in istio/common/scripts/setup_env.sh
-        # Can remove when upstream adds logic to detect `$(uname -m) == "arm64"`
-        ENV["TARGET_ARCH"] = "arm64"
+    dirpath = if OS.linux?
+      "linux_amd64"
+    elsif Hardware::CPU.arm?
+      # Fix missing "amd64" for macOS ARM in istio/common/scripts/setup_env.sh
+      # Can remove when upstream adds logic to detect `$(uname -m) == "arm64"`
+      ENV["TARGET_ARCH"] = "arm64"
 
-        dirpath = "darwin_arm64"
-      else
-        dirpath = "darwin_amd64"
-      end
-    end
-    on_linux do
-      dirpath = "linux_amd64"
+      "darwin_arm64"
+    else
+      "darwin_amd64"
     end
 
     system "make", "istioctl", "istioctl.completion"

--- a/Formula/itk.rb
+++ b/Formula/itk.rb
@@ -62,7 +62,7 @@ class Itk < Formula
       -DModule_ITKVtkGlue=ON
     ]
 
-    on_macos { args << "-DITK_USE_GPU=ON" }
+    args << "-DITK_USE_GPU=ON" if OS.mac?
 
     # Avoid references to the Homebrew shims directory
     inreplace "Modules/Core/Common/src/CMakeLists.txt" do |s|

--- a/Formula/jabba.rb
+++ b/Formula/jabba.rb
@@ -39,8 +39,11 @@ class Jabba < Formula
     ENV["JABBA_HOME"] = testpath/"jabba_home"
 
     system bin/"jabba", "install", jdk_version
-    jdk_path = shell_output("#{bin}/jabba which #{jdk_version}").strip
-    on_macos { jdk_path = "#{jdk_path}/Contents/Home" }
+    jdk_path = if OS.mac?
+      "#{jdk_path}/Contents/Home"
+    else
+      shell_output("#{bin}/jabba which #{jdk_version}").strip
+    end
     assert_match version_check,
                  shell_output("#{jdk_path}/bin/java -version 2>&1")
   end

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -38,10 +38,10 @@ class Jack < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac? && MacOS.version <= :high_sierra
       # See https://github.com/jackaudio/jack2/issues/640#issuecomment-723022578
-      ENV.append "LDFLAGS", "-Wl,-compatibility_version,1" if MacOS.version <= :high_sierra
-      ENV.append "LDFLAGS", "-Wl,-current_version,#{version}" if MacOS.version <= :high_sierra
+      ENV.append "LDFLAGS", "-Wl,-compatibility_version,1"
+      ENV.append "LDFLAGS", "-Wl,-current_version,#{version}"
     end
     system Formula["python@3.9"].opt_bin/"python3", "./waf", "configure", "--prefix=#{prefix}"
     system Formula["python@3.9"].opt_bin/"python3", "./waf", "build"
@@ -62,8 +62,11 @@ class Jack < Formula
     source_name = "test_source"
     sink_name = "test_sink"
     fork do
-      on_macos { exec "#{bin}/jackd", "-X", "coremidi", "-d", "dummy" }
-      on_linux { exec "#{bin}/jackd", "-d", "dummy" }
+      if OS.mac?
+        exec "#{bin}/jackd", "-X", "coremidi", "-d", "dummy"
+      else
+        exec "#{bin}/jackd", "-d", "dummy"
+      end
     end
     system "#{bin}/jack_wait", "--wait", "--timeout", "10"
     fork do

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -30,7 +30,7 @@ class Jasper < Formula
       args = std_cmake_args
       args << "-DJAS_ENABLE_DOC=OFF"
 
-      on_macos do
+      if OS.mac?
         # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
         # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
         glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"

--- a/Formula/jnettop.rb
+++ b/Formula/jnettop.rb
@@ -30,7 +30,7 @@ class Jnettop < Formula
     ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
 
     # Fix undefined reference to `g_thread_init'
-    on_linux do
+    if OS.linux?
       inreplace "Makefile.in", "$(jnettop_LDFLAGS) $(jnettop_OBJECTS)",
                                "$(jnettop_OBJECTS) $(AM_LDFLAGS) $(LDFLAGS) $(jnettop_LDFLAGS)"
     end

--- a/Formula/john.rb
+++ b/Formula/john.rb
@@ -36,9 +36,10 @@ class John < Formula
 
     ENV.deparallelize
 
-    target = "macosx-x86-64"
-    on_linux do
-      target = "linux-x86-64"
+    target = if OS.mac?
+      "macosx-x86-64"
+    else
+      "linux-x86-64"
     end
 
     system "make", "-C", "src", "clean", "CC=#{ENV.cc}", target

--- a/Formula/joplin-cli.rb
+++ b/Formula/joplin-cli.rb
@@ -30,7 +30,7 @@ class JoplinCli < Formula
     node_notifier_vendor_dir = libexec/"lib/node_modules/joplin/node_modules/node-notifier/vendor"
     node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
 
-    on_macos do
+    if OS.mac?
       terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"
       terminal_notifier_dir.mkpath
 

--- a/Formula/jp.rb
+++ b/Formula/jp.rb
@@ -27,9 +27,10 @@ class Jp < Formula
     build_root.install Dir["*"]
     cd build_root do
       arch = Hardware::CPU.arm? ? "arm64" : "x86_64"
-      os = "osx"
-      on_linux do
-        os = "linux"
+      os = if OS.mac?
+        "osx"
+      else
+        "linux"
       end
       system "make", "binaries/#{os}_#{arch}/jp"
       bin.install "binaries/#{os}_#{arch}/jp"
@@ -47,7 +48,7 @@ index adc9d13..664b6af 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -90,3 +90,10 @@ release/$(APP)_$(VERSION)_linux_arm64.zip: binaries/linux_arm64/$(APP)
- 
+
  binaries/linux_arm64/$(APP): $(GOFILES)
  	GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o binaries/linux_arm64/$(APP) ./cmd/$(APP)
 +

--- a/Formula/jupyterlab.rb
+++ b/Formula/jupyterlab.rb
@@ -349,7 +349,7 @@ class Jupyterlab < Formula
     # gather packages to link based on options
     linked = %w[jupyter-core jupyter-client nbformat ipykernel jupyter-console nbconvert notebook]
     dependencies = resources.map(&:name).to_set - linked
-    on_linux { dependencies -= ["appnope"] }
+    dependencies -= ["appnope"] if OS.linux?
     dependencies.each do |r|
       venv.pip_install resource(r)
     end

--- a/Formula/kahip.rb
+++ b/Formula/kahip.rb
@@ -22,7 +22,7 @@ class Kahip < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       gcc_major_ver = Formula["gcc"].any_installed_version.major
       ENV["CC"] = Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}"
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{gcc_major_ver}"

--- a/Formula/katago.rb
+++ b/Formula/katago.rb
@@ -41,7 +41,7 @@ class Katago < Formula
   def install
     cd "cpp" do
       args = %w[-DBUILD_MCTS=1 -DNO_GIT_REVISION=1]
-      on_macos do
+      if OS.mac?
         args << "-DUSE_BACKEND=OPENCL"
         args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}"
       end

--- a/Formula/kim-api.rb
+++ b/Formula/kim-api.rb
@@ -42,11 +42,10 @@ class KimApi < Formula
       "-DBASH_COMPLETION_COMPLETIONSDIR=#{bash_completion}",
     ]
     # adjust compiler settings for package
-    on_macos do
+    if OS.mac?
       args << "-DKIM_API_CMAKE_C_COMPILER=/usr/bin/clang"
       args << "-DKIM_API_CMAKE_CXX_COMPILER=/usr/bin/clang++"
-    end
-    on_linux do
+    else
       args << "-DKIM_API_CMAKE_C_COMPILER=/usr/bin/gcc"
       args << "-DKIM_API_CMAKE_CXX_COMPILER=/usr/bin/g++"
     end

--- a/Formula/klee.rb
+++ b/Formula/klee.rb
@@ -77,11 +77,10 @@ class Klee < Formula
         -DLIBCXX_ENABLE_SHARED:BOOL=ON
         -DLIBCXXABI_ENABLE_THREADS:BOOL=OFF
       ]
-      on_macos do
-        libcxx_args << "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=OFF"
-      end
-      on_linux do
-        libcxx_args << "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=ON"
+      libcxx_args << if OS.mac?
+        "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=OFF"
+      else
+        "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=ON"
       end
 
       mkdir "llvm/build" do

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -35,9 +35,7 @@ class KnotResolver < Formula
 
   def install
     args = std_meson_args + ["--default-library=static"]
-    on_linux do
-      args << "-Dsystemd_files=enabled"
-    end
+    args << "-Dsystemd_files=enabled" if OS.linux?
 
     mkdir "build" do
       system "meson", *args, ".."

--- a/Formula/landscaper.rb
+++ b/Formula/landscaper.rb
@@ -30,9 +30,10 @@ class Landscaper < Formula
     ENV["GO111MODULE"] = "auto"
     ENV.prepend_create_path "PATH", buildpath/"bin"
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    os = "darwin"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "darwin"
+    else
+      "linux"
     end
     ENV["TARGETS"] = "#{os}/#{arch}"
     dir = buildpath/"src/github.com/eneco/landscaper"

--- a/Formula/latexml.rb
+++ b/Formula/latexml.rb
@@ -189,9 +189,7 @@ class Latexml < Formula
     ENV.prepend_create_path "PERL5LIB", libexec+"lib/perl5"
     resources.each do |r|
       r.stage do
-        on_linux do
-          ENV["PERL_CANARY_STABILITY_NOPROMPT"] = "1"
-        end
+        ENV["PERL_CANARY_STABILITY_NOPROMPT"] = "1" if OS.linux?
 
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
         system "make"

--- a/Formula/lc0.rb
+++ b/Formula/lc0.rb
@@ -37,7 +37,7 @@ class Lc0 < Formula
 
   def install
     args = ["-Dgtest=false"]
-    on_linux do
+    if OS.linux?
       args << "-Dopenblas_include=#{Formula["openblas"].opt_include}"
       args << "-Dopenblas_libdirs=#{Formula["openblas"].opt_lib}"
     end

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -51,7 +51,7 @@ class Ldc < Formula
     ENV.cxx11
     (buildpath/"ldc-bootstrap").install resource("ldc-bootstrap")
 
-    on_linux do
+    if OS.linux?
       # Fix ldc-bootstrap/bin/ldmd2: error while loading shared libraries: libxml2.so.2
       ENV.prepend_path "LD_LIBRARY_PATH", Formula["libxml2"].lib
     end
@@ -67,7 +67,7 @@ class Ldc < Formula
       system "make"
       system "make", "install"
 
-      on_macos do
+      if OS.mac?
         # Workaround for https://github.com/ldc-developers/ldc/issues/3670
         cp Formula["llvm"].opt_lib/"libLLVM.dylib", lib/"libLLVM.dylib"
       end

--- a/Formula/ldns.rb
+++ b/Formula/ldns.rb
@@ -43,7 +43,7 @@ class Ldns < Formula
     ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
     system "./configure", *args
 
-    on_macos do
+    if OS.mac?
       inreplace "Makefile" do |s|
         s.change_make_var! "PYTHON_LDFLAGS", "-undefined dynamic_lookup"
         s.gsub!(/(\$\(PYTHON_LDFLAGS\).*) -no-undefined/, "\\1")

--- a/Formula/libass.rb
+++ b/Formula/libass.rb
@@ -37,10 +37,8 @@ class Libass < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
     ]
-    on_macos do
-      # libass uses coretext on macOS, fontconfig on Linux
-      args << "--disable-fontconfig"
-    end
+    # libass uses coretext on macOS, fontconfig on Linux
+    args << "--disable-fontconfig" if OS.mac?
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/libbladerf.rb
+++ b/Formula/libbladerf.rb
@@ -25,7 +25,7 @@ class Libbladerf < Formula
   depends_on "libusb"
 
   def install
-    on_macos { ENV.prepend "CFLAGS", "-I#{MacOS.sdk_path}/usr/include/malloc" }
+    ENV.prepend "CFLAGS", "-I#{MacOS.sdk_path}/usr/include/malloc" if OS.mac?
     mkdir "host/build" do
       system "cmake", "..", *std_cmake_args, "-DUDEV_RULES_PATH=#{lib}/udev/rules.d"
       system "make", "install"

--- a/Formula/libdv.rb
+++ b/Formula/libdv.rb
@@ -20,7 +20,7 @@ class Libdv < Formula
   depends_on "popt"
 
   def install
-    on_macos do
+    if OS.mac?
       # This fixes an undefined symbol error on compile.
       # See the port file for libdv:
       #   https://trac.macports.org/browser/trunk/dports/multimedia/libdv/Portfile

--- a/Formula/libedit.rb
+++ b/Formula/libedit.rb
@@ -29,7 +29,7 @@ class Libedit < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
 
-    on_linux do
+    if OS.linux?
       # Conflicts with readline.
       mv man3/"history.3", man3/"history_libedit.3"
     end

--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -26,9 +26,7 @@ class Libfido2 < Formula
   def install
     args = std_cmake_args
 
-    on_linux do
-      args << "-DUDEV_RULES_DIR=#{lib}/udev/rules.d"
-    end
+    args << "-DUDEV_RULES_DIR=#{lib}/udev/rules.d" if OS.linux?
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -33,9 +33,7 @@ class Libgcrypt < Formula
 
     # Parallel builds work, but only when run as separate steps
     system "make"
-    on_macos do
-      MachO.codesign!("#{buildpath}/tests/.libs/random") if Hardware::CPU.arm?
-    end
+    MachO.codesign!("#{buildpath}/tests/.libs/random") if OS.mac? && Hardware::CPU.arm?
 
     system "make", "check"
     system "make", "install"

--- a/Formula/libgnt.rb
+++ b/Formula/libgnt.rb
@@ -33,7 +33,7 @@ class Libgnt < Formula
     # Work around for ERROR: Problem encountered: ncurses could not be found!
     # Issue is build only checks for ncursesw headers under system prefix /usr
     # Upstream issue: https://issues.imfreedom.org/issue/LIBGNT-15
-    on_linux do
+    if OS.linux?
       inreplace "meson.build", "ncurses_sys_prefix = '/usr'",
                                "ncurses_sys_prefix = '#{Formula["ncurses"].opt_prefix}'"
     end

--- a/Formula/libkeccak.rb
+++ b/Formula/libkeccak.rb
@@ -14,7 +14,7 @@ class Libkeccak < Formula
 
   def install
     args = ["PREFIX=#{prefix}"]
-    on_macos { args << "OSCONFIGFILE=macos.mk" }
+    args << "OSCONFIGFILE=macos.mk" if OS.mac?
 
     system "make", "install", *args
     pkgshare.install %w[.testfile test.c]

--- a/Formula/libmms.rb
+++ b/Formula/libmms.rb
@@ -21,7 +21,7 @@ class Libmms < Formula
   depends_on "glib"
 
   def install
-    on_macos { ENV.append "LDFLAGS", "-liconv" }
+    ENV.append "LDFLAGS", "-liconv" if OS.mac?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/libnotify.rb
+++ b/Formula/libnotify.rb
@@ -68,7 +68,7 @@ class Libnotify < Formula
       -lglib-2.0
       -lgobject-2.0
     ]
-    on_macos { flags << "-lintl" }
+    flags << "-lintl" if OS.mac?
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end

--- a/Formula/libquantum.rb
+++ b/Formula/libquantum.rb
@@ -43,7 +43,7 @@ class Libquantum < Formula
       "-L#{lib}",
       "-lquantum",
     ]
-    on_linux { args << "-fopenmp" }
+    args << "-fopenmp" if OS.linux?
     system ENV.cc, "qtest.c", *args, "-o", "qtest"
     system "./qtest"
   end

--- a/Formula/libre.rb
+++ b/Formula/libre.rb
@@ -18,10 +18,7 @@ class Libre < Formula
   uses_from_macos "zlib"
 
   def install
-    sysroot = nil
-    on_macos do
-      sysroot = "SYSROOT=#{MacOS.sdk_path}/usr"
-    end
+    sysroot = "SYSROOT=#{MacOS.sdk_path}/usr" if OS.mac?
     system "make", *sysroot, "install", "PREFIX=#{prefix}"
   end
 

--- a/Formula/libreadline-java.rb
+++ b/Formula/libreadline-java.rb
@@ -35,8 +35,11 @@ class LibreadlineJava < Formula
 
     # Current Oracle JDKs put the jni.h and jni_md.h in a different place than the
     # original Apple/Sun JDK used to.
-    os = "darwin"
-    on_linux { os = "linux" }
+    os = if OS.mac?
+      "darwin"
+    else
+      "linux"
+    end
     ENV["JAVAINCLUDE"] = "#{java_home}/include"
     ENV["JAVANATINC"]  = "#{java_home}/include/#{os}"
 
@@ -48,7 +51,7 @@ class LibreadlineJava < Formula
       s.change_make_var! "JAVALIBDIR", "$(PREFIX)/share/libreadline-java"
       s.change_make_var! "JAVAINCLUDE", ENV["JAVAINCLUDE"]
       s.change_make_var! "JAVANATINC", ENV["JAVANATINC"]
-      on_macos { s.gsub! "*.so", "*.jnilib" }
+      s.gsub! "*.so", "*.jnilib" if OS.mac?
       s.gsub! "install -D", "install -c"
     end
 
@@ -60,7 +63,7 @@ class LibreadlineJava < Formula
       s.change_make_var! "INCLUDES", "-I $(JAVAINCLUDE) -I $(JAVANATINC) -I #{readline.opt_include}"
       s.change_make_var! "LIBPATH", "-L#{readline.opt_lib}"
       s.change_make_var! "CC", "cc"
-      on_macos do
+      if OS.mac?
         s.gsub! "LIB_EXT := so", "LIB_EXT := jnilib"
         s.gsub! "$(CC) -shared $(OBJECTS) $(LIBPATH) $($(TG)_LIBS) -o $@",
                 "$(CC) -install_name #{HOMEBREW_PREFIX}/lib/$(LIB_PRE)$(TG).$(LIB_EXT) " \

--- a/Formula/librespot.rb
+++ b/Formula/librespot.rb
@@ -23,9 +23,7 @@ class Librespot < Formula
   end
 
   def install
-    on_macos do
-      ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path.to_s
-    end
+    ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path.to_s if OS.mac?
     system "cargo", "install", "--no-default-features", "--features", "rodio-backend,with-dns-sd", *std_cargo_args
   end
 

--- a/Formula/libressl.rb
+++ b/Formula/libressl.rb
@@ -51,7 +51,7 @@ class Libressl < Formula
   end
 
   def post_install
-    on_macos do
+    if OS.mac?
       ohai "Regenerating CA certificate bundle from keychain, this may take a while..."
 
       keychains = %w[

--- a/Formula/libscrypt.rb
+++ b/Formula/libscrypt.rb
@@ -18,11 +18,10 @@ class Libscrypt < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       system "make", "install-osx", "PREFIX=#{prefix}", "LDFLAGS=", "CFLAGS_EXTRA="
       system "make", "check", "LDFLAGS=", "CFLAGS_EXTRA="
-    end
-    on_linux do
+    else
       system "make"
       system "make", "check"
       lib.install "libscrypt.a", "libscrypt.so", "libscrypt.so.0"

--- a/Formula/libsvm.rb
+++ b/Formula/libsvm.rb
@@ -21,13 +21,13 @@ class Libsvm < Formula
   end
 
   def install
-    on_linux { ENV.append_to_cflags "-fPIC" }
+    ENV.append_to_cflags "-fPIC" if OS.linux?
     system "make", "CFLAGS=#{ENV.cflags}"
     system "make", "lib"
     bin.install "svm-scale", "svm-train", "svm-predict"
     lib.install "libsvm.so.2" => shared_library("libsvm", 2)
     lib.install_symlink shared_library("libsvm", 2) => shared_library("libsvm")
-    on_macos { MachO::Tools.change_dylib_id("#{lib}/libsvm.2.dylib", "#{lib}/libsvm.2.dylib") }
+    MachO::Tools.change_dylib_id("#{lib}/libsvm.2.dylib", "#{lib}/libsvm.2.dylib") if OS.mac?
     include.install "svm.h"
   end
 

--- a/Formula/libtool.rb
+++ b/Formula/libtool.rb
@@ -37,14 +37,12 @@ class Libtool < Formula
       --enable-ltdl-install
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
 
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       %w[libtool libtoolize].each do |prog|
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
@@ -52,7 +50,7 @@ class Libtool < Formula
       libexec.install_symlink "gnuman" => "man"
     end
 
-    on_linux do
+    if OS.linux?
       bin.install_symlink "libtool" => "glibtool"
       bin.install_symlink "libtoolize" => "glibtoolize"
 

--- a/Formula/liquidctl.rb
+++ b/Formula/liquidctl.rb
@@ -64,15 +64,11 @@ class Liquidctl < Formula
 
     man_page = buildpath/"liquidctl.8"
     # setting the is_macos register to 1 adjusts the man page for macOS
-    on_macos do
-      inreplace man_page, ".nr is_macos 0", ".nr is_macos 1"
-    end
+    inreplace man_page, ".nr is_macos 0", ".nr is_macos 1" if OS.mac?
     man.mkpath
     man8.install man_page
 
-    on_linux do
-      (lib/"udev/rules.d").install Dir["extra/linux/*.rules"]
-    end
+    (lib/"udev/rules.d").install Dir["extra/linux/*.rules"] if OS.linux?
   end
 
   test do

--- a/Formula/llvm@11.rb
+++ b/Formula/llvm@11.rb
@@ -156,16 +156,14 @@ class LlvmAT11 < Formula
       args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}"
     end
 
-    on_macos do
+    if OS.mac?
       args << "-DLLVM_BUILD_LLVM_C_DYLIB=ON"
       args << "-DLLVM_ENABLE_LIBCXX=ON"
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=#{MacOS::Xcode.installed? ? "ON" : "OFF"}"
 
       sdk = MacOS.sdk_path_if_needed
       args << "-DDEFAULT_SYSROOT=#{sdk}" if sdk
-    end
-
-    on_linux do
+    else
       args << "-DLLVM_ENABLE_LIBCXX=OFF"
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=OFF"
       args << "-DCLANG_DEFAULT_CXX_STDLIB=libstdc++"
@@ -268,7 +266,7 @@ class LlvmAT11 < Formula
     # Testing default toolchain and SDK location.
     system "#{bin}/clang++", "-v",
            "-std=c++11", "test.cpp", "-o", "test++"
-    on_macos { assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" }
+    assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" if OS.mac?
     assert_equal "Hello World!", shell_output("./test++").chomp
     system "#{bin}/clang", "-v", "test.c", "-o", "test"
     assert_equal "Hello World!", shell_output("./test").chomp

--- a/Formula/llvm@7.rb
+++ b/Formula/llvm@7.rb
@@ -90,7 +90,7 @@ class LlvmAT7 < Formula
     (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     (buildpath/"projects/openmp").install resource("openmp")
     (buildpath/"projects/libcxx").install resource("libcxx")
-    on_linux { (buildpath/"projects/libcxxabi").install resource("libcxxabi") }
+    (buildpath/"projects/libcxxabi").install resource("libcxxabi") if OS.linux?
     (buildpath/"projects/libunwind").install resource("libunwind")
     (buildpath/"tools/lld").install resource("lld")
     (buildpath/"tools/polly").install resource("polly")
@@ -119,14 +119,14 @@ class LlvmAT7 < Formula
       -DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}
     ]
 
-    on_macos do
+    if OS.mac?
       args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON" if MacOS.version <= :mojave
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=ON"
       args << "-DLLVM_ENABLE_LIBCXX=ON"
       args << "-DDARWIN_osx_ARCHS=x86_64;x86_64h"
     end
 
-    on_linux do
+    if OS.linux?
       args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON"
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=OFF"
       args << "-DLLVM_ENABLE_LIBCXX=OFF"
@@ -186,8 +186,11 @@ class LlvmAT7 < Formula
     man1.install_symlink share/"clang/tools/scan-build/man/scan-build.1"
 
     # install llvm python bindings
-    xz = "2.7"
-    on_linux { xz = "3.8" }
+    xz = if OS.mac?
+      "2.7"
+    else
+      "3.8"
+    end
     (lib/"python#{xz}/site-packages").install buildpath/"bindings/python/llvm"
     (lib/"python#{xz}/site-packages").install buildpath/"tools/clang/bindings/python/clang"
   end
@@ -223,7 +226,7 @@ class LlvmAT7 < Formula
       "-nobuiltininc",
       "-I#{lib}/clang/#{clean_version}/include",
     ]
-    on_linux { args << "-Wl,-rpath=#{lib}" }
+    args << "-Wl,-rpath=#{lib}" if OS.linux?
 
     system "#{bin}/clang", *args, "omptest.c", "-o", "omptest", *ENV["LDFLAGS"].split
     testresult = shell_output("./omptest")
@@ -258,7 +261,7 @@ class LlvmAT7 < Formula
     # Testing default toolchain and SDK location.
     system "#{bin}/clang++", "-v",
            "-std=c++11", "test.cpp", "-o", "test++"
-    on_macos { assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" }
+    assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" if OS.mac?
     assert_equal "Hello World!", shell_output("./test++").chomp
     system "#{bin}/clang", "-v", "test.c", "-o", "test"
     assert_equal "Hello World!", shell_output("./test").chomp

--- a/Formula/llvm@8.rb
+++ b/Formula/llvm@8.rb
@@ -122,7 +122,7 @@ class LlvmAT8 < Formula
     (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     (buildpath/"projects/openmp").install resource("openmp")
     (buildpath/"projects/libcxx").install resource("libcxx")
-    on_linux { (buildpath/"projects/libcxxabi").install resource("libcxxabi") }
+    (buildpath/"projects/libcxxabi").install resource("libcxxabi") if OS.linux?
     (buildpath/"projects/libunwind").install resource("libunwind")
     (buildpath/"tools/lld").install resource("lld")
     (buildpath/"tools/lldb").install resource("lldb")
@@ -156,7 +156,7 @@ class LlvmAT8 < Formula
       -DLIBOMP_INSTALL_ALIASES=OFF
     ]
 
-    on_macos do
+    if OS.mac?
       args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON" if MacOS.version <= :mojave
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=ON"
       args << "-DLLVM_ENABLE_LIBCXX=ON"
@@ -166,7 +166,7 @@ class LlvmAT8 < Formula
       args << "-DDEFAULT_SYSROOT=#{sdk}" if sdk
     end
 
-    on_linux do
+    if OS.linux?
       args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON"
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=OFF"
       args << "-DLLVM_ENABLE_LIBCXX=OFF"
@@ -217,12 +217,15 @@ class LlvmAT8 < Formula
     man1.install_symlink share/"clang/tools/scan-build/man/scan-build.1"
 
     # install llvm python bindings
-    xz = "2.7"
-    on_linux { xz = "3.8" }
+    xz = if OS.mac?
+      "2.7"
+    else
+      "3.8"
+    end
     (lib/"python#{xz}/site-packages").install buildpath/"bindings/python/llvm"
     (lib/"python#{xz}/site-packages").install buildpath/"tools/clang/bindings/python/clang"
 
-    on_linux do
+    if OS.linux?
       # Strip executables/libraries/object files to reduce their size
       system("strip", "--strip-unneeded", "--preserve-dates", *(Dir[bin/"**/*", lib/"**/*"]).select do |f|
         f = Pathname.new(f)
@@ -262,7 +265,7 @@ class LlvmAT8 < Formula
       "-nobuiltininc",
       "-I#{lib}/clang/#{clean_version}/include",
     ]
-    on_linux { args << "-Wl,-rpath=#{lib}" }
+    args << "-Wl,-rpath=#{lib}" if OS.linux?
 
     system "#{bin}/clang", *args, "omptest.c", "-o", "omptest", *ENV["LDFLAGS"].split
     testresult = shell_output("./omptest")
@@ -297,7 +300,7 @@ class LlvmAT8 < Formula
     # Testing default toolchain and SDK location.
     system "#{bin}/clang++", "-v",
            "-std=c++11", "test.cpp", "-o", "test++"
-    on_macos { assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" }
+    assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" if OS.mac?
     assert_equal "Hello World!", shell_output("./test++").chomp
     system "#{bin}/clang", "-v", "test.c", "-o", "test"
     assert_equal "Hello World!", shell_output("./test").chomp

--- a/Formula/llvm@9.rb
+++ b/Formula/llvm@9.rb
@@ -104,7 +104,7 @@ class LlvmAT9 < Formula
     (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     (buildpath/"projects/openmp").install resource("openmp")
     (buildpath/"projects/libcxx").install resource("libcxx")
-    on_linux { (buildpath/"projects/libcxxabi").install resource("libcxxabi") }
+    (buildpath/"projects/libcxxabi").install resource("libcxxabi") if OS.linux?
     (buildpath/"projects/libunwind").install resource("libunwind")
     (buildpath/"tools/lld").install resource("lld")
     (buildpath/"tools/lldb").install resource("lldb")
@@ -144,7 +144,7 @@ class LlvmAT9 < Formula
       args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}"
     end
 
-    on_macos do
+    if OS.mac?
       args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON" if MacOS.version <= :mojave
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=ON"
       args << "-DLLVM_ENABLE_LIBCXX=ON"
@@ -154,7 +154,7 @@ class LlvmAT9 < Formula
       args << "-DDEFAULT_SYSROOT=#{sdk}" if sdk
     end
 
-    on_linux do
+    if OS.linux?
       args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON"
       args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=OFF"
       args << "-DLLVM_ENABLE_LIBCXX=OFF"
@@ -196,8 +196,11 @@ class LlvmAT9 < Formula
     man1.install_symlink share/"clang/tools/scan-build/man/scan-build.1"
 
     # install llvm python bindings
-    xz = "2.7"
-    on_linux { xz = "3.8" }
+    xz = if OS.mac?
+      "2.7"
+    else
+      "3.8"
+    end
     (lib/"python#{xz}/site-packages").install buildpath/"bindings/python/llvm"
     (lib/"python#{xz}/site-packages").install buildpath/"tools/clang/bindings/python/clang"
 
@@ -240,7 +243,7 @@ class LlvmAT9 < Formula
       "-nobuiltininc",
       "-I#{lib}/clang/#{clean_version}/include",
     ]
-    on_linux { args << "-Wl,-rpath=#{lib}" }
+    args << "-Wl,-rpath=#{lib}" if OS.linux?
 
     system "#{bin}/clang", *args, "omptest.c", "-o", "omptest", *ENV["LDFLAGS"].split
     testresult = shell_output("./omptest")
@@ -275,7 +278,7 @@ class LlvmAT9 < Formula
     # Testing default toolchain and SDK location.
     system "#{bin}/clang++", "-v",
            "-std=c++11", "test.cpp", "-o", "test++"
-    on_macos { assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" }
+    assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" if OS.mac?
     assert_equal "Hello World!", shell_output("./test++").chomp
     system "#{bin}/clang", "-v", "test.c", "-o", "test"
     assert_equal "Hello World!", shell_output("./test").chomp

--- a/Formula/lmdb.rb
+++ b/Formula/lmdb.rb
@@ -24,9 +24,7 @@ class Lmdb < Formula
   def install
     cd "libraries/liblmdb" do
       args = []
-      on_macos do
-        args << "SOEXT=.dylib"
-      end
+      args << "SOEXT=.dylib" if OS.mac?
       system "make", *args
       system "make", "install", *args, "prefix=#{prefix}"
     end

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -47,8 +47,11 @@ class Logstash < Formula
 
     # Delete Windows and other Arch/OS files
     rm Dir["bin/*.bat"]
-    os = "Darwin"
-    on_linux { os = "x86_64-Linux" }
+    os = if OS.mac?
+      "Darwin"
+    else
+      "x86_64-Linux"
+    end
     Dir["vendor/jruby/lib/jni/*"].each do |path|
       rm_r path unless path.include? os
     end

--- a/Formula/lp_solve.rb
+++ b/Formula/lp_solve.rb
@@ -15,12 +15,11 @@ class LpSolve < Formula
   end
 
   def install
-    target = ""
-    subdir = "ux64"
-
-    on_macos do
+    subdir = if OS.mac?
       target = ".osx"
-      subdir = "osx64"
+      "osx64"
+    else
+      "ux64"
     end
 
     cd "lpsolve55" do

--- a/Formula/lsof.rb
+++ b/Formula/lsof.rb
@@ -17,8 +17,7 @@ class Lsof < Formula
   keg_only :provided_by_macos
 
   def install
-    os = "linux"
-    on_macos do
+    os = if OS.mac?
       ENV["LSOF_INCLUDE"] = "#{MacOS.sdk_path}/usr/include"
 
       # Source hardcodes full header paths at /usr/include
@@ -28,7 +27,9 @@ class Lsof < Formula
         dialects/darwin/libproc/machine.h
       ], "/usr/include", "#{MacOS.sdk_path}/usr/include"
 
-      os = "darwin"
+      "darwin"
+    else
+      "linux"
     end
 
     ENV["LSOF_CC"] = ENV.cc

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -43,7 +43,7 @@ class Lua < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix: /usr/bin/ld: lapi.o: relocation R_X86_64_32 against `luaO_nilobject_' can not be used
       # when making a shared object; recompile with -fPIC
       # See http://www.linuxfromscratch.org/blfs/view/cvs/general/lua.html
@@ -53,9 +53,7 @@ class Lua < Formula
     # Substitute formula prefix in `src/Makefile` for install name (dylib ID).
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
-      on_macos do
-        s.gsub! "@OPT_LIB@", opt_lib
-      end
+      s.gsub! "@OPT_LIB@", opt_lib if OS.mac?
       s.remove_make_var! "CC"
       s.change_make_var! "MYCFLAGS", ENV.cflags
       s.change_make_var! "MYLDFLAGS", ENV.ldflags
@@ -64,36 +62,19 @@ class Lua < Formula
     # Fix path in the config header
     inreplace "src/luaconf.h", "/usr/local", HOMEBREW_PREFIX
 
-    os = "macosx"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "macosx"
+    else
+      "linux"
     end
 
-    # We ship our own pkg-config file as Lua no longer provide them upstream.
     system "make", os, "INSTALL_TOP=#{prefix}"
     system "make", "install", "INSTALL_TOP=#{prefix}"
-    (lib/"pkgconfig/lua.pc").write pc_file
 
-    # Fix some software potentially hunting for different pc names.
-    bin.install_symlink "lua" => "lua#{version.major_minor}"
-    bin.install_symlink "lua" => "lua-#{version.major_minor}"
-    bin.install_symlink "luac" => "luac#{version.major_minor}"
-    bin.install_symlink "luac" => "luac-#{version.major_minor}"
-    (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
-    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
-
-    on_linux do
-      lib.install Dir[shared_library("src/liblua", "*")]
-    end
-  end
-
-  def pc_file
+    # We ship our own pkg-config file as Lua no longer provide them upstream.
     libs = %w[-llua -lm]
-    on_linux { libs << "-ldl" }
-
-    <<~EOS
+    libs << "-ldl" if OS.linux?
+    (lib/"pkgconfig/lua.pc").write <<~EOS
       V= #{version.major_minor}
       R= #{version}
       prefix=#{HOMEBREW_PREFIX}
@@ -114,6 +95,18 @@ class Lua < Formula
       Libs: -L${libdir} #{libs.join(" ")}
       Cflags: -I${includedir}
     EOS
+
+    # Fix some software potentially hunting for different pc names.
+    bin.install_symlink "lua" => "lua#{version.major_minor}"
+    bin.install_symlink "lua" => "lua-#{version.major_minor}"
+    bin.install_symlink "luac" => "luac#{version.major_minor}"
+    bin.install_symlink "luac" => "luac-#{version.major_minor}"
+    (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
+    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
+    (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
+    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
+
+    lib.install Dir[shared_library("src/liblua", "*")] if OS.linux?
   end
 
   def caveats

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -41,7 +41,7 @@ class LuaAT51 < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix: /usr/bin/ld: lapi.o: relocation R_X86_64_32 against `luaO_nilobject_' can not be used
       # when making a shared object; recompile with -fPIC
       # See http://www.linuxfromscratch.org/blfs/view/cvs/general/lua.html
@@ -50,7 +50,7 @@ class LuaAT51 < Formula
 
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
-      on_macos do
+      if OS.mac?
         s.gsub! "@LUA_PREFIX@", prefix
         s.sub! "MYCFLAGS_VAL", "-fno-common -DLUA_USE_LINUX"
       end
@@ -71,9 +71,10 @@ class LuaAT51 < Formula
       s.gsub! "Libs: -L${libdir} -llua -lm", "Libs: -L${libdir} -llua.5.1 -lm"
     end
 
-    os = "macosx"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "macosx"
+    else
+      "linux"
     end
 
     args = [
@@ -83,9 +84,7 @@ class LuaAT51 < Formula
     ]
 
     system "make", os, *args
-    on_linux do
-      args << "TO_LIB=liblua.so.5.1.5"
-    end
+    args << "TO_LIB=liblua.so.5.1.5" if OS.linux?
     system "make", "install", *args
 
     (lib/"pkgconfig").install "etc/lua.pc"
@@ -105,7 +104,7 @@ class LuaAT51 < Formula
     (lib/"pkgconfig").install_symlink "lua-5.1.pc" => "lua5.1.pc"
     (libexec/"lib/pkgconfig").install_symlink lib/"pkgconfig/lua-5.1.pc" => "lua.pc"
 
-    on_linux do
+    if OS.linux?
       # Hack around wrong .so file naming
       %w[.so.5.1 .5.1.5.so .5.1.so 5.1.so].each do |suffix|
         lib.install_symlink "liblua.so.5.1.5" => "liblua#{suffix}"

--- a/Formula/lua@5.3.rb
+++ b/Formula/lua@5.3.rb
@@ -44,7 +44,7 @@ class LuaAT53 < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix: /usr/bin/ld: lapi.o: relocation R_X86_64_32 against `luaO_nilobject_' can not be used
       # when making a shared object; recompile with -fPIC
       # See http://www.linuxfromscratch.org/blfs/view/cvs/general/lua.html
@@ -54,9 +54,7 @@ class LuaAT53 < Formula
     # Substitute formula prefix in `src/Makefile` for install name (dylib ID).
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
-      on_macos do
-        s.gsub! "@LUA_PREFIX@", prefix
-      end
+      s.gsub! "@LUA_PREFIX@", prefix if OS.mac?
       s.remove_make_var! "CC"
       s.change_make_var! "CFLAGS", "#{ENV.cflags} -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS)"
       s.change_make_var! "MYLDFLAGS", ENV.ldflags
@@ -65,36 +63,19 @@ class LuaAT53 < Formula
     # Fix path in the config header
     inreplace "src/luaconf.h", "/usr/local", HOMEBREW_PREFIX
 
-    os = "macosx"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "macosx"
+    else
+      "linux"
     end
 
-    # We ship our own pkg-config file as Lua no longer provide them upstream.
     system "make", os, "INSTALL_TOP=#{prefix}", "INSTALL_INC=#{include}/lua", "INSTALL_MAN=#{man1}"
     system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_INC=#{include}/lua", "INSTALL_MAN=#{man1}"
-    (lib/"pkgconfig/lua.pc").write pc_file
 
-    # Fix some software potentially hunting for different pc names.
-    bin.install_symlink "lua" => "lua#{version.major_minor}"
-    bin.install_symlink "lua" => "lua-#{version.major_minor}"
-    bin.install_symlink "luac" => "luac#{version.major_minor}"
-    bin.install_symlink "luac" => "luac-#{version.major_minor}"
-    (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
-    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
-
-    on_linux do
-      lib.install Dir[shared_library("src/liblua", "*")]
-    end
-  end
-
-  def pc_file
+    # We ship our own pkg-config file as Lua no longer provide them upstream.
     libs = %W[-llua#{version.major_minor} -lm]
-    on_linux { libs << "-ldl" }
-
-    <<~EOS
+    libs << "-ldl" if OS.linux?
+    (lib/"pkgconfig/lua.pc").write <<~EOS
       V= #{version.major_minor}
       R= #{version}
       prefix=#{opt_prefix}
@@ -115,6 +96,18 @@ class LuaAT53 < Formula
       Libs: -L${libdir} #{libs.join(" ")}
       Cflags: -I${includedir}
     EOS
+
+    # Fix some software potentially hunting for different pc names.
+    bin.install_symlink "lua" => "lua#{version.major_minor}"
+    bin.install_symlink "lua" => "lua-#{version.major_minor}"
+    bin.install_symlink "luac" => "luac#{version.major_minor}"
+    bin.install_symlink "luac" => "luac-#{version.major_minor}"
+    (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
+    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
+    (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
+    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
+
+    lib.install Dir[shared_library("src/liblua", "*")] if OS.linux?
   end
 
   def caveats

--- a/Formula/lv.rb
+++ b/Formula/lv.rb
@@ -33,7 +33,7 @@ class Lv < Formula
   patch :DATA
 
   def install
-    on_macos do
+    if OS.mac?
       # zcat doesn't handle gzip'd data on OSX.
       # Reported upstream to nrt@ff.iij4u.or.jp
       inreplace "src/stream.c", 'gz_filter = "zcat"', 'gz_filter = "gzcat"'

--- a/Formula/make.rb
+++ b/Formula/make.rb
@@ -24,13 +24,11 @@ class Make < Formula
       --prefix=#{prefix}
     ]
 
-    on_macos do
-      args << "--program-prefix=g"
-    end
+    args << "--program-prefix=g" if OS.mac?
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gmake" =>"make"
       (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
     end

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -34,7 +34,7 @@ class Makensis < Formula
       "STRIP=0",
       "VERSION=#{version}",
     ]
-    on_linux { args << "APPEND_LINKFLAGS=-Wl,-rpath,#{rpath}" }
+    args << "APPEND_LINKFLAGS=-Wl,-rpath,#{rpath}" if OS.linux?
 
     system "scons", "makensis", *args
     bin.install "build/urelease/makensis/makensis"

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -79,7 +79,7 @@ class Mariadb < Formula
       -DCOMPILATION_COMMENT=#{tap.user}
     ]
 
-    on_linux do
+    if OS.linux?
       args << "-DWITH_NUMA=OFF"
       args << "-DENABLE_DTRACE=NO"
       args << "-DCONNECT_WITH_JDBC=OFF"

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -85,7 +85,7 @@ class MariadbAT102 < Formula
       -DCOMPILATION_COMMENT=Homebrew
     ]
 
-    on_linux do
+    if OS.linux?
       args << "-DWITH_NUMA=OFF"
       args << "-DENABLE_DTRACE=NO"
       args << "-DCONNECT_WITH_JDBC=OFF"

--- a/Formula/mariadb@10.3.rb
+++ b/Formula/mariadb@10.3.rb
@@ -78,7 +78,7 @@ class MariadbAT103 < Formula
       -DCOMPILATION_COMMENT=Homebrew
     ]
 
-    on_linux do
+    if OS.linux?
       args << "-DWITH_NUMA=OFF"
       args << "-DENABLE_DTRACE=NO"
       args << "-DCONNECT_WITH_JDBC=OFF"

--- a/Formula/mariadb@10.4.rb
+++ b/Formula/mariadb@10.4.rb
@@ -78,7 +78,7 @@ class MariadbAT104 < Formula
       -DCOMPILATION_COMMENT=Homebrew
     ]
 
-    on_linux do
+    if OS.linux?
       args << "-DWITH_NUMA=OFF"
       args << "-DENABLE_DTRACE=NO"
       args << "-DCONNECT_WITH_JDBC=OFF"

--- a/Formula/mariadb@10.5.rb
+++ b/Formula/mariadb@10.5.rb
@@ -79,7 +79,7 @@ class MariadbAT105 < Formula
       -DCOMPILATION_COMMENT=#{tap.user}
     ]
 
-    on_linux do
+    if OS.linux?
       args << "-DWITH_NUMA=OFF"
       args << "-DENABLE_DTRACE=NO"
       args << "-DCONNECT_WITH_JDBC=OFF"

--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -71,9 +71,7 @@ class Mavsdk < Formula
     # Fix version being reported as `v#{version}-dirty`
     inreplace "CMakeLists.txt", "OUTPUT_VARIABLE VERSION_STR", "OUTPUT_VARIABLE VERSION_STR_IGNORED"
 
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
     # Install protoc-gen-mavsdk deps
     venv_dir = buildpath/"bootstrap"
@@ -108,7 +106,7 @@ class Mavsdk < Formula
 
   test do
     # Force use of Clang on Mojave
-    on_macos { ENV.clang }
+    ENV.clang if OS.mac?
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -84,7 +84,7 @@ class Mesa < Formula
     mkdir "build" do
       args = ["-Db_ndebug=true"]
 
-      on_linux do
+      if OS.linux?
         args << "-Dplatforms=x11,wayland"
         args << "-Dglx=auto"
         args << "-Ddri3=true"
@@ -106,7 +106,7 @@ class Mesa < Formula
       system "ninja", "install"
     end
 
-    on_linux do
+    if OS.linux?
       # Strip executables/libraries/object files to reduce their size
       system("strip", "--strip-unneeded", "--preserve-dates", *(Dir[bin/"**/*", lib/"**/*"]).select do |f|
         f = Pathname.new(f)

--- a/Formula/midnight-commander.rb
+++ b/Formula/midnight-commander.rb
@@ -53,9 +53,7 @@ class MidnightCommander < Formula
     system "./configure", *args
     system "make", "install"
 
-    on_macos do
-      inreplace share/"mc/syntax/Syntax", HOMEBREW_SHIMS_PATH/"mac/super", "/usr/bin"
-    end
+    inreplace share/"mc/syntax/Syntax", HOMEBREW_SHIMS_PATH/"mac/super", "/usr/bin" if OS.mac?
   end
 
   test do

--- a/Formula/minicom.rb
+++ b/Formula/minicom.rb
@@ -21,9 +21,7 @@ class Minicom < Formula
 
   def install
     # There is a silly bug in the Makefile where it forgets to link to iconv. Workaround below.
-    on_macos do
-      ENV["LIBS"] = "-liconv"
-    end
+    ENV["LIBS"] = "-liconv" if OS.mac?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -47,9 +47,7 @@ class MinimalRacket < Formula
       ]
 
       ENV["LDFLAGS"] = "-rpath #{Formula["openssl@1.1"].opt_lib}"
-      on_linux do
-        ENV["LDFLAGS"] = "-Wl,-rpath=#{Formula["openssl@1.1"].opt_lib}"
-      end
+      ENV["LDFLAGS"] = "-Wl,-rpath=#{Formula["openssl@1.1"].opt_lib}" if OS.linux?
 
       system "./configure", *args
       system "make"

--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -34,7 +34,7 @@ class Minizip < Formula
     system "make"
 
     cd "contrib/minizip" do
-      on_macos do
+      if OS.mac?
         # edits to statically link to libz.a
         inreplace "Makefile.am" do |s|
           s.sub! "-L$(zlib_top_builddir)", "$(zlib_top_builddir)/libz.a"

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -72,7 +72,7 @@ class MitScheme < Formula
     inreplace "microcode/configure" do |s|
       s.gsub! "/usr/local", prefix
 
-      on_macos do
+      if OS.mac?
         # Fixes "configure: error: No MacOSX SDK for version: 10.10"
         # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47769
         s.gsub!(/SDK=MacOSX\$\{MACOS\}$/, "SDK=MacOSX#{MacOS.sdk.version}")

--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -45,7 +45,7 @@ class Mmseqs2 < Formula
       "-DHAVE_SSE4_1=1"
     end
 
-    on_macos do
+    if OS.mac?
       libomp = Formula["libomp"]
       args << "-DOpenMP_C_FLAGS=-Xpreprocessor\ -fopenmp\ -I#{libomp.opt_include}"
       args << "-DOpenMP_C_LIB_NAMES=omp"

--- a/Formula/modules.rb
+++ b/Formula/modules.rb
@@ -32,7 +32,7 @@ class Modules < Formula
       --without-x
     ]
 
-    on_linux do
+    if OS.linux?
       args << "--with-pager=#{Formula["less"].opt_bin}/less"
       args << "--with-tclsh=#{Formula["tcl-tk"].opt_bin}/tclsh"
     end
@@ -52,11 +52,11 @@ class Modules < Formula
 
   test do
     assert_match "restore", shell_output("#{bin}/envml --help")
-    shell = "zsh"
-    on_linux { shell = "sh" }
-    cmd = "source"
-    on_linux { cmd = "." }
-
+    shell, cmd = if OS.mac?
+      ["zsh", "source"]
+    else
+      ["sh", "."]
+    end
     output = shell_output("#{shell} -c '#{cmd} #{prefix}/init/#{shell}; module' 2>&1")
     assert_match version.to_s, output
   end

--- a/Formula/mongoose.rb
+++ b/Formula/mongoose.rb
@@ -25,10 +25,8 @@ class Mongoose < Formula
       bin.install "mongoose_mac" => "mongoose"
     end
 
-    on_macos do
-      system ENV.cc, "-dynamiclib", "mongoose.c", "-o", "libmongoose.dylib"
-    end
-    on_linux do
+    system ENV.cc, "-dynamiclib", "mongoose.c", "-o", "libmongoose.dylib" if OS.mac?
+    if OS.linux?
       system ENV.cc, "-fPIC", "-c", "mongoose.c"
       system ENV.cc, "-shared", "-Wl,-soname,libmongoose.so", "-o", "libmongoose.so", "mongoose.o", "-lc", "-lpthread"
     end

--- a/Formula/mongrel2.rb
+++ b/Formula/mongrel2.rb
@@ -39,9 +39,7 @@ class Mongrel2 < Formula
 
     # Mongrel2 pulls from these ENV vars instead
     ENV["OPTFLAGS"] = "#{ENV.cflags} #{ENV.cppflags}"
-    on_macos do
-      ENV["OPTLIBS"] = "#{ENV.ldflags} -undefined dynamic_lookup"
-    end
+    ENV["OPTLIBS"] = "#{ENV.ldflags} -undefined dynamic_lookup" if OS.mac?
 
     system "make", "all"
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/monkeysphere.rb
+++ b/Formula/monkeysphere.rb
@@ -50,8 +50,11 @@ class Monkeysphere < Formula
     ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin"
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
-    res = resources
-    on_macos { res = [resource("Crypt::OpenSSL::Bignum")] if MacOS.version <= :catalina }
+    res = if OS.mac? && MacOS.version <= :catalina
+      [resource("Crypt::OpenSSL::Bignum")]
+    else
+      resources
+    end
 
     res.each do |r|
       r.stage do

--- a/Formula/mpg123.rb
+++ b/Formula/mpg123.rb
@@ -27,9 +27,7 @@ class Mpg123 < Formula
       --with-module-suffix=.so
     ]
 
-    on_macos do
-      args << "--with-default-audio=coreaudio"
-    end
+    args << "--with-default-audio=coreaudio" if OS.mac?
 
     args << if Hardware::CPU.arm?
       "--with-cpu=aarch64"

--- a/Formula/mpich.rb
+++ b/Formula/mpich.rb
@@ -79,7 +79,7 @@ class Mpich < Formula
     args << "CXXFLAGS=-Wno-deprecated"
     args << "CFLAGS=-fgnu89-inline -Wno-deprecated"
 
-    on_linux do
+    if OS.linux?
       # Use libfabric https://lists.mpich.org/pipermail/discuss/2021-January/006092.html
       args << "--with-device=ch4:ofi"
       args << "--with-libfabric=#{Formula["libfabric"].opt_prefix}"

--- a/Formula/mtools.rb
+++ b/Formula/mtools.rb
@@ -26,9 +26,7 @@ class Mtools < Formula
       --sysconfdir=#{etc}
       --without-x
     ]
-    on_macos do
-      args << "LIBS=-liconv"
-    end
+    args << "LIBS=-liconv" if OS.mac?
 
     # The mtools configure script incorrectly detects stat64. This forces it off
     # to fix build errors on Apple Silicon. See stat(6) and pv.rb.

--- a/Formula/muparser.rb
+++ b/Formula/muparser.rb
@@ -19,7 +19,7 @@ class Muparser < Formula
   depends_on "cmake" => :build
 
   def install
-    on_linux { ENV.cxx11 }
+    ENV.cxx11 if OS.linux?
     mkdir "build" do
       system "cmake", "..", *std_cmake_args, "-DENABLE_OPENMP=OFF"
       system "make", "install"

--- a/Formula/mydumper.rb
+++ b/Formula/mydumper.rb
@@ -30,7 +30,7 @@ class Mydumper < Formula
     ]
     # find_package(ZLIB) has trouble on Big Sur since physical libz.dylib
     # doesn't exist on the filesystem.  Instead provide details ourselves:
-    on_macos do
+    if OS.mac?
       args << "-DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=1"
       args << "-DZLIB_INCLUDE_DIRS=/usr/include"
       args << "-DZLIB_LIBRARIES=-lz"

--- a/Formula/myman.rb
+++ b/Formula/myman.rb
@@ -32,7 +32,7 @@ class Myman < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       ENV["RMDIR"] = "grmdir"
       ENV["SED"] = "gsed"
       ENV["INSTALL"] = "ginstall"

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -53,7 +53,7 @@ class Mysql < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix libmysqlgcs.a(gcs_logging.cc.o): relocation R_X86_64_32
       # against `_ZN17Gcs_debug_options12m_debug_noneB5cxx11E' can not be used when making
       # a shared object; recompile with -fPIC

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -67,9 +67,10 @@ class MysqlAT56 < Formula
     system "make", "install"
 
     # Avoid references to the Homebrew shims directory
-    os = "mac"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "mac"
+    else
+      "linux"
     end
     inreplace bin/"mysqlbug", HOMEBREW_SHIMS_PATH/"#{os}/super/", ""
 
@@ -161,16 +162,16 @@ index 34ed6f4..4becbbc 100644
 --- a/cmake/mysql_version.cmake
 +++ b/cmake/mysql_version.cmake
 @@ -31,7 +31,7 @@ SET(DOT_FRM_VERSION "6")
- 
+
  # Generate "something" to trigger cmake rerun when VERSION changes
  CONFIGURE_FILE(
 -  ${CMAKE_SOURCE_DIR}/VERSION
 +  ${CMAKE_SOURCE_DIR}/MYSQL_VERSION
    ${CMAKE_BINARY_DIR}/VERSION.dep
  )
- 
+
 @@ -39,7 +39,7 @@ CONFIGURE_FILE(
- 
+
  MACRO(MYSQL_GET_CONFIG_VALUE keyword var)
   IF(NOT ${var})
 -   FILE (STRINGS ${CMAKE_SOURCE_DIR}/VERSION str REGEX "^[ ]*${keyword}=")
@@ -178,4 +179,3 @@ index 34ed6f4..4becbbc 100644
     IF(str)
       STRING(REPLACE "${keyword}=" "" str ${str})
       STRING(REGEX REPLACE  "[ ].*" ""  str "${str}")
-

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -38,7 +38,7 @@ class MysqlAT57 < Formula
   patch :DATA
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix libmysqlgcs.a(gcs_logging.cc.o): relocation R_X86_64_32
       # against `_ZN17Gcs_debug_options12m_debug_noneB5cxx11E' can not be used when making
       # a shared object; recompile with -fPIC

--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -72,9 +72,9 @@ class Mytop < Formula
 
   def install
     res = resources
-    on_macos do
+    if OS.mac? && (MacOS.version < :mojave)
       # Before Mojave, DBI was part of the system Perl
-      res -= [resource("DBI")] if MacOS.version < :mojave
+      res -= [resource("DBI")]
     end
 
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"

--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -35,9 +35,7 @@ class Ncmpcpp < Formula
   def install
     ENV.cxx11
 
-    on_macos do
-      ENV.append "LDFLAGS", "-liconv"
-    end
+    ENV.append "LDFLAGS", "-liconv" if OS.mac?
 
     ENV.append "BOOST_LIB_SUFFIX", "-mt"
     ENV.append "CXXFLAGS", "-D_XOPEN_SOURCE_EXTENDED"

--- a/Formula/ncurses.rb
+++ b/Formula/ncurses.rb
@@ -35,9 +35,7 @@ class Ncurses < Formula
       "--with-gpm=no",
       "--without-ada",
     ]
-    on_linux do
-      args << "--with-terminfo-dirs=#{share}/terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo"
-    end
+    args << "--with-terminfo-dirs=#{share}/terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo" if OS.linux?
     system "./configure", *args
     system "make", "install"
     make_libncurses_symlinks

--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -78,14 +78,14 @@ class Neko < Formula
     # Also, no reason for maria-connector to compile its own version of zlib,
     # just link against the system copy.
     mysql_cmake_args = ["-Wno-dev", "-DWITH_EXTERNAL_ZLIB=1"]
-    on_macos do
+    if OS.mac?
       mysql_cmake_args << "-DICONV_LIBRARIES=-liconv"
       mysql_cmake_args << "-DICONV_INCLUDE_DIR="
     end
     inreplace "libs/mysql/CMakeLists.txt", "-Wno-dev", mysql_cmake_args.join(" ")
 
     args = std_cmake_args
-    on_linux do
+    if OS.linux?
       args << "-DAPR_LIBRARY=#{Formula["apr"].opt_lib}"
       args << "-DAPR_INCLUDE_DIR=#{Formula["apr"].opt_include}/apr-1"
       args << "-DAPRUTIL_LIBRARY=#{Formula["apr-util"].opt_lib}"

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -52,9 +52,7 @@ class Neomutt < Formula
       --with-ui=ncurses
     ]
 
-    on_linux do
-      args << "--pkgconf"
-    end
+    args << "--pkgconf" if OS.linux?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -105,13 +105,11 @@ class Netcdf < Formula
       lib/"libnetcdf.settings", lib/"libnetcdf-cxx.settings"
     ], %r{#{HOMEBREW_SHIMS_PATH}/[^/]+/super/#{ENV.cc}}, ENV.cc
 
-    on_linux do
+    if OS.linux?
       inreplace bin/"ncxx4-config",
                 %r{#{HOMEBREW_SHIMS_PATH}/[^/]+/super/#{Regexp.escape(ENV.cxx)}},
                 ENV.cxx
-    end
-
-    on_macos do
+    else
       # SIP causes system Python not to play nicely with @rpath
       libnetcdf = (lib/"libnetcdf.dylib").readlink
       macho = MachO.open("#{lib}/libnetcdf-cxx4.dylib")

--- a/Formula/netdata.rb
+++ b/Formula/netdata.rb
@@ -70,11 +70,10 @@ class Netdata < Formula
       --enable-dbengine
       --with-user=netdata
     ]
-    on_macos do
+    if OS.mac?
       args << "UUID_LIBS=-lc"
       args << "UUID_CFLAGS=-I/usr/include"
-    end
-    on_linux do
+    else
       args << "UUID_LIBS=-luuid"
       args << "UUID_CFLAGS=-I#{Formula["util-linux"].opt_include}"
     end

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -50,14 +50,12 @@ class Netpbm < Formula
       s.change_make_var! "JASPERLIB", "-ljasper"
       s.change_make_var! "JASPERHDR_DIR", "#{Formula["jasper"].opt_include}/jasper"
 
-      on_macos do
+      if OS.mac?
         s.change_make_var! "CFLAGS_SHLIB", "-fno-common"
         s.change_make_var! "NETPBMLIBTYPE", "dylib"
         s.change_make_var! "NETPBMLIBSUFFIX", "dylib"
         s.change_make_var! "LDSHLIB", "--shared -o $(SONAME)"
-      end
-
-      on_linux do
+      else
         s.change_make_var! "CFLAGS_SHLIB", "-fPIC"
       end
     end

--- a/Formula/newrelic-cli.rb
+++ b/Formula/newrelic-cli.rb
@@ -19,10 +19,9 @@ class NewrelicCli < Formula
   def install
     ENV["PROJECT_VER"] = version
     system "make", "compile-only"
-    on_macos do
+    if OS.mac?
       bin.install "bin/darwin/newrelic"
-    end
-    on_linux do
+    else
       bin.install "bin/linux/newrelic"
     end
 

--- a/Formula/newrelic-infra-agent.rb
+++ b/Formula/newrelic-infra-agent.rb
@@ -20,20 +20,18 @@ class NewrelicInfraAgent < Formula
   def install
     goarch = Hardware::CPU.arm? ? "arm64" : "amd64"
     ENV["VERSION"] = version.to_s
-    os = "darwin"
-    ENV["CGO_ENABLED"] = "1"
-    on_linux do
-      os = "linux"
+    ENV["GOOS"] = if OS.mac?
+      ENV["CGO_ENABLED"] = "1"
+      "darwin"
+    else
       ENV["CGO_ENABLED"] = "0"
+      "linux"
     end
-    ENV["GOOS"] = os
     system "make", "dist-for-os"
     bin.install "dist/#{os}-newrelic-infra_#{os}_#{goarch}/newrelic-infra"
     bin.install "dist/#{os}-newrelic-infra-ctl_#{os}_#{goarch}/newrelic-infra-ctl"
     bin.install "dist/#{os}-newrelic-infra-service_#{os}_#{goarch}/newrelic-infra-service"
-    on_macos do
-      (var/"db/newrelic-infra").install "assets/licence/LICENSE.macos.txt"
-    end
+    (var/"db/newrelic-infra").install "assets/licence/LICENSE.macos.txt" if OS.mac?
   end
 
   def post_install

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -31,7 +31,7 @@ class Newt < Formula
   def install
     args = ["--prefix=#{prefix}", "--without-tcl"]
 
-    on_macos do
+    if OS.mac?
       inreplace "Makefile.in" do |s|
         # name libraries correctly
         # https://bugzilla.redhat.com/show_bug.cgi?id=1192285

--- a/Formula/ngircd.rb
+++ b/Formula/ngircd.rb
@@ -32,7 +32,7 @@ class Ngircd < Formula
                           "--with-openssl"
     system "make", "install"
 
-    on_macos do
+    if OS.mac?
       prefix.install "contrib/MacOSX/de.barton.ngircd.plist.tmpl" => "de.barton.ngircd.plist"
       (prefix/"de.barton.ngircd.plist").chmod 0644
 

--- a/Formula/ngrep.rb
+++ b/Formula/ngrep.rb
@@ -31,14 +31,12 @@ class Ngrep < Formula
       "--disable-pcap-restart",
     ]
 
-    on_macos do
+    args << if OS.mac?
       # this line required to make configure succeed
-      args << "--with-pcap-includes=#{sdk}/usr/include/pcap"
-    end
-
-    on_linux do
+      "--with-pcap-includes=#{sdk}/usr/include/pcap"
+    else
       # this line required to make configure succeed
-      args << "--with-pcap-includes=#{Formula["libpcap"].opt_include}/pcap"
+      "--with-pcap-includes=#{Formula["libpcap"].opt_include}/pcap"
     end
 
     system "./configure", *args

--- a/Formula/node@12.rb
+++ b/Formula/node@12.rb
@@ -38,7 +38,7 @@ class NodeAT12 < Formula
     term_size_vendor_dir = lib/"node_modules/npm/node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/node@14.rb
+++ b/Formula/node@14.rb
@@ -38,7 +38,7 @@ class NodeAT14 < Formula
     term_size_vendor_dir = lib/"node_modules/npm/node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/nspr.rb
+++ b/Formula/nspr.rb
@@ -32,7 +32,7 @@ class Nspr < Formula
       ]
       system "./configure", *args
 
-      on_macos do
+      if OS.mac?
         # Remove the broken (for anyone but Firefox) install_name
         inreplace "config/autoconf.mk", "-install_name @executable_path/$@ ", "-install_name #{lib}/$@ "
       end

--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -50,8 +50,11 @@ class Nss < Formula
     # rather than copying the referenced file.
     cd "../dist"
     bin.mkpath
-    os = "Darwin"
-    on_linux { os = "Linux" }
+    os = if OS.mac?
+      "Darwin"
+    else
+      "Linux"
+    end
     Dir.glob("#{os}*/bin/*") do |file|
       cp file, bin unless file.include? ".dylib"
     end

--- a/Formula/nut.rb
+++ b/Formula/nut.rb
@@ -70,11 +70,10 @@ class Nut < Formula
       --without-snmp
       --without-wrap
     ]
-    on_macos do
-      args << "--with-macosx_ups"
-    end
-    on_linux do
-      args << "--with-udev-dir=#{lib}/udev"
+    args << if OS.mac?
+      "--with-macosx_ups"
+    else
+      "--with-udev-dir=#{lib}/udev"
     end
 
     system "./configure", *args

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -30,13 +30,11 @@ class Nzbget < Formula
 
     # Fix "ncurses library not found"
     # Reported 14 Aug 2016: https://github.com/nzbget/nzbget/issues/264
-    on_macos do
+    if OS.mac?
       (buildpath/"brew_include").install_symlink MacOS.sdk_path/"usr/include/ncurses.h"
       ENV["ncurses_CFLAGS"] = "-I#{buildpath}/brew_include"
       ENV["ncurses_LIBS"] = "-L/usr/lib -lncurses"
-    end
-
-    on_linux do
+    else
       ENV["ncurses_CFLAGS"] = "-I#{Formula["ncurses"].opt_include}"
       ENV["ncurses_LIBS"] = "-L#{Formula["ncurses"].opt_lib} -lncurses"
     end
@@ -52,7 +50,7 @@ class Nzbget < Formula
 
     # Set upstream's recommended values for file systems without
     # sparse-file support (e.g., HFS+); see Homebrew/homebrew-core#972
-    on_macos do
+    if OS.mac?
       inreplace "nzbget.conf", "DirectWrite=yes", "DirectWrite=no"
       inreplace "nzbget.conf", "ArticleCache=0", "ArticleCache=700"
     end

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -103,7 +103,7 @@ class Octave < Formula
             "--with-portaudio",
             "--with-sndfile"]
 
-    on_linux do
+    if OS.linux?
       # Explicitly specify aclocal and automake without versions
       args << "ACLOCAL=aclocal"
       args << "AUTOMAKE=automake"

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -93,7 +93,7 @@ class Opencv < Formula
     ]
 
     # Disable precompiled headers and force opencv to use brewed libraries on Linux
-    on_linux do
+    if OS.linux?
       args << "-DENABLE_PRECOMPILED_HEADERS=OFF"
       args << "-DJPEG_LIBRARY=#{Formula["libjpeg"].opt_lib}/libjpeg.so"
       args << "-DOpenBLAS_LIB=#{Formula["openblas"].opt_lib}/libopenblas.so"

--- a/Formula/opencv@3.rb
+++ b/Formula/opencv@3.rb
@@ -88,9 +88,10 @@ class OpencvAT3 < Formula
     end
 
     mkdir "build" do
-      os = "mac"
-      on_linux do
-        os = "linux"
+      os = if OS.mac?
+        "mac"
+      else
+        "linux"
       end
       system "cmake", "..", *args
       inreplace "modules/core/version_string.inc", "#{HOMEBREW_SHIMS_PATH}/#{os}/super/", ""

--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -54,9 +54,10 @@ class Openimageio < Formula
 
     # CMake picks up the system's python shared library, even if we have a brewed one.
     py3ver = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
-    py3prefix = Formula["python@3.9"].opt_frameworks/"Python.framework/Versions/#{py3ver}"
-    on_linux do
-      py3prefix = Formula["python@3.9"].opt_prefix
+    py3prefix = if OS.mac?
+      Formula["python@3.9"].opt_frameworks/"Python.framework/Versions/#{py3ver}"
+    else
+      Formula["python@3.9"].opt_prefix
     end
 
     ENV["PYTHONPATH"] = lib/"python#{py3ver}/site-packages"

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -72,9 +72,7 @@ class Openjdk < Formula
   def install
     boot_jdk = Pathname.pwd/"boot-jdk"
     resource("boot-jdk").stage boot_jdk
-    on_macos do
-      boot_jdk /= "Contents/Home"
-    end
+    boot_jdk /= "Contents/Home" if OS.mac?
     java_options = ENV.delete("_JAVA_OPTIONS")
 
     args = %W[
@@ -95,7 +93,7 @@ class Openjdk < Formula
     ]
 
     framework_path = nil
-    on_macos do
+    if OS.mac?
       args += %W[
         --enable-dtrace
         --with-extra-ldflags=-headerpad_max_install_names
@@ -117,9 +115,7 @@ class Openjdk < Formula
           "--with-extra-ldflags=-arch arm64 -F#{framework_path}",
         ]
       end
-    end
-
-    on_linux do
+    else
       args += %W[
         --with-x=#{HOMEBREW_PREFIX}
         --with-cups=#{HOMEBREW_PREFIX}
@@ -133,7 +129,7 @@ class Openjdk < Formula
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"
     system "make", "images"
 
-    on_macos do
+    if OS.mac?
       jdk = Dir["build/*/images/jdk-bundle/*"].first
       libexec.install jdk => "openjdk.jdk"
       bin.install_symlink Dir[libexec/"openjdk.jdk/Contents/Home/bin/*"]
@@ -150,9 +146,7 @@ class Openjdk < Formula
         # Replace Apple signature by ad-hoc one (otherwise relocation will break it)
         system "codesign", "-f", "-s", "-", dest/"Versions/A/JavaNativeFoundation"
       end
-    end
-
-    on_linux do
+    else
       libexec.install Dir["build/linux-x86_64-server-release/images/jdk/*"]
       bin.install_symlink Dir[libexec/"bin/*"]
       include.install_symlink Dir[libexec/"include/*.h"]

--- a/Formula/openjdk@8.rb
+++ b/Formula/openjdk@8.rb
@@ -64,7 +64,7 @@ class OpenjdkAT8 < Formula
     inreplace "hotspot/make/bsd/makefiles/saproc.make",
               '-isysroot "$(SDKPATH)" -iframework"$(SDKPATH)/System/Library/Frameworks"', ""
 
-    on_macos do
+    if OS.mac?
       # Fix macOS version detection. After 10.10 this was changed to a 6 digit number,
       # but this Makefile was written in the era of 4 digit numbers.
       inreplace "hotspot/make/bsd/makefiles/gcc.make" do |s|
@@ -73,7 +73,7 @@ class OpenjdkAT8 < Formula
       end
     end
 
-    on_linux do
+    if OS.linux?
       # Fix linker errors on brewed GCC
       inreplace "common/autoconf/flags.m4", "-Xlinker -O1", ""
       inreplace "hotspot/make/linux/makefiles/gcc.make", "-Xlinker -O1", ""
@@ -94,7 +94,7 @@ class OpenjdkAT8 < Formula
       --with-vendor-vm-bug-url=#{tap.issues_url}
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--with-toolchain-type=clang"
 
       # Work around SDK issues with JavaVM framework.
@@ -106,9 +106,7 @@ class OpenjdkAT8 < Formula
                    --with-extra-cxxflags=-F#{javavm_framework_path}
                    --with-extra-ldflags=-F#{javavm_framework_path}]
       end
-    end
-
-    on_linux do
+    else
       args += %W[--with-toolchain-type=gcc
                  --x-includes=#{HOMEBREW_PREFIX}/include
                  --x-libraries=#{HOMEBREW_PREFIX}/lib
@@ -127,12 +125,12 @@ class OpenjdkAT8 < Formula
     cd "build/release/images" do
       jdk = libexec
 
-      on_macos do
+      if OS.mac?
         libexec.install Dir["j2sdk-bundle/*"].first => "openjdk.jdk"
         jdk /= "openjdk.jdk/Contents/Home"
+      else
+        libexec.install Dir["j2sdk-image/*"]
       end
-
-      on_linux { libexec.install Dir["j2sdk-image/*"] }
 
       bin.install_symlink Dir[jdk/"bin/*"]
       include.install_symlink Dir[jdk/"include/*.h"]

--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -52,7 +52,7 @@ class Openldap < Formula
       --enable-valsort
     ]
 
-    on_linux do
+    if OS.linux?
       args << "--without-systemd"
 
       # Disable manpage generation, because it requires groff which has a huge

--- a/Formula/openmotif.rb
+++ b/Formula/openmotif.rb
@@ -36,7 +36,7 @@ class Openmotif < Formula
     because: "both Lesstif and Openmotif are complete replacements for each other"
 
   def install
-    on_linux do
+    if OS.linux?
       # This patch is needed for Ubuntu 16.04 LTS, which uses
       # --as-needed with ld.  It should no longer
       # be needed on Ubuntu 18.04 LTS.

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -41,18 +41,15 @@ class Openmsx < Formula
     inreplace "build/probe.py", "/usr/local", HOMEBREW_PREFIX
 
     # Help finding Tcl (https://github.com/openMSX/openMSX/issues/1082)
-    on_macos do
-      ENV["TCL_CONFIG"] = "#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
-    end
+    ENV["TCL_CONFIG"] = "#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework" if OS.mac?
 
     system "./configure"
     system "make"
 
-    on_macos do
+    if OS.mac?
       prefix.install Dir["derived/**/openMSX.app"]
       bin.write_exec_script "#{prefix}/openMSX.app/Contents/MacOS/openmsx"
-    end
-    on_linux do
+    else
       system "make", "install"
     end
   end

--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -38,11 +38,13 @@ class OpenshiftCli < Formula
 
   def install
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    os = "darwin"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "darwin"
+    else
       # See https://github.com/golang/go/issues/26487
       ENV.O0
+
+      "linux"
     end
     ENV["GOPATH"] = buildpath
     dir = buildpath/"src/github.com/openshift/oc"
@@ -50,8 +52,12 @@ class OpenshiftCli < Formula
 
     cd dir do
       args = ["cross-build-#{os}-#{arch}"]
-      args << (build.stable? ? "WHAT=cmd/oc" : "WHAT=staging/src/github.com/openshift/oc/cmd/oc")
-      on_linux { args << "SHELL=/bin/bash" }
+      args << if build.stable?
+        "WHAT=cmd/oc"
+      else
+        "WHAT=staging/src/github.com/openshift/oc/cmd/oc"
+      end
+      args << "SHELL=/bin/bash" if OS.linux?
 
       system "make", *args
       bin.install "_output/bin/#{os}_#{arch}/oc"
@@ -78,7 +84,7 @@ index 940a90415..a3584fbc9 100644
 @@ -88,6 +88,10 @@ cross-build-darwin-amd64:
  	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
  .PHONY: cross-build-darwin-amd64
- 
+
 +cross-build-darwin-arm64:
 +	+@GOOS=darwin GOARCH=arm64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_arm64
 +.PHONY: cross-build-darwin-arm64

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -56,7 +56,7 @@ class Openssh < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       ENV.append "CPPFLAGS", "-D__APPLE_SANDBOX_NAMED_EXTERNAL__"
 
       # Ensure sandbox profile prefix is correct.
@@ -75,9 +75,7 @@ class Openssh < Formula
       --with-security-key-builtin
     ]
 
-    on_linux do
-      args << "--with-privsep-path=#{var}/lib/sshd"
-    end
+    args << "--with-privsep-path=#{var}/lib/sshd" if OS.linux?
 
     system "./configure", *args
     system "make"

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -69,7 +69,7 @@ class OpensslAT11 < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
       %w[ExtUtils::MakeMaker Test::Harness Test::More].each do |r|
@@ -90,15 +90,12 @@ class OpensslAT11 < Formula
     ENV["PERL"] = Formula["perl"].opt_bin/"perl" if which("perl") == Formula["perl"].opt_bin/"perl"
 
     arch_args = []
-    on_macos do
+    if OS.mac?
       arch_args += %W[darwin64-#{Hardware::CPU.arch}-cc enable-ec_nistp_64_gcc_128]
-    end
-    on_linux do
-      if Hardware::CPU.intel?
-        arch_args << (Hardware::CPU.is_64_bit? ? "linux-x86_64" : "linux-elf")
-      elsif Hardware::CPU.arm?
-        arch_args << (Hardware::CPU.is_64_bit? ? "linux-aarch64" : "linux-armv4")
-      end
+    elsif Hardware::CPU.intel?
+      arch_args << (Hardware::CPU.is_64_bit? ? "linux-x86_64" : "linux-elf")
+    elsif Hardware::CPU.arm?
+      arch_args << (Hardware::CPU.is_64_bit? ? "linux-aarch64" : "linux-armv4")
     end
 
     system "perl", "./Configure", *(configure_args + arch_args)
@@ -112,8 +109,11 @@ class OpensslAT11 < Formula
   end
 
   def post_install
-    on_macos(&method(:macos_post_install))
-    on_linux(&method(:linux_post_install))
+    if OS.mac?
+      macos_post_install
+    else
+      linux_post_install
+    end
   end
 
   def macos_post_install

--- a/Formula/openvpn.rb
+++ b/Formula/openvpn.rb
@@ -39,8 +39,11 @@ class Openvpn < Formula
                           "--enable-pkcs11",
                           "--prefix=#{prefix}"
     inreplace "sample/sample-plugins/Makefile" do |s|
-      on_macos { s.gsub! HOMEBREW_SHIMS_PATH/"mac/super/pkg-config", Formula["pkg-config"].opt_bin/"pkg-config" }
-      on_linux { s.gsub! HOMEBREW_SHIMS_PATH/"linux/super/ld", "ld" }
+      if OS.mac?
+        s.gsub! HOMEBREW_SHIMS_PATH/"mac/super/pkg-config", Formula["pkg-config"].opt_bin/"pkg-config"
+      else
+        s.gsub! HOMEBREW_SHIMS_PATH/"linux/super/ld", "ld"
+      end
     end
     system "make", "install"
 

--- a/Formula/ophcrack.rb
+++ b/Formula/ophcrack.rb
@@ -28,9 +28,7 @@ class Ophcrack < Formula
       --with-libssl=#{Formula["openssl@1.1"].opt_prefix}
       --prefix=#{prefix}
     ]
-    on_linux do
-      args << "--with-libexpat=#{Formula["expat"].opt_prefix}"
-    end
+    args << "--with-libexpat=#{Formula["expat"].opt_prefix}" if OS.linux?
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/p7zip.rb
+++ b/Formula/p7zip.rb
@@ -17,10 +17,9 @@ class P7zip < Formula
   patch :DATA
 
   def install
-    on_macos do
+    if OS.mac?
       mv "makefile.macosx_llvm_64bits", "makefile.machine"
-    end
-    on_linux do
+    else
       mv "makefile.linux_any_cpu", "makefile.machine"
     end
     system "make", "all3",
@@ -50,13 +49,13 @@ diff -u -r a/makefile b/makefile
 -	$(MAKE) -C CPP/7zip/Compress/Rar          depend
  	$(MAKE) -C CPP/7zip/UI/GUI                depend
  	$(MAKE) -C CPP/7zip/UI/FileManager        depend
- 
+
 @@ -42,7 +41,6 @@
  common7z:common
  	$(MKDIR) bin/Codecs
  	$(MAKE) -C CPP/7zip/Bundles/Format7zFree all
 -	$(MAKE) -C CPP/7zip/Compress/Rar         all
- 
+
  lzham:common
  	$(MKDIR) bin/Codecs
 @@ -67,7 +65,6 @@

--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -55,8 +55,11 @@ class Packetbeat < Formula
   end
 
   test do
-    eth = "en"
-    on_linux { eth = "eth" }
+    eth = if OS.mac?
+      "en"
+    else
+      "eth"
+    end
     assert_match "0: #{eth}0", shell_output("#{bin}/packetbeat devices")
     assert_match version.to_s, shell_output("#{bin}/packetbeat version")
   end

--- a/Formula/pari.rb
+++ b/Formula/pari.rb
@@ -40,8 +40,11 @@ class Pari < Formula
     system "make", "all"
     system "make", "install"
 
-    os = "mac"
-    on_linux { os = "linux" }
+    os = if OS.mac?
+      "mac"
+    else
+      "linux"
+    end
     # Avoid references to Homebrew shims
     inreplace lib/"pari/pari.cfg", HOMEBREW_LIBRARY/"Homebrew/shims/#{os}/super/", "/usr/bin/"
   end

--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -25,7 +25,7 @@ class Patchelf < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fix ld.so path and rpath
       # see https://github.com/Homebrew/linuxbrew-core/pull/20548#issuecomment-672061606
       ENV["HOMEBREW_DYNAMIC_LINKER"] = File.readlink("#{HOMEBREW_PREFIX}/lib/ld.so")

--- a/Formula/pcapplusplus.rb
+++ b/Formula/pcapplusplus.rb
@@ -15,8 +15,11 @@ class Pcapplusplus < Formula
   uses_from_macos "libpcap"
 
   def install
-    os = "mac_os_x"
-    on_linux { os = "linux" }
+    os = if OS.mac?
+      "mac_os_x"
+    else
+      "linux"
+    end
     system "./configure-#{os}.sh", "--install-dir", prefix
 
     # library requires to run 'make all' and

--- a/Formula/pcsc-lite.rb
+++ b/Formula/pcsc-lite.rb
@@ -32,9 +32,7 @@ class PcscLite < Formula
               --sysconfdir=#{etc}
               --disable-libsystemd]
 
-    on_linux do
-      args << "--disable-udev"
-    end
+    args << "--disable-udev" if OS.linux?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/pdf2htmlex.rb
+++ b/Formula/pdf2htmlex.rb
@@ -60,7 +60,7 @@ class Pdf2htmlex < Formula
       # https://github.com/coolwanglu/pdf2htmlEX/issues/713
       inreplace "gutils/gimagereadgif.c", "DGifCloseFile(gif)", "DGifCloseFile(gif, NULL)"
 
-      on_macos do
+      if OS.mac?
         # Fix linker error; see: https://trac.macports.org/ticket/25012
         ENV.append "LDFLAGS", "-lintl"
       end

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -44,9 +44,7 @@ class Pdnsrec < Formula
   def install
     ENV.cxx11
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -118,11 +118,11 @@ class PerconaServer < Formula
       test_args = ["--vardir=#{Dir.mktmpdir}"]
       # For Linux, disable failing on warning: "Setting thread 31563 nice to 0 failed"
       # Docker containers lack CAP_SYS_NICE capability by default.
-      on_linux { test_args << "--nowarnings" }
+      test_args << "--nowarnings" if OS.linux?
       system "./mysql-test-run.pl", "status", *test_args
     end
 
-    on_macos do
+    if OS.mac?
       # Remove libssl copies as the binaries use the keg anyway and they create problems for other applications
       rm lib/"libssl.dylib"
       rm lib/"libssl.1.1.dylib"
@@ -231,11 +231,11 @@ __END__
 --- a/plugin/auth_ldap/CMakeLists.txt
 +++ b/plugin/auth_ldap/CMakeLists.txt
 @@ -36,7 +36,7 @@ IF(WITH_LDAP)
- 
+
    # libler?
    MYSQL_ADD_PLUGIN(authentication_ldap_simple ${ALP_SOURCES_SIMPLE}
 -    LINK_LIBRARIES ldap_r MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_simple")
 +    LINK_LIBRARIES ldap MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_simple")
- 
+
    IF(UNIX)
      IF(INSTALL_MYSQLTESTDIR)

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -102,7 +102,7 @@ class PerconaXtrabackup < Formula
     # remove conflicting library that is already installed by mysql
     rm lib/"libmysqlservices.a"
 
-    on_macos do
+    if OS.mac?
       # Remove libssl copies as the binaries use the keg anyway and they create problems for other applications
       rm lib/"libssl.dylib"
       rm lib/"libssl.1.1.dylib"
@@ -120,9 +120,7 @@ class PerconaXtrabackup < Formula
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
     # This is not part of the system Perl on Linux and on macOS since Mojave
-    install_dbi = (MacOS.version >= :mojave)
-    on_linux { install_dbi = true }
-    if install_dbi
+    if OS.linux? || MacOS.version >= :mojave
       resource("DBI").stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
         system "make", "install"

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -42,9 +42,7 @@ class Perl < Formula
       -Duselargefiles
       -Dusethreads
     ]
-    on_macos do
-      args << "-Dsed=/usr/bin/sed"
-    end
+    args << "-Dsed=/usr/bin/sed" if OS.mac?
 
     args << "-Dusedevel" if build.head?
 
@@ -56,7 +54,7 @@ class Perl < Formula
   end
 
   def post_install
-    on_linux do
+    if OS.linux?
       perl_archlib = Utils.safe_popen_read("perl", "-MConfig", "-e", "print $Config{archlib}")
       perl_core = Pathname.new(perl_archlib)/"CORE"
       if File.readlines("#{perl_core}/perl.h").grep(/include <xlocale.h>/).any? &&

--- a/Formula/perl@5.18.rb
+++ b/Formula/perl@5.18.rb
@@ -34,9 +34,7 @@ class PerlAT518 < Formula
       -Duselargefiles
       -Dusethreads
     ]
-    on_macos do
-      args << "-Dsed=/usr/bin/sed"
-    end
+    args << "-Dsed=/usr/bin/sed" if OS.mac?
 
     system "./Configure", *args
     system "make"

--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -43,14 +43,10 @@ class PetscComplex < Formula
     # Avoid references to Homebrew shims
     rm_f lib/"petsc/conf/configure-hash"
 
-    on_macos do
+    if OS.mac?
       inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
-    end
-
-    on_linux do
-      if File.readlines("#{lib}/petsc/conf/petscvariables").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
-        inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
-      end
+    elsif File.readlines("#{lib}/petsc/conf/petscvariables").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
+      inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
     end
   end
 

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -44,14 +44,10 @@ class Petsc < Formula
     # Avoid references to Homebrew shims
     rm_f lib/"petsc/conf/configure-hash"
 
-    on_macos do
+    if OS.mac?
       inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
-    end
-
-    on_linux do
-      if File.readlines("#{lib}/petsc/conf/petscvariables").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
-        inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
-      end
+    elsif File.readlines("#{lib}/petsc/conf/petscvariables").grep(/#{HOMEBREW_SHIMS_PATH}/o).any?
+      inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/linux/super/", ""
     end
   end
 

--- a/Formula/pgbadger.rb
+++ b/Formula/pgbadger.rb
@@ -19,8 +19,11 @@ class Pgbadger < Formula
     system "make"
     system "make", "install"
 
-    man_dir = "share/man/man1"
-    on_linux { man_dir = "man/man1" }
+    man_dir = if OS.mac?
+      "share/man/man1"
+    else
+      "man/man1"
+    end
     bin.install "usr/local/bin/pgbadger"
     man1.install "usr/local/#{man_dir}/pgbadger.1p"
   end

--- a/Formula/pgformatter.rb
+++ b/Formula/pgformatter.rb
@@ -17,7 +17,7 @@ class Pgformatter < Formula
     system "perl", "Makefile.PL", "DESTDIR=."
     system "make", "install"
 
-    on_linux do
+    if OS.linux?
       # Move man pages to share directory so they will be linked correctly on Linux
       mkdir "usr/local/share"
       mv "usr/local/man", "usr/local/share"

--- a/Formula/phoronix-test-suite.rb
+++ b/Formula/phoronix-test-suite.rb
@@ -33,7 +33,7 @@ class PhoronixTestSuite < Formula
   end
 
   test do
-    on_macos { cd pkgshare }
+    cd pkgshare if OS.mac?
 
     # Work around issue directly running command on Linux CI by using spawn.
     # Error is "Forked child process failed: pid ##### SIGKILL"

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -68,9 +68,9 @@ class Php < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
       # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
 
     # buildconf required due to system library linking bug patch
@@ -107,11 +107,10 @@ class Php < Formula
 
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
-    on_macos do
+    if OS.mac?
       ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
       ENV["SASL_LIBS"] = "-lsasl2"
-    end
-    on_linux do
+    else
       ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
       ENV["SQLITE_LIBS"] = "-lsqlite3"
       ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
@@ -119,10 +118,7 @@ class Php < Formula
 
     # Each extension that is built on Mojave needs a direct reference to the
     # sdk path or it won't find the headers
-    headers_path = ""
-    on_macos do
-      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
-    end
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
 
     args = %W[
       --prefix=#{prefix}
@@ -192,12 +188,11 @@ class Php < Formula
       --with-zlib
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-dtrace"
       args << "--with-ldap-sasl"
       args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
-    end
-    on_linux do
+    else
       args << "--disable-dtrace"
       args << "--without-ldap-sasl"
       args << "--without-ndbm"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -117,8 +117,7 @@ class PhpAT72 < Formula
 
     # Each extension that is built on Mojave needs a direct reference to the
     # sdk path or it won't find the headers
-    headers_path = ""
-    on_macos { headers_path = "=#{MacOS.sdk_path_if_needed}/usr" }
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
 
     args = %W[
       --prefix=#{prefix}
@@ -188,7 +187,7 @@ class PhpAT72 < Formula
       --with-xmlrpc
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-dtrace"
       args << "--with-bz2#{headers_path}"
       args << "--with-libedit#{headers_path}"
@@ -198,7 +197,7 @@ class PhpAT72 < Formula
       args << "--with-zlib#{headers_path}"
     end
 
-    on_linux do
+    if OS.linux?
       args << "--disable-dtrace"
       args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
       args << "--with-bzip2=#{Formula["bzip2"].opt_prefix}"

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -63,9 +63,9 @@ class PhpAT73 < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
       # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
 
     # buildconf required due to system library linking bug patch
@@ -109,10 +109,8 @@ class PhpAT73 < Formula
 
     # Each extension that is built on Mojave needs a direct reference to the
     # sdk path or it won't find the headers
-    headers_path = ""
-    on_macos do
-      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
-    end
+
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
 
     args = %W[
       --prefix=#{prefix}
@@ -181,7 +179,7 @@ class PhpAT73 < Formula
       --with-xmlrpc
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-dtrace"
       args << "--with-ldap-sasl#{headers_path}"
       args << "--with-zlib#{headers_path}"
@@ -191,7 +189,7 @@ class PhpAT73 < Formula
       args << "--with-libxml-dir#{headers_path}"
       args << "--with-xsl#{headers_path}"
     end
-    on_linux do
+    if OS.linux?
       args << "--disable-dtrace"
       args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
       args << "--with-bz2=#{Formula["bzip2"].opt_prefix}"

--- a/Formula/php@7.4.rb
+++ b/Formula/php@7.4.rb
@@ -65,9 +65,9 @@ class PhpAT74 < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
       # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
 
     # buildconf required due to system library linking bug patch
@@ -108,11 +108,10 @@ class PhpAT74 < Formula
 
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
-    on_macos do
+    if OS.mac?
       ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
       ENV["SASL_LIBS"] = "-lsasl2"
-    end
-    on_linux do
+    else
       ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
       ENV["SQLITE_LIBS"] = "-lsqlite3"
       ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
@@ -120,10 +119,7 @@ class PhpAT74 < Formula
 
     # Each extension that is built on Mojave needs a direct reference to the
     # sdk path or it won't find the headers
-    headers_path = ""
-    on_macos do
-      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
-    end
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
 
     args = %W[
       --prefix=#{prefix}
@@ -193,12 +189,11 @@ class PhpAT74 < Formula
       --with-zlib
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-dtrace"
       args << "--with-ldap-sasl"
       args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
-    end
-    on_linux do
+    else
       args << "--disable-dtrace"
       args << "--without-ldap-sasl"
       args << "--without-ndbm"

--- a/Formula/picat.rb
+++ b/Formula/picat.rb
@@ -19,10 +19,11 @@ class Picat < Formula
   end
 
   def install
-    makefile = "Makefile.mac64"
-    on_linux do
+    makefile = if OS.mac?
+      "Makefile.mac64"
+    else
       ENV.cxx11
-      makefile = "Makefile.linux64"
+      "Makefile.linux64"
     end
     system "make", "-C", "emu", "-f", makefile
     bin.install "emu/picat" => "picat"

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -30,10 +30,9 @@ class Pjproject < Formula
     system "make", "install"
 
     arch = Utils.safe_popen_read("uname", "-m").chomp
-    on_macos do
+    if OS.mac?
       bin.install "pjsip-apps/bin/pjsua-#{arch}-apple-darwin#{OS.kernel_version}" => "pjsua"
-    end
-    on_linux do
+    else
       bin.install "pjsip-apps/bin/pjsua-#{arch}-unknown-linux-gnu" => "pjsua"
     end
   end

--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -25,14 +25,14 @@ class PkgConfig < Formula
       #{HOMEBREW_PREFIX}/lib/pkgconfig
       #{HOMEBREW_PREFIX}/share/pkgconfig
     ]
-    on_macos do
+    pc_path << if OS.mac?
       pc_path << "/usr/local/lib/pkgconfig"
       pc_path << "/usr/lib/pkgconfig"
-      pc_path << "#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"
+      "#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"
+    else
+      "#{HOMEBREW_LIBRARY}/Homebrew/os/linux/pkgconfig"
     end
-    on_linux do
-      pc_path << "#{HOMEBREW_LIBRARY}/Homebrew/os/linux/pkgconfig"
-    end
+
     pc_path = pc_path.uniq.join(File::PATH_SEPARATOR)
 
     system "./configure", "--disable-debug",

--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -30,11 +30,10 @@ class Podman < Formula
     end
 
     system "make", "podman-remote-#{os}"
-    on_macos do
+    if OS.mac?
       bin.install "bin/#{os}/podman" => "podman-remote"
       bin.install_symlink bin/"podman-remote" => "podman"
-    end
-    on_linux do
+    else
       bin.install "bin/podman-remote"
     end
 

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -20,9 +20,7 @@ class Ponyc < Formula
   def install
     ENV.cxx11
 
-    on_linux do
-      inreplace "CMakeLists.txt", "PONY_COMPILER=\"${CMAKE_C_COMPILER}\"", "PONY_COMPILER=\"#{ENV.cc}\""
-    end
+    inreplace "CMakeLists.txt", "PONY_COMPILER=\"${CMAKE_C_COMPILER}\"", "PONY_COMPILER=\"#{ENV.cc}\"" if OS.linux?
 
     ENV["MAKEFLAGS"] = "build_flags=-j#{ENV.make_jobs}"
     system "make", "libs"

--- a/Formula/poppler-qt5.rb
+++ b/Formula/poppler-qt5.rb
@@ -76,7 +76,7 @@ class PopplerQt5 < Formula
       system "make", "install", "prefix=#{prefix}"
     end
 
-    on_macos do
+    if OS.mac?
       libpoppler = (lib/"libpoppler.dylib").readlink
       [
         "#{lib}/libpoppler-cpp.dylib",

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -71,7 +71,7 @@ class Poppler < Formula
       system "make", "install", "prefix=#{prefix}"
     end
 
-    on_macos do
+    if OS.mac?
       libpoppler = (lib/"libpoppler.dylib").readlink
       [
         "#{lib}/libpoppler-cpp.dylib",

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -54,7 +54,7 @@ class Portmidi < Formula
     include.mkpath
     lib.mkpath
 
-    on_macos do
+    if OS.mac?
       ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
 
       inreplace "pm_mac/Makefile.osx", "PF=/usr/local", "PF=#{prefix}"
@@ -67,8 +67,7 @@ class Portmidi < Formula
 
       system "make", "-f", "pm_mac/Makefile.osx"
       system "make", "-f", "pm_mac/Makefile.osx", "install"
-    end
-    on_linux do
+    else
       system "cmake", ".", *std_cmake_args, "-DCMAKE_CACHEFILE_DIR=#{buildpath}/build"
       system "make", "install"
     end

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -62,7 +62,7 @@ class Postgresql < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -83,7 +83,7 @@ class Postgresql < Formula
                                     "includedir_server=#{include}/postgresql/server",
                                     "includedir_internal=#{include}/postgresql/internal"
 
-    on_linux do
+    if OS.linux?
       inreplace lib/"postgresql/pgxs/src/Makefile.global",
                 "LD = #{HOMEBREW_PREFIX}/Homebrew/Library/Homebrew/shims/linux/super/ld",
                 "LD = #{HOMEBREW_PREFIX}/bin/ld"

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -59,7 +59,7 @@ class PostgresqlAT10 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -84,7 +84,7 @@ class PostgresqlAT10 < Formula
     # Attempting to fix that by adding a dependency on `open-sp` doesn't
     # work and the build errors out on generating the documentation, so
     # for now let's simply omit it so we can package Postgresql for Mojave.
-    on_macos do
+    if OS.mac?
       if DevelopmentTools.clang_build_version >= 1000
         system "make", "all"
         system "make", "-C", "contrib", "install", "all", *dirs
@@ -92,8 +92,7 @@ class PostgresqlAT10 < Formula
       else
         system "make", "install-world", *dirs
       end
-    end
-    on_linux do
+    else
       system "make", "all"
       system "make", "-C", "contrib", "install", "all", *dirs
       system "make", "install", "all", *dirs

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -61,7 +61,7 @@ class PostgresqlAT11 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -82,7 +82,7 @@ class PostgresqlAT11 < Formula
                                     "includedir_server=#{include}/server",
                                     "includedir_internal=#{include}/internal"
 
-    on_linux do
+    if OS.linux?
       inreplace lib/"pgxs/src/Makefile.global",
                 "LD = #{HOMEBREW_PREFIX}/Homebrew/Library/Homebrew/shims/linux/super/ld",
                 "LD = #{HOMEBREW_PREFIX}/bin/ld"

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -65,7 +65,7 @@ class PostgresqlAT12 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -91,7 +91,7 @@ class PostgresqlAT12 < Formula
                                     "includedir_server=#{include}/postgresql/server",
                                     "includedir_internal=#{include}/postgresql/internal"
 
-    on_linux do
+    if OS.linux?
       inreplace lib/"postgresql/pgxs/src/Makefile.global",
                 "LD = #{HOMEBREW_PREFIX}/Homebrew/Library/Homebrew/shims/linux/super/ld",
                 "LD = #{HOMEBREW_PREFIX}/bin/ld"

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -65,7 +65,7 @@ class PostgresqlAT94 < Formula
       --with-uuid=e2fs
     ]
 
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -82,9 +82,7 @@ class PostgresqlAT94 < Formula
                   "exit(! does_int64_work())",
                   "return(! does_int64_work())"
       end
-    end
-
-    on_linux do
+    else
       # rebuild `configure` after patching
       # (remove if patch block not needed)
       system "autoreconf", "-ivf"
@@ -103,7 +101,7 @@ class PostgresqlAT94 < Formula
     # Attempting to fix that by adding a dependency on `open-sp` doesn't
     # work and the build errors out on generating the documentation, so
     # for now let's simply omit it so we can package Postgresql for Mojave.
-    on_macos do
+    if OS.mac?
       if DevelopmentTools.clang_build_version >= 1000
         system "make", "all"
         system "make", "-C", "contrib", "install", "all", *dirs
@@ -111,8 +109,7 @@ class PostgresqlAT94 < Formula
       else
         system "make", "install-world", *dirs
       end
-    end
-    on_linux do
+    else
       system "make", "all"
       system "make", "-C", "contrib", "install", "all", *dirs
       system "make", "install", "all", *dirs

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -65,7 +65,7 @@ class PostgresqlAT95 < Formula
       --with-uuid=e2fs
     ]
 
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -76,7 +76,7 @@ class PostgresqlAT95 < Formula
     # which does not work on CLT-only installs.
     args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
 
-    on_linux do
+    if OS.linux?
       # rebuild `configure` after patching
       # (remove if patch block not needed)
       system "autoreconf", "-ivf"
@@ -95,7 +95,7 @@ class PostgresqlAT95 < Formula
     # Attempting to fix that by adding a dependency on `open-sp` doesn't
     # work and the build errors out on generating the documentation, so
     # for now let's simply omit it so we can package Postgresql for Mojave.
-    on_macos do
+    if OS.mac?
       if DevelopmentTools.clang_build_version >= 1000
         system "make", "all"
         system "make", "-C", "contrib", "install", "all", *dirs
@@ -103,8 +103,7 @@ class PostgresqlAT95 < Formula
       else
         system "make", "install-world", *dirs
       end
-    end
-    on_linux do
+    else
       system "make", "all"
       system "make", "-C", "contrib", "install", "all", *dirs
       system "make", "install", "all", *dirs

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -59,7 +59,7 @@ class PostgresqlAT96 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-    on_macos do
+    if OS.mac?
       args += %w[
         --with-bonjour
         --with-tcl
@@ -83,7 +83,7 @@ class PostgresqlAT96 < Formula
     # Attempting to fix that by adding a dependency on `open-sp` doesn't
     # work and the build errors out on generating the documentation, so
     # for now let's simply omit it so we can package Postgresql for Mojave.
-    on_macos do
+    if OS.mac?
       if DevelopmentTools.clang_build_version >= 1000
         system "make", "all"
         system "make", "-C", "contrib", "install", "all", *dirs
@@ -91,8 +91,7 @@ class PostgresqlAT96 < Formula
       else
         system "make", "install-world", *dirs
       end
-    end
-    on_linux do
+    else
       system "make", "all"
       system "make", "-C", "contrib", "install", "all", *dirs
       system "make", "install", "all", *dirs

--- a/Formula/ppsspp.rb
+++ b/Formula/ppsspp.rb
@@ -46,12 +46,11 @@ class Ppsspp < Formula
     mkdir "build" do
       system "cmake", "..", *args
       system "make"
-      on_macos do
+      if OS.mac?
         prefix.install "PPSSPPSDL.app"
         bin.write_exec_script "#{prefix}/PPSSPPSDL.app/Contents/MacOS/PPSSPPSDL"
         mv "#{bin}/PPSSPPSDL", "#{bin}/ppsspp"
-      end
-      on_linux do
+      else
         bin.install "PPSSPPSDL" => "ppsspp"
       end
     end

--- a/Formula/pre-commit.rb
+++ b/Formula/pre-commit.rb
@@ -90,7 +90,7 @@ class PreCommit < Formula
   def post_install
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
     dirs_to_fix = [libexec/"lib/python#{xy}"]
-    on_linux { dirs_to_fix << libexec/"bin" }
+    dirs_to_fix << libexec/"bin" if OS.linux?
     dirs_to_fix.each do |folder|
       folder.each_child do |f|
         next unless f.symlink?

--- a/Formula/premake.rb
+++ b/Formula/premake.rb
@@ -22,9 +22,10 @@ class Premake < Formula
 
   def install
     if build.head?
-      platform = "osx"
-      on_linux do
-        platform = "linux"
+      platform = if OS.mac?
+        "osx"
+      else
+        "linux"
       end
       system "make", "-f", "Bootstrap.mak", platform
       system "./bin/release/premake5", "gmake2"
@@ -32,9 +33,10 @@ class Premake < Formula
       system "make"
       bin.install "bin/release/premake5"
     else
-      platform = "macosx"
-      on_linux do
-        platform = "unix"
+      platform = if OS.mac?
+        "macosx"
+      else
+        "unix"
       end
       system "make", "-C", "build/gmake.#{platform}"
       bin.install "bin/release/premake4"

--- a/Formula/pstoedit.rb
+++ b/Formula/pstoedit.rb
@@ -26,7 +26,7 @@ class Pstoedit < Formula
   fails_with gcc: "5"
 
   def install
-    on_macos { ENV.cxx11 }
+    ENV.cxx11 if OS.mac?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -52,7 +52,7 @@ class Pulseaudio < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", buildpath/"lib/perl5"
       resource("XML::Parser").stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{buildpath}"
@@ -70,13 +70,11 @@ class Pulseaudio < Formula
       --disable-x11
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-coreaudio-output"
       args << "--with-mac-sysroot=#{MacOS.sdk_path}"
       args << "--with-mac-version-min=#{MacOS.version}"
-    end
-
-    on_linux do
+    else
       # Perl depends on gdbm.
       # If the dependency of pulseaudio on perl is build-time only,
       # pulseaudio detects and links gdbm at build-time, but cannot locate it at run-time.
@@ -99,7 +97,7 @@ class Pulseaudio < Formula
     end
     system "make", "install"
 
-    on_linux do
+    if OS.linux?
       # https://stackoverflow.com/questions/56309056/is-gschemas-compiled-architecture-specific-can-i-ship-it-with-my-python-library
       rm "#{share}/glib-2.0/schemas/gschemas.compiled"
     end

--- a/Formula/pup.rb
+++ b/Formula/pup.rb
@@ -26,9 +26,10 @@ class Pup < Formula
     dir.install buildpath.children
 
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    os = "darwin"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "darwin"
+    else
+      "linux"
     end
 
     cd dir do

--- a/Formula/puzzles.rb
+++ b/Formula/puzzles.rb
@@ -41,9 +41,7 @@ class Puzzles < Formula
     system "cmake", ".", *std_cmake_args
     system "make", "install"
 
-    on_macos do
-      bin.write_exec_script prefix/"Puzzles.app/Contents/MacOS/Puzzles"
-    end
+    bin.write_exec_script prefix/"Puzzles.app/Contents/MacOS/Puzzles" if OS.mac?
   end
 
   test do

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -96,7 +96,7 @@ class Pypy < Formula
     end
 
     (libexec/"lib").install libexec/"bin/#{shared_library("libpypy-c")}"
-    on_macos do
+    if OS.mac?
       MachO::Tools.change_install_name("#{libexec}/bin/pypy",
                                        "@rpath/libpypy-c.dylib",
                                        "#{libexec}/lib/libpypy-c.dylib")
@@ -111,7 +111,7 @@ class Pypy < Formula
 
     # Delete two files shipped which we do not want to deliver
     # These files make patchelf fail
-    on_linux do
+    if OS.linux?
       rm_f libexec/"bin/libpypy-c.so.debug"
       rm_f libexec/"bin/pypy.debug"
     end

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -84,7 +84,7 @@ class Pypy3 < Formula
 
     (libexec/"lib").install libexec/"bin/#{shared_library("libpypy3-c")}" => shared_library("libpypy3-c")
 
-    on_macos do
+    if OS.mac?
       MachO::Tools.change_install_name("#{libexec}/bin/pypy3",
                                        "@rpath/libpypy3-c.dylib",
                                        "#{libexec}/lib/libpypy3-c.dylib")
@@ -105,7 +105,7 @@ class Pypy3 < Formula
 
     # Delete two files shipped which we do not want to deliver
     # These files make patchelf fail
-    on_linux do
+    if OS.linux?
       rm_f libexec/"bin/libpypy3-c.so.debug"
       rm_f libexec/"bin/pypy3.debug"
     end

--- a/Formula/pyqt@5.rb
+++ b/Formula/pyqt@5.rb
@@ -78,7 +78,7 @@ class PyqtAT5 < Formula
     end
 
     components = %w[3d chart datavis networkauth purchasing]
-    on_macos { components << "webengine" unless Hardware::CPU.arm? }
+    components << "webengine" if OS.mac? && !Hardware::CPU.arm?
     components.each do |p|
       resource(p).stage do
         inreplace "pyproject.toml", "[tool.sip.project]",

--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -91,7 +91,7 @@ class PythonAT38 < Formula
     ENV["PYTHONPATH"] = nil
 
     # Override the auto-detection in setup.py, which assumes a universal build.
-    on_macos do
+    if OS.mac?
       ENV["PYTHON_DECIMAL_WITH_MACHINE"] = Hardware::CPU.arm? ? "uint128" : "x64"
     end
 
@@ -106,12 +106,10 @@ class PythonAT38 < Formula
       --with-system-libmpdec
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-framework=#{frameworks}"
       args << "--with-dtrace"
-    end
-
-    on_linux do
+    else
       args << "--enable-shared"
 
       # Required for the _ctypes module
@@ -154,7 +152,7 @@ class PythonAT38 < Formula
               "for d_ in ['#{Formula["sqlite"].opt_include}']:"
     end
 
-    on_linux do
+    if OS.linux?
       # Python's configure adds the system ncurses include entry to CPPFLAGS
       # when doing curses header check. The check may fail when there exists
       # a 32-bit system ncurses (conflicts with the brewed 64-bit one).
@@ -186,15 +184,13 @@ class PythonAT38 < Formula
     ENV.deparallelize do
       # Tell Python not to install into /Applications (default for framework builds)
       system "make", "install", "PYTHONAPPSDIR=#{prefix}"
-      on_macos do
-        system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{pkgshare}"
-      end
+      system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{pkgshare}" if OS.mac?
     end
 
     # Any .app get a " 3" attached, so it does not conflict with python 2.x.
     Dir.glob("#{prefix}/*.app") { |app| mv app, app.sub(/\.app$/, " 3.app") }
 
-    on_macos do
+    if OS.mac?
       # Prevent third-party packages from building against fragile Cellar paths
       inreplace Dir[lib_cellar/"**/_sysconfigdata__darwin_darwin.py",
                     lib_cellar/"config*/Makefile",
@@ -210,9 +206,7 @@ class PythonAT38 < Formula
       inreplace Dir[lib_cellar/"**/_sysconfigdata__darwin_darwin.py"],
                 %r{('LINKFORSHARED': .*?)'(Python.framework/Versions/3.\d+/Python)'}m,
                 "\\1'#{opt_prefix}/Frameworks/\\2'"
-    end
-
-    on_linux do
+    else
       # Prevent third-party packages from building against fragile Cellar paths
       inreplace Dir[lib_cellar/"**/_sysconfigdata_*linux_x86_64-*.py",
                     lib_cellar/"config*/Makefile",

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -104,7 +104,7 @@ class PythonAT39 < Formula
     ENV["PYTHONPATH"] = nil
 
     # Override the auto-detection in setup.py, which assumes a universal build.
-    on_macos do
+    if OS.mac?
       ENV["PYTHON_DECIMAL_WITH_MACHINE"] = Hardware::CPU.arm? ? "uint128" : "x64"
     end
 
@@ -129,15 +129,14 @@ class PythonAT39 < Formula
       --with-system-libmpdec
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-framework=#{frameworks}"
       args << "--with-dtrace"
 
       # Override LLVM_AR to be plain old system ar.
       # https://bugs.python.org/issue43109
       args << "LLVM_AR=/usr/bin/ar"
-    end
-    on_linux do
+    else
       args << "--enable-shared"
     end
 
@@ -176,7 +175,7 @@ class PythonAT39 < Formula
               "for d_ in ['#{Formula["sqlite"].opt_include}']:"
     end
 
-    on_linux do
+    if OS.linux?
       # Python's configure adds the system ncurses include entry to CPPFLAGS
       # when doing curses header check. The check may fail when there exists
       # a 32-bit system ncurses (conflicts with the brewed 64-bit one).
@@ -208,15 +207,13 @@ class PythonAT39 < Formula
     ENV.deparallelize do
       # Tell Python not to install into /Applications (default for framework builds)
       system "make", "install", "PYTHONAPPSDIR=#{prefix}"
-      on_macos do
-        system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{pkgshare}"
-      end
+      system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{pkgshare}" if OS.mac?
     end
 
     # Any .app get a " 3" attached, so it does not conflict with python 2.x.
     Dir.glob("#{prefix}/*.app") { |app| mv app, app.sub(/\.app$/, " 3.app") }
 
-    on_macos do
+    if OS.mac?
       # Prevent third-party packages from building against fragile Cellar paths
       inreplace Dir[lib_cellar/"**/_sysconfigdata__darwin_darwin.py",
                     lib_cellar/"config*/Makefile",
@@ -232,9 +229,7 @@ class PythonAT39 < Formula
       inreplace Dir[lib_cellar/"**/_sysconfigdata__darwin_darwin.py"],
                 %r{('LINKFORSHARED': .*?)'(Python.framework/Versions/3.\d+/Python)'}m,
                 "\\1'#{opt_prefix}/Frameworks/\\2'"
-    end
-
-    on_linux do
+    else
       # Prevent third-party packages from building against fragile Cellar paths
       inreplace Dir[lib_cellar/"**/_sysconfigdata_*linux_x86_64-*.py",
                     lib_cellar/"config*/Makefile",

--- a/Formula/pythran.rb
+++ b/Formula/pythran.rb
@@ -38,7 +38,7 @@ class Pythran < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       gcc_major_ver = Formula["gcc"].any_installed_version.major
       inreplace "pythran/pythran-darwin.cfg" do |s|
         s.gsub!(/^include_dirs=/, "include_dirs=#{Formula["openblas"].opt_include}")

--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -30,12 +30,10 @@ class Qcachegrind < Formula
                                                "-config", "release"
       system "make"
 
-      on_macos do
+      if OS.mac?
         prefix.install "qcachegrind.app"
         bin.install_symlink prefix/"qcachegrind.app/Contents/MacOS/qcachegrind"
-      end
-
-      on_linux do
+      else
         bin.install "qcachegrind/qcachegrind"
       end
     end

--- a/Formula/qdbm.rb
+++ b/Formula/qdbm.rb
@@ -33,16 +33,13 @@ class Qdbm < Formula
     ]
 
     # Does not want to build on Linux
-    on_macos do
-      args << "--enable-bzip"
-    end
+    args << "--enable-bzip" if OS.mac?
 
     system "./configure", *args
-    on_macos do
+    if OS.mac?
       system "make", "mac"
       system "make", "install-mac"
-    end
-    on_linux do
+    else
       system "make"
       system "make", "install"
     end

--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -68,9 +68,7 @@ class Qemu < Formula
     # Samba installations from external taps.
     args << "--smbd=#{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd"
 
-    on_macos do
-      args << "--enable-cocoa"
-    end
+    args << "--enable-cocoa" if OS.mac?
 
     system "./configure", *args
     system "make", "V=1", "install"

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -41,7 +41,7 @@ class Qscintilla2 < Formula
     args = []
     spec = ""
 
-    on_macos do
+    if OS.mac?
       # TODO: when using qt 6, modify the spec
       spec = (ENV.compiler == :clang) ? "macx-clang" : "macx-g++"
       spec << "-arm64" if Hardware::CPU.arm?

--- a/Formula/qt@5.rb
+++ b/Formula/qt@5.rb
@@ -115,7 +115,7 @@ class QtAT5 < Formula
       -dbus-runtime
     ]
 
-    on_macos do
+    if OS.mac?
       args << "-no-rpath"
       args << "-system-zlib"
       if Hardware::CPU.arm?
@@ -125,9 +125,7 @@ class QtAT5 < Formula
         # Should be reenabled unconditionally once it is fixed on Apple Silicon
         args << "-proprietary-codecs"
       end
-    end
-
-    on_linux do
+    else
       args << "-R#{lib}"
       # https://bugreports.qt.io/browse/QTBUG-71564
       args << "-no-avx2"

--- a/Formula/quilt.rb
+++ b/Formula/quilt.rb
@@ -28,11 +28,10 @@ class Quilt < Formula
       "--prefix=#{prefix}",
       "--without-getopt",
     ]
-    on_macos do
+    if OS.mac?
       args << "--with-sed=#{HOMEBREW_PREFIX}/bin/gsed"
       args << "--with-stat=/usr/bin/stat" # on macOS, quilt expects BSD stat
-    end
-    on_linux do
+    else
       args << "--with-sed=#{HOMEBREW_PREFIX}/bin/sed"
     end
     system "./configure", *args

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -39,13 +39,12 @@ class Qwt < Formula
     end
 
     args = ["-config", "release", "-spec"]
-    spec = if ENV.compiler == :clang
+    spec = if OS.linux?
+      "linux-g++"
+    elsif ENV.compiler == :clang
       "macx-clang"
     else
       "macx-g++"
-    end
-    on_linux do
-      spec = "linux-g++"
     end
     spec << "-arm64" if Hardware::CPU.arm?
     args << spec
@@ -64,7 +63,7 @@ class Qwt < Formula
         return (curve1 == NULL);
       }
     EOS
-    on_macos do
+    if OS.mac?
       system ENV.cxx, "test.cpp", "-o", "out",
         "-std=c++11",
         "-framework", "qwt", "-framework", "QtCore",
@@ -72,8 +71,7 @@ class Qwt < Formula
         "-I#{lib}/qwt.framework/Headers",
         "-I#{Formula["qt@5"].opt_lib}/QtCore.framework/Versions/5/Headers",
         "-I#{Formula["qt@5"].opt_lib}/QtGui.framework/Versions/5/Headers"
-    end
-    on_linux do
+    else
       system ENV.cxx,
         "-I#{Formula["qt@5"].opt_include}",
         "-I#{Formula["qt@5"].opt_include}/QtCore",

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -59,13 +59,11 @@ class R < Formula
       "--with-cairo",
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--without-x"
       args << "--with-aqua"
-    end
-
-    on_linux do
-      args << "--libdir=#{lib}" # avoid using lib64 on CentOS
+    else
+      c args << "--libdir=#{lib}" # avoid using lib64 on CentOS
 
       # Avoid references to homebrew shims
       args << "LD=ld"
@@ -110,10 +108,7 @@ class R < Formula
     lib.install_symlink Dir[r_home/"lib/*"]
 
     # avoid triggering mandatory rebuilds of r when gcc is upgraded
-    check_replace = true
-    on_linux do
-      check_replace = false
-    end
+    check_replace = OS.mac?
     inreplace lib/"R/etc/Makeconf", Formula["gcc"].prefix.realpath,
                                     Formula["gcc"].opt_prefix,
                                     check_replace

--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -18,9 +18,7 @@ class Rclone < Formula
 
   def install
     args = *std_go_args
-    on_macos do
-      args += ["-tags", "brew"]
-    end
+    args += ["-tags", "brew"] if OS.mac?
     system "go", "build",
       "-ldflags", "-s -X github.com/rclone/rclone/fs.Version=v#{version}",
       *args

--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -42,9 +42,10 @@ class Rdkit < Formula
     # Get Python location
     python_executable = Formula["python@3.9"].opt_bin/"python3"
     py3ver = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
-    py3prefix = Formula["python@3.9"].opt_frameworks/"Python.framework/Versions/#{py3ver}"
-    on_linux do
-      py3prefix = Formula["python@3.9"].opt_prefix
+    py3prefix = if OS.mac?
+      Formula["python@3.9"].opt_frameworks/"Python.framework/Versions/#{py3ver}"
+    else
+      Formula["python@3.9"].opt_prefix
     end
     py3include = "#{py3prefix}/include/python#{py3ver}"
     numpy_include = Formula["numpy"].opt_lib/"python#{py3ver}/site-packages/numpy/core/include"

--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -25,15 +25,11 @@ class Readline < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
-    on_linux do
-      args << "--with-curses"
-    end
+    args << "--with-curses" if OS.linux?
     system "./configure", *args
 
     args = []
-    on_linux do
-      args << "SHLIB_LIBS=-lcurses"
-    end
+    args << "SHLIB_LIBS=-lcurses" if OS.linux?
     # There is no termcap.pc in the base system, so we have to comment out
     # the corresponding Requires.private line.
     # Otherwise, pkg-config will consider the readline module unusable.

--- a/Formula/redshift.rb
+++ b/Formula/redshift.rb
@@ -39,7 +39,7 @@ class Redshift < Formula
       --disable-gui
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--enable-corelocation"
       args << "--enable-quartz"
     end

--- a/Formula/reminiscence.rb
+++ b/Formula/reminiscence.rb
@@ -43,7 +43,7 @@ class Reminiscence < Formula
 
     ENV.prepend "CPPFLAGS", "-I#{libexec}/include"
     ENV.prepend "LDFLAGS", "-L#{libexec}/lib"
-    on_linux do
+    if OS.linux?
       # Fixes: reminiscence: error while loading shared libraries: libvorbisidec.so.1
       ENV.append "LDFLAGS", "-Wl,-rpath=#{libexec}/lib"
     end

--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -47,9 +47,7 @@ class Resty < Formula
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
 
     bin.install "pypp"
-    on_linux do
-      rewrite_shebang detected_python_shebang, bin/"pypp"
-    end
+    rewrite_shebang detected_python_shebang, bin/"pypp" if OS.linux?
   end
 
   def caveats

--- a/Formula/ripmime.rb
+++ b/Formula/ripmime.rb
@@ -26,9 +26,7 @@ class Ripmime < Formula
     args = %W[
       CFLAGS=#{ENV.cflags}
     ]
-    on_macos do
-      args << "LIBS=-liconv"
-    end
+    args << "LIBS=-liconv" if OS.mac?
     system "make", *args
     bin.install "ripmime"
     man1.install "ripmime.1"

--- a/Formula/rmlint.rb
+++ b/Formula/rmlint.rb
@@ -27,7 +27,7 @@ class Rmlint < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.append_to_cflags "-I#{Formula["util-linux"].opt_include}"
       ENV.append_to_cflags "-I#{Formula["elfutils"].opt_include}"
       ENV.append "LDFLAGS", "-Wl,-rpath=#{Formula["elfutils"].opt_lib}"

--- a/Formula/rogue.rb
+++ b/Formula/rogue.rb
@@ -36,7 +36,7 @@ class Rogue < Formula
       s.gsub! "-if test ! -d $(man6dir) ; then $(INSTALL) -m 0644 rogue.6 $(DESTDIR)$(mandir)/$(PROGRAM).6 ; fi", ""
     end
 
-    on_linux do
+    if OS.linux?
       inreplace "mdport.c", "#ifdef NCURSES_VERSION",
         "#ifdef NCURSES_VERSION\nTERMTYPE *tp = (TERMTYPE *) (cur_term);"
       inreplace "mdport.c", "cur_term->type.Strings", "tp->Strings"

--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -59,7 +59,7 @@ class RomTools < Formula
       USE_SYSTEM_LIB_FLAC=1
       USE_SYSTEM_LIB_UTF8PROC=1
     ]
-    on_linux do
+    if OS.linux?
       args << "USE_SYSTEM_LIB_PORTAUDIO=1"
       args << "USE_SYSTEM_LIB_PORTMIDI=1"
     end
@@ -70,9 +70,7 @@ class RomTools < Formula
       nltool nlwav pngcmp regrep romcmp srcclean testkeys unidasm
     ]
     bin.install "split" => "rom-split"
-    on_macos do
-      bin.install "aueffectutil"
-    end
+    bin.install "aueffectutil" if OS.mac?
     man1.install Dir["docs/man/*.1"]
   end
 

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -51,7 +51,7 @@ class Root < Formula
   skip_clean "bin"
 
   def install
-    on_linux { ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/root" }
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/root" if OS.linux?
 
     # Freetype/afterimage/gl2ps/lz4 are vendored in the tarball, so are fine.
     # However, this is still permitting the build process to make remote
@@ -150,7 +150,7 @@ class Root < Formula
       }
     EOS
     flags = %w[cflags libs ldflags].map { |f| "$(root-config --#{f})" }
-    on_linux { flags << "-Wl,-rpath,#{lib}/root" }
+    flags << "-Wl,-rpath,#{lib}/root" if OS.linux?
     shell_output("$(root-config --cxx) test.cpp #{flags.join(" ")}")
     assert_equal "Hello, world!\n", shell_output("./a.out")
 

--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -63,15 +63,13 @@ class Rpm < Formula
                           "__LD=/usr/bin/ld"
     system "make", "install"
 
-    on_macos do
-      inreplace lib/"rpm/macros", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
-    end
+    inreplace lib/"rpm/macros", "#{HOMEBREW_SHIMS_PATH}/mac/super/", "" if OS.mac?
   end
 
   def post_install
     (var/"lib/rpm").mkpath
 
-    on_macos do
+    if OS.mac?
       # Attempt to fix expected location of GPG to a sane default.
       inreplace lib/"rpm/macros", "/usr/bin/gpg2", HOMEBREW_PREFIX/"bin/gpg"
     end

--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -39,10 +39,10 @@ class Rtmpdump < Formula
   def install
     ENV.deparallelize
 
-    os = "darwin"
-
-    on_linux do
-      os = "posix"
+    os = if OS.mac?
+      "darwin"
+    else
+      "posix"
     end
 
     system "make", "CC=#{ENV.cc}",

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -65,9 +65,7 @@ class Ruby < Formula
       --with-opt-dir=#{paths.join(":")}
       --without-gmp
     ]
-    on_macos do
-      args << "--disable-dtrace" unless MacOS::CLT.installed?
-    end
+    args << "--disable-dtrace" if OS.mac? && !MacOS::CLT.installed?
 
     # Correct MJIT_CC to not use superenv shim
     args << "MJIT_CC=/usr/bin/#{DevelopmentTools.default_compiler}"

--- a/Formula/ruby@2.4.rb
+++ b/Formula/ruby@2.4.rb
@@ -47,9 +47,7 @@ class RubyAT24 < Formula
       --with-opt-dir=#{paths.join(":")}
       --without-gmp
     ]
-    on_macos do
-      args << "--disable-dtrace" unless MacOS::CLT.installed?
-    end
+    args << "--disable-dtrace" if OS.mac? && !MacOS::CLT.installed?
 
     system "./configure", *args
 

--- a/Formula/ruby@2.5.rb
+++ b/Formula/ruby@2.5.rb
@@ -46,9 +46,7 @@ class RubyAT25 < Formula
       --with-opt-dir=#{paths.join(":")}
       --without-gmp
     ]
-    on_macos do
-      args << "--disable-dtrace" unless MacOS::CLT.installed?
-    end
+    args << "--disable-dtrace" if OS.mac? && !MacOS::CLT.installed?
 
     system "./configure", *args
 

--- a/Formula/ruby@2.6.rb
+++ b/Formula/ruby@2.6.rb
@@ -51,9 +51,7 @@ class RubyAT26 < Formula
       --with-opt-dir=#{paths.join(":")}
       --without-gmp
     ]
-    on_macos do
-      args << "--disable-dtrace" unless MacOS::CLT.installed?
-    end
+    args << "--disable-dtrace" if OS.mac? && !MacOS::CLT.installed?
 
     # Correct MJIT_CC to not use superenv shim
     args << "MJIT_CC=/usr/bin/#{DevelopmentTools.default_compiler}"

--- a/Formula/ruby@2.7.rb
+++ b/Formula/ruby@2.7.rb
@@ -57,9 +57,7 @@ class RubyAT27 < Formula
       --with-opt-dir=#{paths.join(":")}
       --without-gmp
     ]
-    on_macos do
-      args << "--disable-dtrace" unless MacOS::CLT.installed?
-    end
+    args << "--disable-dtrace" if OS.mac? && !MacOS::CLT.installed?
 
     # Correct MJIT_CC to not use superenv shim
     args << "MJIT_CC=/usr/bin/#{DevelopmentTools.default_compiler}"

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -73,7 +73,7 @@ class Rust < Formula
 
     # Fix build failure for compiler_builtins "error: invalid deployment target
     # for -stdlib=libc++ (requires OS X 10.7 or later)"
-    on_macos { ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version }
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version if OS.mac?
 
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
@@ -99,9 +99,7 @@ class Rust < Formula
     resource("cargo").stage do
       ENV["RUSTC"] = bin/"rustc"
       args = %W[--root #{prefix} --path .]
-      on_macos do
-        args += %w[--features curl-sys/force-system-lib-on-osx]
-      end
+      args += %w[--features curl-sys/force-system-lib-on-osx] if OS.mac?
       system "cargo", "install", *args
       man1.install Dir["src/etc/man/*.1"]
       bash_completion.install "src/etc/cargo.bashcomp.sh"

--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -75,7 +75,7 @@ class Samba < Formula
            "--prefix=#{prefix}"
     system "make"
     system "make", "install"
-    on_macos do
+    if OS.mac?
       # macOS has its own SMB daemon as /usr/sbin/smbd, so rename our smbd to samba-dot-org-smbd to avoid conflict.
       # samba-dot-org-smbd is used by qemu.rb .
       # Rename mdfind and profiles as well to avoid conflicting with /usr/bin/{mdfind,profiles}

--- a/Formula/scrollkeeper.rb
+++ b/Formula/scrollkeeper.rb
@@ -34,7 +34,7 @@ class Scrollkeeper < Formula
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
       resources.each do |res|
         res.stage do

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -45,10 +45,9 @@ class Sdl2 < Formula
     system "./autogen.sh" if build.head?
 
     args = %W[--prefix=#{prefix} --enable-hidapi]
-    on_macos do
-      args << "--without-x"
-    end
-    on_linux do
+    args << if OS.mac?
+      "--without-x"
+    else
       args << "--with-x"
       args << "--enable-pulseaudio"
       args << "--enable-pulseaudio-shared"
@@ -62,7 +61,7 @@ class Sdl2 < Formula
       args << "--enable-video-x11-xinput"
       args << "--enable-video-x11-xrandr"
       args << "--enable-video-x11-xshape"
-      args << "--enable-x11-shared"
+      "--enable-x11-shared"
     end
     system "./configure", *args
     system "make", "install"

--- a/Formula/serd.rb
+++ b/Formula/serd.rb
@@ -24,9 +24,7 @@ class Serd < Formula
   end
 
   def install
-    on_linux do
-      ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
-    end
+    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin" if OS.linux?
     system "./waf", "configure", "--prefix=#{prefix}"
     system "./waf"
     system "./waf", "install"

--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -49,9 +49,7 @@ class Sfml < Formula
             "-DSFML_INSTALL_PKGCONFIG_FILES=TRUE",
             "-DSFML_BUILD_DOC=TRUE"]
 
-    on_linux do
-      args << "-DSFML_USE_SYSTEM_DEPS=ON"
-    end
+    args << "-DSFML_USE_SYSTEM_DEPS=ON" if OS.linux?
 
     system "cmake", ".", *std_cmake_args, *args
     system "make", "install"

--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -46,7 +46,7 @@ class ShairportSync < Formula
       --sysconfdir=#{etc}/shairport-sync
       --prefix=#{prefix}
     ]
-    on_macos do
+    if OS.mac?
       args << "--with-dns_sd" # Enable bonjour
       args << "--with-os=darwin"
     end

--- a/Formula/signal-cli.rb
+++ b/Formula/signal-cli.rb
@@ -67,8 +67,11 @@ class SignalCli < Formula
       system "zip", "-d", zkgroup_jar, "libzkgroup.so"
 
       # build & embed library for current platform
-      target = "mac_dylib"
-      on_linux { target = "libzkgroup" }
+      target = if OS.mac?
+        "mac_dylib"
+      else
+        "libzkgroup"
+      end
       system "make", target
       cd "ffi/java/src/main/resources" do
         system "zip", "-u", zkgroup_jar, shared_library("libzkgroup")

--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -141,7 +141,7 @@ class Sile < Formula
     ENV.prepend "LDFLAGS", "-L#{lua.opt_lib}"
 
     zlib_dir = expat_dir = "#{MacOS.sdk_path_if_needed}/usr"
-    on_linux do
+    if OS.linux?
       zlib_dir = Formula["zlib"].opt_prefix
       expat_dir = Formula["expat"].opt_prefix
     end

--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -30,7 +30,7 @@ class Sleuthkit < Formula
   conflicts_with "ffind", because: "both install a `ffind` executable"
 
   def install
-    on_macos { ENV["SED"] = "/usr/bin/sed" }
+    ENV["SED"] = "/usr/bin/sed" if OS.mac?
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
     ENV["ANT_FOUND"] = Formula["ant"].opt_bin/"ant"
     ENV.append_to_cflags "-DNDEBUG"
@@ -41,7 +41,7 @@ class Sleuthkit < Formula
     cd "bindings/java" do
       system "ant"
 
-      on_linux do
+      if OS.linux?
         inreplace "Makefile", HOMEBREW_LIBRARY/"Homebrew/shims/linux/super/ld", "ld"
         inreplace "jni/Makefile", HOMEBREW_LIBRARY/"Homebrew/shims/linux/super/ld", "ld"
       end

--- a/Formula/snappy.rb
+++ b/Formula/snappy.rb
@@ -38,9 +38,7 @@ class Snappy < Formula
 
   def install
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
     # Disable tests/benchmarks used for Snappy development
     args = std_cmake_args + %w[
@@ -57,7 +55,7 @@ class Snappy < Formula
 
   test do
     # Force use of Clang on Mojave
-    on_macos { ENV.clang }
+    ENV.clang if OS.mac?
 
     (testpath/"test.cpp").write <<~EOS
       #include <assert.h>

--- a/Formula/sngrep.rb
+++ b/Formula/sngrep.rb
@@ -21,9 +21,7 @@ class Sngrep < Formula
   uses_from_macos "ncurses"
 
   def install
-    on_linux do
-      ENV.append_to_cflags "-I#{Formula["ncurses"].opt_include}/ncursesw"
-    end
+    ENV.append_to_cflags "-I#{Formula["ncurses"].opt_include}/ncursesw" if OS.linux?
 
     system "./bootstrap.sh"
     system "./configure", "--disable-debug",

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -28,11 +28,10 @@ class SonarqubeLts < Formula
 
   def install
     # Delete native bin directories for other systems
-    remove = "linux"
-    keep = "macosx-universal"
-    on_linux do
-      remove = "macosx"
-      keep = "linux-x86"
+    remove, keep = if OS.mac?
+      ["linux", "macosx-universal"]
+    else
+      ["macosx", "linux-x86"]
     end
 
     rm_rf Dir["bin/{#{remove},windows}-*"]

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -25,11 +25,10 @@ class Sonarqube < Formula
 
   def install
     # Delete native bin directories for other systems
-    remove = "linux"
-    keep = "macosx-universal"
-    on_linux do
-      remove = "macosx"
-      keep = "linux-x86"
+    remove, keep = if OS.mac?
+      ["linux", "macosx-universal"]
+    else
+      ["macosx", "linux-x86"]
     end
 
     rm_rf Dir["bin/{#{remove},windows}-*"]

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -20,9 +20,10 @@ class SourceToImage < Formula
 
   def install
     system "hack/build-go.sh"
-    os = "darwin"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "darwin"
+    else
+      "linux"
     end
     arch = Hardware::CPU.arm? ? "arm64" : "amd64"
     bin.install "_output/local/bin/#{os}/#{arch}/s2i"

--- a/Formula/splint.rb
+++ b/Formula/splint.rb
@@ -29,9 +29,7 @@ class Splint < Formula
             "--infodir=#{info}",
             "--mandir=#{man}"]
 
-    on_linux do
-      args << "LEXLIB=#{Formula["flex"].opt_lib}/libfl.so"
-    end
+    args << "LEXLIB=#{Formula["flex"].opt_lib}/libfl.so" if OS.linux?
 
     system "./configure", *args
     system "make"

--- a/Formula/sqlcipher.rb
+++ b/Formula/sqlcipher.rb
@@ -39,9 +39,7 @@ class Sqlcipher < Formula
     ].join(" ")
     args << "CFLAGS=#{cflags}"
 
-    on_linux do
-      args << "LIBS=-lm"
-    end
+    args << "LIBS=-lm" if OS.linux?
 
     system "./configure", *args
     system "make"

--- a/Formula/sqliteodbc.rb
+++ b/Formula/sqliteodbc.rb
@@ -29,12 +29,12 @@ class Sqliteodbc < Formula
     lib.mkdir
     args = ["--with-odbc=#{Formula["unixodbc"].opt_prefix}",
             "--with-sqlite3=#{Formula["sqlite"].opt_prefix}"]
-    on_linux { args << "--with-libxml2=#{Formula["libxml2"].opt_prefix}" }
+    args << "--with-libxml2=#{Formula["libxml2"].opt_prefix}" if OS.linux?
 
     system "./configure", "--prefix=#{prefix}", *args
     system "make"
     system "make", "install"
-    on_macos { lib.install_symlink lib/"libsqlite3odbc.dylib" => "libsqlite3odbc.so" }
+    lib.install_symlink lib/"libsqlite3odbc.dylib" => "libsqlite3odbc.so" if OS.mac?
   end
 
   test do

--- a/Formula/stella.rb
+++ b/Formula/stella.rb
@@ -28,7 +28,7 @@ class Stella < Formula
   def install
     sdl2 = Formula["sdl2"]
     libpng = Formula["libpng"]
-    on_macos do
+    if OS.mac?
       cd "src/macos" do
         inreplace "stella.xcodeproj/project.pbxproj" do |s|
           s.gsub! %r{(\w{24} /\* SDL2\.framework)}, '//\1'
@@ -43,9 +43,7 @@ class Stella < Formula
         prefix.install "build/Release/Stella.app"
         bin.write_exec_script "#{prefix}/Stella.app/Contents/MacOS/Stella"
       end
-    end
-
-    on_linux do
+    else
       system "./configure", "--prefix=#{prefix}",
                             "--bindir=#{bin}",
                             "--enable-release",
@@ -57,11 +55,9 @@ class Stella < Formula
   end
 
   test do
-    on_macos do
+    if OS.mac?
       assert_match "E.T. - The Extra-Terrestrial", shell_output("#{bin}/Stella -listrominfo").strip
-    end
-
-    on_linux do
+    else
       assert_match "failed to initialize: unable to open database file",
         shell_output("#{bin}/stella -listrominfo").strip
     end

--- a/Formula/stlink.rb
+++ b/Formula/stlink.rb
@@ -19,7 +19,7 @@ class Stlink < Formula
 
   def install
     args = std_cmake_args
-    on_linux do
+    if OS.linux?
       args << "-DSTLINK_MODPROBED_DIR=#{lib}/modprobe.d"
       args << "-DSTLINK_UDEV_RULES_DIR=#{lib}/udev/rules.d"
     end

--- a/Formula/stunnel.rb
+++ b/Formula/stunnel.rb
@@ -72,8 +72,11 @@ class Stunnel < Formula
   end
 
   test do
-    user = "nobody"
-    on_linux { user = ENV["USER"] }
+    user = if OS.mac?
+      "nobody"
+    else
+      ENV["USER"]
+    end
     (testpath/"tstunnel.conf").write <<~EOS
       cert = #{etc}/stunnel/stunnel.pem
 

--- a/Formula/suricata.rb
+++ b/Formula/suricata.rb
@@ -75,13 +75,11 @@ class Suricata < Formula
       --with-libnet-libraries=#{libnet.opt_lib}
     ]
 
-    on_macos do
-      args << "--enable-ipfw"
-    end
-
-    on_linux do
+    args << if OS.mac?
+      "--enable-ipfw"
+    else
       args << "--with-libpcap-includes=#{Formula["libpcap"].opt_include}"
-      args << "--with-libpcap-libraries=#{Formula["libpcap"].opt_lib}"
+      "--with-libpcap-libraries=#{Formula["libpcap"].opt_lib}"
     end
 
     system "./configure", *args

--- a/Formula/swi-prolog.rb
+++ b/Formula/swi-prolog.rb
@@ -33,7 +33,7 @@ class SwiProlog < Formula
 
   def install
     # Remove shim paths from binary files `swipl-ld` and `libswipl.so.*`
-    on_linux do
+    if OS.linux?
       inreplace "cmake/Params.cmake" do |s|
         s.gsub! "${CMAKE_C_COMPILER}", "\"gcc\""
         s.gsub! "${CMAKE_CXX_COMPILER}", "\"g++\""

--- a/Formula/swift-sh.rb
+++ b/Formula/swift-sh.rb
@@ -20,7 +20,7 @@ class SwiftSh < Formula
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"
     bin.install ".build/release/swift-sh"
-    on_macos { bin.install ".build/release/swift-sh-edit" }
+    bin.install ".build/release/swift-sh-edit" if OS.mac?
   end
 
   test do

--- a/Formula/synscan.rb
+++ b/Formula/synscan.rb
@@ -24,10 +24,9 @@ class Synscan < Formula
     ENV.append "LIBS", "-L#{Formula["libpcap"].opt_lib} -lpcap"
     system "./configure", "--prefix=#{prefix}",
                           "--with-libpcap=yes"
-    on_macos do
+    if OS.mac?
       system "make", "macos"
-    end
-    on_linux do
+    else
       system "make", "linux"
     end
     system "make", "install"

--- a/Formula/sysdig.rb
+++ b/Formula/sysdig.rb
@@ -46,7 +46,7 @@ class Sysdig < Formula
       -DUSE_BUNDLED_DEPS=OFF
       -DCREATE_TEST_TARGETS=OFF
     ]
-    on_linux { args << "-DBUILD_DRIVER=OFF" }
+    args << "-DBUILD_DRIVER=OFF" if OS.linux?
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -35,15 +35,13 @@ class Tbb < Formula
 
     cd "python" do
       ENV.append_path "CMAKE_PREFIX_PATH", prefix.to_s
-      on_macos do
-        ENV["LDFLAGS"] = "-rpath #{opt_lib}"
-      end
+      ENV["LDFLAGS"] = "-rpath #{opt_lib}" if OS.mac?
 
       ENV["TBBROOT"] = prefix
       system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
     end
 
-    on_linux do
+    if OS.linux?
       inreplace prefix/"rml/CMakeFiles/irml.dir/flags.make",
                 "#{HOMEBREW_LIBRARY}/Homebrew/shims/linux/super/g++-5",
                 "/usr/bin/c++"

--- a/Formula/tbb@2020.rb
+++ b/Formula/tbb@2020.rb
@@ -42,15 +42,18 @@ class TbbAT2020 < Formula
 
     cd "python" do
       ENV["TBBROOT"] = prefix
-      on_linux do
+      if OS.linux?
         system "make", "-C", "rml", "compiler=#{compiler}", "CPATH=#{include}"
         lib.install Dir["rml/libirml.so*"]
       end
       system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
     end
 
-    os = "Darwin"
-    on_linux { os = "Linux" }
+    os = if OS.mac?
+      "Darwin"
+    else
+      "Linux"
+    end
     system "cmake", *std_cmake_args,
                     "-DINSTALL_DIR=lib/cmake/TBB",
                     "-DSYSTEM_NAME=#{os}",

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -80,9 +80,7 @@ class TclTk < Formula
 
     resource("tk").stage do
       cd "unix" do
-        on_macos do
-          args << "--enable-aqua=yes"
-        end
+        args << "--enable-aqua=yes" if OS.mac?
         system "./configure", *args, "--without-x", "--with-tcl=#{lib}"
         system "make"
         system "make", "install"
@@ -98,14 +96,10 @@ class TclTk < Formula
     resource("tcllib").stage do
       system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
       system "make", "install"
-      on_macos do
-        ENV["SDKROOT"] = MacOS.sdk_path
-      end
+      ENV["SDKROOT"] = MacOS.sdk_path if OS.mac?
       system "make", "critcl"
       cp_r "modules/tcllibc", "#{lib}/"
-      on_macos do
-        ln_s "#{lib}/tcllibc/macosx-x86_64-clang", "#{lib}/tcllibc/macosx-x86_64"
-      end
+      ln_s "#{lib}/tcllibc/macosx-x86_64-clang", "#{lib}/tcllibc/macosx-x86_64" if OS.mac?
     end
 
     resource("tcltls").stage do

--- a/Formula/tcpreplay.rb
+++ b/Formula/tcpreplay.rb
@@ -29,9 +29,8 @@ class Tcpreplay < Formula
       --enable-dynamic-link
     ]
 
-    on_macos do
+    args << if OS.mac?
       ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
-      args << "--with-macosx-sdk=#{MacOS.version}"
 
       # The SDK is currently found using `xcrun --sdk macosx<V>` starting with
       # input `--with-macosx-sdk=<V>` and then going from older 10.8 onward.
@@ -42,10 +41,10 @@ class Tcpreplay < Formula
       # Check in next release if the workaround can be removed.
       # Upstream issue: https://github.com/appneta/tcpreplay/issues/668
       inreplace "configure.ac", /(\$with_macosx_sdk\s+)(?:10\.\d+\s+)+/, "\\1" if Hardware::CPU.arm?
-    end
 
-    on_linux do
-      args << "--with-libpcap=#{Formula["libpcap"].opt_prefix}"
+      "--with-macosx-sdk=#{MacOS.version}"
+    else
+      "--with-libpcap=#{Formula["libpcap"].opt_prefix}"
     end
 
     system "./autogen.sh"

--- a/Formula/tealdeer.rb
+++ b/Formula/tealdeer.rb
@@ -24,9 +24,7 @@ class Tealdeer < Formula
   conflicts_with "tldr", because: "both install `tldr` binaries"
 
   def install
-    on_linux do
-      ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
-    end
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix if OS.linux?
     system "cargo", "install", *std_cargo_args
     bash_completion.install "bash_tealdeer" => "tldr"
     zsh_completion.install "zsh_tealdeer" => "_tldr"

--- a/Formula/teensy_loader_cli.rb
+++ b/Formula/teensy_loader_cli.rb
@@ -20,7 +20,7 @@ class TeensyLoaderCli < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       ENV["OS"] = "MACOSX"
       ENV["SDK"] = MacOS.sdk_path || "/"
 

--- a/Formula/terraform-docs.rb
+++ b/Formula/terraform-docs.rb
@@ -18,9 +18,10 @@ class TerraformDocs < Formula
   def install
     system "make", "build"
     cpu = Hardware::CPU.arm? ? "arm64" : "amd64"
-    os = "darwin"
-    on_linux do
-      os = "linux"
+    os = if OS.mac?
+      "darwin"
+    else
+      "linux"
     end
     bin.install "bin/#{os}-#{cpu}/terraform-docs"
     prefix.install_metafiles

--- a/Formula/terraform@0.11.rb
+++ b/Formula/terraform@0.11.rb
@@ -36,9 +36,10 @@ class TerraformAT011 < Formula
       ENV.delete "AWS_ACCESS_KEY"
       ENV.delete "AWS_SECRET_KEY"
 
-      os = "darwin"
-      on_linux do
-        os = "linux"
+      os = if OS.mac?
+        "darwin"
+      else
+        "linux"
       end
       ENV["XC_OS"] = os
       ENV["XC_ARCH"] = "amd64"

--- a/Formula/thrax.rb
+++ b/Formula/thrax.rb
@@ -31,7 +31,7 @@ class Thrax < Formula
   def install
     system "./configure", *std_configure_args
     system "make", "install"
-    on_linux { rewrite_shebang detected_python_shebang, bin/"thraxmakedep" }
+    rewrite_shebang detected_python_shebang, bin/"thraxmakedep" if OS.linux?
   end
 
   test do

--- a/Formula/transmission-cli.rb
+++ b/Formula/transmission-cli.rb
@@ -28,7 +28,7 @@ class TransmissionCli < Formula
   uses_from_macos "zlib"
 
   def install
-    on_macos do
+    if OS.mac?
       ENV.append "LDFLAGS", "-framework Foundation -prebind"
       ENV.append "LDFLAGS", "-liconv"
     end

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -36,11 +36,10 @@ class Tundra < Formula
       }
     EOS
 
-    os = "macosx"
-    cc = "clang"
-    on_linux do
-      os = "linux"
-      cc = "gcc"
+    os, cc = if OS.mac?
+      ["macosx", "clang"]
+    else
+      ["linux", "gcc"]
     end
 
     (testpath/"tundra.lua").write <<~EOS

--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -40,12 +40,8 @@ class Unbound < Formula
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
-    on_macos do
-      args << "--with-libexpat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed
-    end
-    on_linux do
-      args << "--with-libexpat=#{Formula["expat"].opt_prefix}"
-    end
+    args << "--with-libexpat=#{MacOS.sdk_path}/usr" if OS.mac? && MacOS.sdk_path_if_needed
+    args << "--with-libexpat=#{Formula["expat"].opt_prefix}" if OS.linux?
     system "./configure", *args
 
     inreplace "doc/example.conf", 'username: "unbound"', 'username: "@@HOMEBREW-UNBOUND-USER@@"'

--- a/Formula/unpaper.rb
+++ b/Formula/unpaper.rb
@@ -33,9 +33,7 @@ class Unpaper < Formula
   def install
     system "autoreconf", "-i" if build.head?
 
-    on_linux do
-      system "autoreconf", "-i"
-    end
+    system "autoreconf", "-i" if OS.linux?
 
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/unrtf.rb
+++ b/Formula/unrtf.rb
@@ -23,9 +23,7 @@ class Unrtf < Formula
   def install
     system "./bootstrap"
     args = %W[--prefix=#{prefix}]
-    on_macos do
-      args << "LIBS=-liconv"
-    end
+    args << "LIBS=-liconv" if OS.mac?
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/unzip.rb
+++ b/Formula/unzip.rb
@@ -69,9 +69,7 @@ class Unzip < Formula
       L_BZ2=-lbz2
       macosx
     ]
-    on_macos do
-      args << "LFLAGS1=-liconv"
-    end
+    args << "LFLAGS1=-liconv" if OS.mac?
     system "make", "-f", "unix/Makefile", *args
     system "make", "prefix=#{prefix}", "MANDIR=#{man1}", "install"
   end

--- a/Formula/urlview.rb
+++ b/Formula/urlview.rb
@@ -39,7 +39,7 @@ class Urlview < Formula
 
     man1.mkpath
 
-    on_linux do
+    if OS.linux?
       touch("NEWS") # autoreconf will fail if this file does not exist
       system "autoreconf", "-i"
     end

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -39,15 +39,14 @@ class UtilLinux < Formula
       --disable-silent-rules
     ]
 
-    on_macos do
+    if OS.mac?
       args << "--disable-hardlink" # does not build on macOS
       args << "--disable-ipcs" # does not build on macOS
       args << "--disable-ipcrm" # does not build on macOS
       args << "--disable-wall" # already comes with macOS
       args << "--disable-libmount" # does not build on macOS
       args << "--enable-libuuid" # conflicts with ossp-uuid
-    end
-    on_linux do
+    else
       args << "--disable-use-tty-group" # Fix chgrp: changing group of 'wall': Operation not permitted
       args << "--disable-kill" # Conflicts with coreutils.
       args << "--disable-cal" # Conflicts with bsdmainutils

--- a/Formula/uwsgi.rb
+++ b/Formula/uwsgi.rb
@@ -79,9 +79,7 @@ class Uwsgi < Formula
                  transformation_chunked transformation_gzip
                  transformation_offload transformation_tofile
                  transformation_toupper ugreen webdav zergpool]
-    on_macos do
-      plugins << "alarm_speech"
-    end
+    plugins << "alarm_speech" if OS.mac?
 
     (libexec/"uwsgi").mkpath
     plugins.each do |plugin|

--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -116,7 +116,7 @@ class V8 < Formula
       use_lld:                      false, # https://github.com/Homebrew/homebrew-core/pull/84351#issuecomment-909621336
     }
 
-    on_linux do
+    if OS.linux?
       gn_args[:is_clang] = false # use GCC on Linux
       gn_args[:use_sysroot] = false # don't use sysroot
       gn_args[:custom_toolchain] = "\"//build/toolchain/linux/unbundle:default\"" # uses system toolchain
@@ -148,7 +148,7 @@ class V8 < Formula
 
     libexec.install Dir["out.gn/#{shared_library("*")}"]
     lib.install_symlink Dir[libexec/shared_library("libv8*")]
-    on_linux { rm Dir[lib/"*.TOC"] } # Remove symlinks to .so.TOC text files
+    rm Dir[lib/"*.TOC"] if OS.linux? # Remove symlinks to .so.TOC text files
   end
 
   test do

--- a/Formula/vamp-plugin-sdk.rb
+++ b/Formula/vamp-plugin-sdk.rb
@@ -47,8 +47,11 @@ class VampPluginSdk < Formula
       vampGetPluginDescriptor(unsigned int version, unsigned int index) { return NULL; }
     EOS
 
-    flags = ["-Wl,-dylib"]
-    on_linux { flags = ["-shared", "-fPIC"] }
+    flags = if OS.mac?
+      ["-Wl,-dylib"]
+    else
+      ["-shared", "-fPIC"]
+    end
 
     system ENV.cxx, "test.cpp", "-I#{include}", *flags, "-o", shared_library("test")
     assert_match "Usage:", shell_output("#{bin}/vamp-rdf-template-generator 2>&1", 2)

--- a/Formula/vera++.rb
+++ b/Formula/vera++.rb
@@ -85,7 +85,7 @@ class Veraxx < Formula
       -DBoost_INCLUDE_DIR:PATH=#{buildpath}/3rdParty/include
       -DBoost_LIBRARY_DIR_RELEASE:PATH=#{buildpath}/3rdParty/lib
     ]
-    on_linux do
+    if OS.linux?
       # Disable building Python rules support since vera++ needs Python 2.
       # Revisit on release with Python 3: https://bitbucket.org/verateam/vera/issues/108/migrate-to-python-3
       args << "-DVERA_PYTHON=OFF"

--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -34,7 +34,7 @@ class VercelCli < Formula
     dist_dir = libexec/"lib/node_modules/vercel/dist"
     rm_rf dist_dir/"term-size"
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/vis.rb
+++ b/Formula/vis.rb
@@ -44,7 +44,7 @@ class Vis < Formula
     luaenv = { LUA_PATH: ENV["LUA_PATH"], LUA_CPATH: ENV["LUA_CPATH"] }
     bin.env_script_all_files(libexec/"bin", luaenv)
 
-    on_macos do
+    if OS.mac?
       # Rename vis & the matching manpage to avoid clashing with the system.
       mv bin/"vis", bin/"vise"
       mv man1/"vis.1", man1/"vise.1"

--- a/Formula/vpcs.rb
+++ b/Formula/vpcs.rb
@@ -18,10 +18,9 @@ class Vpcs < Formula
 
   def install
     cd "src" do
-      on_macos do
+      if OS.mac?
         system "make", "-f", "Makefile.osx"
-      end
-      on_linux do
+      else
         system "make", "-f", "Makefile.linux"
       end
       bin.install "vpcs"

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -105,9 +105,7 @@ class Vtk < Formula
     # https://github.com/Homebrew/linuxbrew-core/pull/21654#issuecomment-738549701
     args << "-DOpenGL_GL_PREFERENCE=LEGACY"
 
-    on_macos do
-      args << "-DVTK_USE_COCOA:BOOL=ON"
-    end
+    args << "-DVTK_USE_COCOA:BOOL=ON" if OS.mac?
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -76,7 +76,7 @@ class VtkAT82 < Formula
 
     # Fix build with GCC 10 or newer
     # Adapted from https://bugs.gentoo.org/attachment.cgi?id=641488&action=diff
-    on_linux { inreplace "CMake/VTKGenerateExportHeader.cmake", "[3-9]", "[1-9][0-9]" }
+    inreplace "CMake/VTKGenerateExportHeader.cmake", "[3-9]", "[1-9][0-9]" if OS.linux?
 
     pyver = Language::Python.major_minor_version "python3"
     args = std_cmake_args + %W[
@@ -106,9 +106,7 @@ class VtkAT82 < Formula
       -DSIP_PYQT_DIR='#{Formula["pyqt5"].opt_share}/sip'
     ]
 
-    on_macos do
-      args << "-DVTK_USE_COCOA=ON"
-    end
+    args << "-DVTK_USE_COCOA=ON" if OS.mac?
 
     mkdir "build" do
       system "cmake", "..", *args
@@ -134,7 +132,7 @@ class VtkAT82 < Formula
       lib/"cmake/vtk-#{version.major_minor}/VTKConfig.cmake",
       lib/"cmake/vtk-#{version.major_minor}/Modules/vtkPython.cmake",
     ]
-    on_macos { inreplace_cmake_modules << lib/"cmake/vtk-#{version.major_minor}/VTKTargets-release.cmake" }
+    inreplace_cmake_modules << lib/"cmake/vtk-#{version.major_minor}/VTKTargets-release.cmake" if OS.mac?
 
     inreplace inreplace_cmake_modules, prefix, opt_prefix
   end

--- a/Formula/vue-cli.rb
+++ b/Formula/vue-cli.rb
@@ -34,7 +34,7 @@ class VueCli < Formula
     node_notifier_vendor_dir = libexec/"lib/node_modules/@vue/cli/node_modules/node-notifier/vendor"
     node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
 
-    on_macos do
+    if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"
       macos_dir.mkpath
       # Replace the vendored pre-built term-size with one we build ourselves

--- a/Formula/webtorrent-cli.rb
+++ b/Formula/webtorrent-cli.rb
@@ -25,8 +25,13 @@ class WebtorrentCli < Formula
     modules_dir = libexec/"lib/node_modules"/name/"node_modules"
     modules_dir.glob("*/prebuilds/{win32-,linux-arm}*").map(&:rmtree)
 
-    arch_to_remove = Hardware::CPU.intel? ? "arm64" : "x64"
-    on_linux { arch_to_remove = "*" }
+    arch_to_remove = if OS.linux?
+      "*"
+    elsif Hardware::CPU.intel?
+      "arm64"
+    else
+      "x64"
+    end
     modules_dir.glob("*/prebuilds/darwin-#{arch_to_remove}").map(&:rmtree)
   end
 

--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -20,14 +20,12 @@ class Whois < Formula
   depends_on "libidn2"
 
   def install
-    on_macos do
-      ENV.append "LDFLAGS", "-L/usr/lib -liconv"
-    end
+    ENV.append "LDFLAGS", "-L/usr/lib -liconv" if OS.mac?
 
-    have_iconv = "HAVE_ICONV=1"
-
-    on_linux do
-      have_iconv = "HAVE_ICONV=0"
+    have_iconv = if OS.mac?
+      "HAVE_ICONV=1"
+    else
+      "HAVE_ICONV=0"
     end
 
     system "make", "whois", have_iconv

--- a/Formula/wolfssl.rb
+++ b/Formula/wolfssl.rb
@@ -80,7 +80,7 @@ class Wolfssl < Formula
       --enable-fasthugemath
     ]
 
-    on_macos do
+    if OS.mac?
       # Extra flag is stated as a needed for the Mac platform.
       # https://www.wolfssl.com/docs/wolfssl-manual/ch2/
       # Also, only applies if fastmath is enabled.

--- a/Formula/wren-cli.rb
+++ b/Formula/wren-cli.rb
@@ -15,10 +15,9 @@ class WrenCli < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       system "make", "-C", "projects/make.mac"
-    end
-    on_linux do
+    else
       system "make", "-C", "projects/make"
     end
     bin.install "bin/wren_cli"

--- a/Formula/wren.rb
+++ b/Formula/wren.rb
@@ -19,10 +19,9 @@ class Wren < Formula
   end
 
   def install
-    on_macos do
+    if OS.mac?
       system "make", "-C", "projects/make.mac"
-    end
-    on_linux do
+    else
       system "make", "-C", "projects/make"
     end
     lib.install Dir["lib/*"]

--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -26,16 +26,12 @@ class Wxmaxima < Formula
       system "ninja"
       system "ninja", "install"
 
-      on_macos do
-        prefix.install "src/wxMaxima.app"
-      end
+      prefix.install "src/wxMaxima.app" if OS.mac?
     end
 
     bash_completion.install "data/wxmaxima"
 
-    on_macos do
-      bin.write_exec_script "#{prefix}/wxMaxima.app/Contents/MacOS/wxmaxima"
-    end
+    bin.write_exec_script "#{prefix}/wxMaxima.app/Contents/MacOS/wxmaxima" if OS.mac?
   end
 
   def caveats

--- a/Formula/wxpython.rb
+++ b/Formula/wxpython.rb
@@ -44,7 +44,7 @@ class Wxpython < Formula
     inreplace "wscript", "MACOSX_DEPLOYMENT_TARGET = \"10.6\"",
                          "MACOSX_DEPLOYMENT_TARGET = \"#{MacOS.version}\""
 
-    on_macos do
+    if OS.mac?
       sdk = MacOS.sdk_path_if_needed
       ENV.append_to_cflags "-I#{sdk}/usr/include" if sdk
     end

--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -54,7 +54,7 @@ class Wxwidgets < Formula
       "--disable-monolithic",
     ]
 
-    on_macos do
+    if OS.mac?
       # Set with-macosx-version-min to avoid configure defaulting to 10.5
       args << "--with-macosx-version-min=#{MacOS.version}"
       args << "--with-osx_cocoa"

--- a/Formula/wxwidgets@3.0.rb
+++ b/Formula/wxwidgets@3.0.rb
@@ -54,7 +54,7 @@ class WxwidgetsAT30 < Formula
       "--disable-monolithic",
     ]
 
-    on_macos do
+    if OS.mac?
       # Set with-macosx-version-min to avoid configure defaulting to 10.5
       args << "--with-macosx-version-min=#{MacOS.version}"
       args << "--with-osx_cocoa"

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -50,12 +50,10 @@ class X265 < Formula
       system "make"
       mv "libx265.a", "libx265_main.a"
 
-      on_macos do
+      if OS.mac?
         system "libtool", "-static", "-o", "libx265.a", "libx265_main.a",
                           "libx265_main10.a", "libx265_main12.a"
-      end
-
-      on_linux do
+      else
         system "ar", "cr", "libx265.a", "libx265_main.a", "libx265_main10.a",
                            "libx265_main12.a"
         system "ranlib", "libx265.a"

--- a/Formula/xgboost.rb
+++ b/Formula/xgboost.rb
@@ -34,9 +34,7 @@ class Xgboost < Formula
 
   def install
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
-    on_macos do
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
-    end
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
     mkdir "build" do
       system "cmake", *std_cmake_args, ".."
@@ -48,7 +46,7 @@ class Xgboost < Formula
 
   test do
     # Force use of Clang on Mojave
-    on_macos { ENV.clang }
+    ENV.clang if OS.mac?
 
     cp_r (pkgshare/"demo"), testpath
     cd "demo/data" do

--- a/Formula/xmake.rb
+++ b/Formula/xmake.rb
@@ -19,9 +19,7 @@ class Xmake < Formula
   end
 
   def install
-    on_linux do
-      ENV["XMAKE_ROOT"] = "y" if ENV["HOMEBREW_GITHUB_ACTIONS"]
-    end
+    ENV["XMAKE_ROOT"] = "y" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
     system "make"
     system "make", "install", "prefix=#{prefix}"

--- a/Formula/xmltoman.rb
+++ b/Formula/xmltoman.rb
@@ -32,7 +32,7 @@ class Xmltoman < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
       resources.each do |res|
@@ -55,9 +55,7 @@ class Xmltoman < Formula
     bin.install %w[xmltoman xmlmantohtml]
     pkgshare.install %w[xmltoman.xsl xmltoman.dtd xmltoman.css]
 
-    on_linux do
-      bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
-    end
+    bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"]) if OS.linux?
   end
 
   def test_do

--- a/Formula/xplanet.rb
+++ b/Formula/xplanet.rb
@@ -49,9 +49,7 @@ class Xplanet < Formula
       "--without-x",
       "--without-xscreensaver",
     ]
-    on_macos do
-      args << "--with-aqua"
-    end
+    args << "--with-aqua" if OS.mac?
     system "./configure", *args
 
     system "make", "install"

--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -39,7 +39,7 @@ class Yaws < Formula
     extra_args = %W[
       --with-extrainclude=#{MacOS.sdk_path}/usr/include/security
     ]
-    on_linux do
+    if OS.linux?
       extra_args = %W[
         --with-extrainclude=#{Formula["linux-pam"].opt_include}/security
       ]
@@ -58,7 +58,7 @@ class Yaws < Formula
     (lib/"yaws/examples/include").mkpath
 
     # Remove Homebrew shims references on Linux
-    on_linux do
+    if OS.linux?
       inreplace Dir["#{prefix}/var/yaws/www/*/Makefile"], HOMEBREW_LIBRARY/"Homebrew/shims/linux/super/",
         "/usr/bin/"
     end

--- a/Formula/ykman.rb
+++ b/Formula/ykman.rb
@@ -69,7 +69,7 @@ class Ykman < Formula
   end
 
   def install
-    on_linux do
+    if OS.linux?
       # Fixes: smartcard/scard/helpers.c:28:22: fatal error: winscard.h: No such file or directory
       ENV.append "CFLAGS", "-I#{Formula["pcsc-lite"].opt_include}/PCSC"
     end

--- a/Formula/ykpers.rb
+++ b/Formula/ykpers.rb
@@ -46,11 +46,10 @@ class Ykpers < Formula
       --prefix=#{prefix}
       --with-libyubikey-prefix=#{Formula["libyubikey"].opt_prefix}
     ]
-    on_macos do
-      args << "--with-backend=osx"
-    end
-    on_linux do
-      args << "--with-backend=libusb-1.0"
+    args << if OS.mac?
+      "--with-backend=osx"
+    else
+      "--with-backend=libusb-1.0"
     end
     system "./configure", *args
     system "make", "check"

--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -27,7 +27,7 @@ class Zabbix < Formula
       --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
-    on_macos do
+    if OS.mac?
       sdk = MacOS::CLT.installed? ? "" : MacOS.sdk_path
       args << "--with-iconv=#{sdk}/usr"
     end

--- a/Formula/zita-convolver.rb
+++ b/Formula/zita-convolver.rb
@@ -23,9 +23,7 @@ class ZitaConvolver < Formula
 
   def install
     cd "source" do
-      on_macos do
-        inreplace "Makefile", "-Wl,-soname,", "-Wl,-install_name,"
-      end
+      inreplace "Makefile", "-Wl,-soname,", "-Wl,-install_name," if OS.mac?
       inreplace "Makefile", "ldconfig", "ln -sf $(ZITA-CONVOLVER_MIN) $(DESTDIR)$(LIBDIR)/$(ZITA-CONVOLVER_MAJ)"
       system "make", "install", "PREFIX=#{prefix}", "SUFFIX="
     end

--- a/Formula/znc.rb
+++ b/Formula/znc.rb
@@ -37,7 +37,7 @@ class Znc < Formula
     ENV.append "CXXFLAGS", "-std=c++11"
     ENV.append "CXXFLAGS", "-stdlib=libc++" if ENV.compiler == :clang
 
-    on_linux do
+    if OS.linux?
       ENV.append "CXXFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.append "LIBS", "-L#{Formula["zlib"].opt_lib}"
     end

--- a/Formula/zola.rb
+++ b/Formula/zola.rb
@@ -21,9 +21,7 @@ class Zola < Formula
   end
 
   def install
-    on_linux do
-      ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
-    end
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix if OS.linux?
     system "cargo", "install", *std_cargo_args
 
     bash_completion.install "completions/zola.bash"


### PR DESCRIPTION
Merge Homebrew/homebrew-core into Homebrew/linuxbrew-core

+ [ ] a52dec
+ [ ] abuse
+ [ ] activemq
+ [ ] aescrypt-packetizer
+ [ ] afl-fuzz
+ [ ] ahcpd
+ [ ] aide
+ [ ] ampl-mp
+ [ ] analog
+ [ ] ansible
+ [ ] ansible@2.8
+ [ ] ansible@2.9
+ [ ] apcupsd
+ [ ] apidoc
+ [ ] apr
+ [ ] arangodb
+ [ ] aria2
+ [ ] arpoison
+ [ ] artillery
+ [ ] ask-cli
+ [ ] augustus
+ [ ] autoconf
+ [ ] autoconf@2.69
+ [ ] automake
+ [ ] aws-vault
+ [ ] awscli
+ [ ] babeld
+ [ ] bacula-fd
+ [ ] bazel
+ [ ] bear
+ [ ] beast
+ [ ] bento4
+ [ ] bind
+ [ ] binutils
+ [ ] blahtexml
+ [ ] blast
+ [ ] boost-mpi
+ [ ] boost-python3
+ [ ] boost
+ [ ] browser
+ [ ] bzip2
+ [ ] cabocha
+ [ ] cairo
+ [ ] calc
+ [ ] cbmc
+ [ ] ccextractor
+ [ ] ccfits
+ [ ] cconv
+ [ ] cfengine
+ [ ] chapel
+ [ ] chicken
+ [ ] clamav
+ [ ] clozure-cl
+ [ ] cmake
+ [ ] cmigemo
+ [ ] cogl
+ [ ] color-code
+ [ ] coreutils
+ [ ] csvprintf
+ [ ] curl
+ [ ] dartsim
+ [ ] dbdeployer
+ [ ] dbus
+ [ ] dcmtk
+ [ ] dcos-cli
+ [ ] ddd
+ [ ] deno
+ [ ] dep
+ [ ] depqbf
+ [ ] djview4
+ [ ] dmd
+ [ ] docbook2x
+ [ ] docker-credential-helper
+ [ ] dockerize
+ [ ] dotnet
+ [ ] dpkg
+ [ ] dsvpn
+ [ ] duck
+ [ ] duckdb
+ [ ] dwdiff
+ [ ] e2fsprogs
+ [ ] ed
+ [ ] elasticsearch
+ [ ] emscripten
+ [ ] envoy
+ [ ] erlang
+ [ ] erlang@21
+ [ ] erlang@22
+ [ ] erlang@23
+ [ ] espeak
+ [ ] ethereum
+ [ ] ettercap
+ [ ] faas-cli
+ [ ] fanyi
+ [ ] fastlane
+ [ ] fetch-crl
+ [ ] ffmpeg
+ [ ] fibjs
+ [ ] findutils
+ [ ] firebase-cli
+ [ ] flex
+ [ ] folly
+ [ ] fontconfig
+ [ ] foremost
+ [ ] freeswitch
+ [ ] ftgl
+ [ ] gatsby-cli
+ [ ] gcc
+ [ ] gcc@10
+ [ ] gcc@4.9
+ [ ] gcc@5
+ [ ] gcc@6
+ [ ] gcc@7
+ [ ] gcc@8
+ [ ] gcc@9
+ [ ] gdal
+ [ ] gdcm
+ [ ] gdl
+ [ ] gedit
+ [ ] geographiclib
+ [ ] gettext
+ [ ] ghc
+ [ ] ghc@8.6
+ [ ] ghc@8.8
+ [ ] git
+ [ ] gitversion
+ [ ] glab
+ [ ] glade
+ [ ] glib
+ [ ] gmp
+ [ ] gnome-themes-standard
+ [ ] gnu-indent
+ [ ] gnu-sed
+ [ ] gnu-tar
+ [ ] gnu-time
+ [ ] gnu-typist
+ [ ] gnu-units
+ [ ] gnu-which
+ [ ] gnumeric
+ [ ] gnupg
+ [ ] gnutls
+ [ ] go@1.10
+ [ ] goffice
+ [ ] gource
+ [ ] gperftools
+ [ ] gpredict
+ [ ] gptfdisk
+ [ ] grafana
+ [ ] grep
+ [ ] grin-wallet
+ [ ] grpc
+ [ ] gtk+3
+ [ ] gtk4
+ [ ] gtksourceview3
+ [ ] gwenhywfar
+ [ ] hackrf
+ [ ] handbrake
+ [ ] haproxy
+ [ ] hasura-cli
+ [ ] hdf5-mpi
+ [ ] hdf5
+ [ ] hidapi
+ [ ] homebank
+ [ ] htop
+ [ ] httpd
+ [ ] hydra
+ [ ] hyperscan
+ [ ] imagemagick
+ [ ] imap-uw
+ [ ] inetutils
+ [ ] infer
+ [ ] intltool
+ [ ] iozone
+ [ ] ipopt
+ [ ] ipython
+ [ ] irrlicht
+ [ ] irssi
+ [ ] istioctl
+ [ ] itk
+ [ ] jabba
+ [ ] jack
+ [ ] jasper
+ [ ] jnettop
+ [ ] john
+ [ ] joplin-cli
+ [ ] jp
+ [ ] julia
+ [ ] jupyterlab
+ [ ] kahip
+ [ ] katago
+ [ ] kim-api
+ [ ] klee
+ [ ] knot-resolver
+ [ ] landscaper
+ [ ] latexml
+ [ ] lc0
+ [ ] ldc
+ [ ] ldns
+ [ ] libass
+ [ ] libbladerf
+ [ ] libdv
+ [ ] libedit
+ [ ] libfido2
+ [ ] libgcrypt
+ [ ] libgnt
+ [ ] libkeccak
+ [ ] libmms
+ [ ] libnotify
+ [ ] libquantum
+ [ ] libre
+ [ ] libreadline-java
+ [ ] librespot
+ [ ] libressl
+ [ ] libscrypt
+ [ ] libstfl
+ [ ] libsvm
+ [ ] libtool
+ [ ] liquidctl
+ [ ] llvm
+ [ ] llvm@11
+ [ ] llvm@7
+ [ ] llvm@8
+ [ ] llvm@9
+ [ ] lmdb
+ [ ] logstash
+ [ ] lp_solve
+ [ ] lsof
+ [ ] lua
+ [ ] lua@5.1
+ [ ] lua@5.3
+ [ ] lv
+ [ ] make
+ [ ] makensis
+ [ ] mariadb
+ [ ] mariadb@10.2
+ [ ] mariadb@10.3
+ [ ] mariadb@10.4
+ [ ] mariadb@10.5
+ [ ] mavsdk
+ [ ] mesa
+ [ ] midnight-commander
+ [ ] minicom
+ [ ] minimal-racket
+ [ ] minizip
+ [ ] mit-scheme
+ [ ] mmseqs2
+ [ ] modules
+ [ ] mongoose
+ [ ] mongrel2
+ [ ] monkeysphere
+ [ ] mpg123
+ [ ] mpich
+ [ ] mtools
+ [ ] muparser
+ [ ] mydumper
+ [ ] myman
+ [ ] mysql
+ [ ] mysql@5.6
+ [ ] mysql@5.7
+ [ ] mytop
+ [ ] ncmpcpp
+ [ ] ncurses
+ [ ] neko
+ [ ] neomutt
+ [ ] netcdf
+ [ ] netdata
+ [ ] netpbm
+ [ ] newrelic-cli
+ [ ] newrelic-infra-agent
+ [ ] newt
+ [ ] ngircd
+ [ ] ngrep
+ [ ] node@12
+ [ ] node@14
+ [ ] nspr
+ [ ] nss
+ [ ] nut
+ [ ] nzbget
+ [ ] octave
+ [ ] opencv
+ [ ] opencv@3
+ [ ] openimageio
+ [ ] openjdk
+ [ ] openjdk@11
+ [ ] openjdk@8
+ [ ] openldap
+ [ ] openmotif
+ [ ] openmsx
+ [ ] openshift-cli
+ [ ] openssh
+ [ ] openssl@1.1
+ [ ] openvpn
+ [ ] ophcrack
+ [ ] p7zip
+ [ ] packetbeat
+ [ ] pari
+ [ ] patchelf
+ [ ] pcapplusplus
+ [ ] pcsc-lite
+ [ ] pdf2htmlex
+ [ ] pdnsrec
+ [ ] percona-server
+ [ ] percona-xtrabackup
+ [ ] perl
+ [ ] perl@5.18
+ [ ] petsc-complex
+ [ ] petsc
+ [ ] pgbadger
+ [ ] pgformatter
+ [ ] phoronix-test-suite
+ [ ] php
+ [ ] php@7.2
+ [ ] php@7.3
+ [ ] php@7.4
+ [ ] picat
+ [ ] pjproject
+ [ ] pkg-config
+ [ ] podman
+ [ ] ponyc
+ [ ] poppler-qt5
+ [ ] poppler
+ [ ] portmidi
+ [ ] postgresql
+ [ ] postgresql@10
+ [ ] postgresql@11
+ [ ] postgresql@12
+ [ ] postgresql@9.4
+ [ ] postgresql@9.5
+ [ ] postgresql@9.6
+ [ ] ppsspp
+ [ ] pre-commit
+ [ ] premake
+ [ ] pstoedit
+ [ ] pulseaudio
+ [ ] pup
+ [ ] puzzles
+ [ ] pypy
+ [ ] pypy3
+ [ ] pyqt@5
+ [ ] python@3.7
+ [ ] python@3.8
+ [ ] python@3.9
+ [ ] pythran
+ [ ] qcachegrind
+ [ ] qdbm
+ [ ] qemu
+ [ ] qscintilla2
+ [ ] qt@5
+ [ ] quilt
+ [ ] qwt
+ [ ] r
+ [ ] rclone
+ [ ] rdkit
+ [ ] readline
+ [ ] redshift
+ [ ] reminiscence
+ [ ] resty
+ [ ] ripmime
+ [ ] rmlint
+ [ ] rogue
+ [ ] rom-tools
+ [ ] root
+ [ ] rpm
+ [ ] rtmpdump
+ [ ] ruby
+ [ ] ruby@2.4
+ [ ] ruby@2.5
+ [ ] ruby@2.6
+ [ ] ruby@2.7
+ [ ] rust
+ [ ] samba
+ [ ] scrollkeeper
+ [ ] sdl2
+ [ ] serd
+ [ ] sfml
+ [ ] shairport-sync
+ [ ] signal-cli
+ [ ] sile
+ [ ] sleuthkit
+ [ ] snappy
+ [ ] sngrep
+ [ ] sonarqube-lts
+ [ ] sonarqube
+ [ ] source-to-image
+ [ ] splint
+ [ ] sqlcipher
+ [ ] sqliteodbc
+ [ ] stella
+ [ ] stlink
+ [ ] stunnel
+ [ ] subversion
+ [ ] suricata
+ [ ] swi-prolog
+ [ ] swift-sh
+ [ ] swift
+ [ ] synscan
+ [ ] sysdig
+ [ ] tbb
+ [ ] tbb@2020
+ [ ] tcl-tk
+ [ ] tcpreplay
+ [ ] tealdeer
+ [ ] teensy_loader_cli
+ [ ] terraform-docs
+ [ ] terraform@0.11
+ [ ] thrax
+ [ ] transmission-cli
+ [ ] tundra
+ [ ] unbound
+ [ ] unpaper
+ [ ] unrtf
+ [ ] unzip
+ [ ] urlview
+ [ ] util-linux
+ [ ] uwsgi
+ [ ] v8
+ [ ] vamp-plugin-sdk
+ [ ] vera++
+ [ ] vercel-cli
+ [ ] vis
+ [ ] vpcs
+ [ ] vtk
+ [ ] vtk@8.2
+ [ ] vue-cli
+ [ ] webtorrent-cli
+ [ ] whois
+ [ ] wolfssl
+ [ ] wren-cli
+ [ ] wren
+ [ ] wxmaxima
+ [ ] wxpython
+ [ ] wxwidgets
+ [ ] wxwidgets@3.0
+ [ ] x265
+ [ ] xgboost
+ [ ] xmake
+ [ ] xmltoman
+ [ ] xplanet
+ [ ] yaws
+ [ ] ykman
+ [ ] ykpers
+ [ ] zabbix
+ [ ] zita-convolver
+ [ ] znc
+ [ ] zola