### PR TITLE
Merge 2021-09-13 caa4c8597a9

### DIFF
--- a/Formula/bison.rb
+++ b/Formula/bison.rb
@@ -2,18 +2,17 @@ class Bison < Formula
   desc "Parser generator"
   homepage "https://www.gnu.org/software/bison/"
   # X.Y.9Z are beta releases that sometimes get accidentally uploaded to the release FTP
-  url "https://ftp.gnu.org/gnu/bison/bison-3.8.tar.xz"
-  mirror "https://ftpmirror.gnu.org/bison/bison-3.8.tar.xz"
-  sha256 "1e0a14a8bf52d878e500c33d291026b9ebe969c27b3998d4b4285ab6dbce4527"
+  url "https://ftp.gnu.org/gnu/bison/bison-3.8.1.tar.xz"
+  mirror "https://ftpmirror.gnu.org/bison/bison-3.8.1.tar.xz"
+  sha256 "31fc602488aad6bdecf0ccc556e0fc72fc57cdc595cf92398f020e0cf4980f15"
   license "GPL-3.0-or-later"
   version_scheme 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "77122849bbea244353105d6d820e0ec97f08e511bbef8a5ec9291a77c0f2256e"
-    sha256 cellar: :any_skip_relocation, big_sur:       "ac7e42c9d0356549683eef548e969e2107271a4d5b3e2307b22648056b3d8a10"
-    sha256 cellar: :any_skip_relocation, catalina:      "12d1897e723aa58ec33e149eaba1da6385a1faadaaddf71f9ed97f0f7039c395"
-    sha256 cellar: :any_skip_relocation, mojave:        "f20f2029b67798bebb691be2dbdc5bf3ae752e31fa65d7360b9487a83c37f1c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e249bcde22dd8db752b41ea9f58bbe442cc6f8a630f6afe8fb575b3f5fe40352" # linuxbrew-core
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "f26eabffa4dd6d453b7c01e0491910bf70af70e400e1d684d3e31a511a7bfcf1"
+    sha256 cellar: :any_skip_relocation, big_sur:       "f3a25f8afa584abf7688824ad8eaa624b4702aa531339599c63947b2234c8dc5"
+    sha256 cellar: :any_skip_relocation, catalina:      "7698f085a806dd977569237a92661673233232acc29803087eb4a8784cc621d8"
+    sha256 cellar: :any_skip_relocation, mojave:        "80ea46ebdade5d5e8c8dbf6ea0c1e275ae669531b18bb06211b1c47bd27f0c42"
   end
 
   keg_only :provided_by_macos

--- a/Formula/datalad.rb
+++ b/Formula/datalad.rb
@@ -3,14 +3,14 @@ class Datalad < Formula
 
   desc "Data distribution geared toward scientific datasets"
   homepage "https://www.datalad.org"
-  url "https://files.pythonhosted.org/packages/57/b3/37fd4ed45eb08d6cf401f41149e66582d4322ff37ff5f9fd0971813880a9/datalad-0.14.7.tar.gz"
-  sha256 "02478cff60bb50f7c5fa3b3b7128013fee619bf7da373a60d9ab0493c9f7aad2"
+  url "https://files.pythonhosted.org/packages/9e/58/93afb756967b466f014cebd92312c024288afdd4c33fca0c900c83027f27/datalad-0.14.8.tar.gz"
+  sha256 "a233594e14b10a68580c04efd2133e49c5ebd4309f13a777a37022983cd09005"
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:  "296eaf46031bf72b74fb3a0e2393b06e328f282ae9fb88c73836747d4ee4307d"
-    sha256 cellar: :any_skip_relocation, catalina: "8b1666dc0b64cdc4d173fb3e888c751284280a3471200c9fd771a53dd634e887"
-    sha256 cellar: :any_skip_relocation, mojave:   "f597716a63ef7b1244b8b19e319e0a3052ceddcea1c7d02af8f68a62afed237a"
+    sha256 cellar: :any_skip_relocation, big_sur:  "1c56f5c4187a8239fddff8c2ea1138a7ebe2d44f4ec0310613221e33a76f4d33"
+    sha256 cellar: :any_skip_relocation, catalina: "a7750590aedb8cdb6cd74e6e797d07c364fdc159a2c121d40e1839b0addc70b5"
+    sha256 cellar: :any_skip_relocation, mojave:   "8d6cf824fbd5549e04e3f623bbb15db7170a257a144c2396fed72261b3512019"
   end
 
   depends_on "git-annex"
@@ -54,8 +54,8 @@ class Datalad < Formula
   end
 
   resource "Deprecated" do
-    url "https://files.pythonhosted.org/packages/52/ab/30ae1f10e27385b3d2a4120b8edbcb187ba9ae2c4daf811f4f823aa4f0e2/Deprecated-1.2.12.tar.gz"
-    sha256 "6d2de2de7931a968874481ef30208fd4e08da39177d61d3d4ebdf4366e7dbca1"
+    url "https://files.pythonhosted.org/packages/c8/d1/e412abc2a358a6b9334250629565fe12697ca1cdee4826239eddf944ddd0/Deprecated-1.2.13.tar.gz"
+    sha256 "43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"
   end
 
   resource "distro" do
@@ -84,8 +84,8 @@ class Datalad < Formula
   end
 
   resource "importlib-metadata" do
-    url "https://files.pythonhosted.org/packages/58/f1/9b77b8aa38482b7c284b8f8eda8b99d3b1103a280f107bab362a1c518c92/importlib_metadata-4.6.3.tar.gz"
-    sha256 "0645585859e9a6689c523927a5032f2ba5919f1f7d0e84bd4533312320de1ff9"
+    url "https://files.pythonhosted.org/packages/f0/70/ca3dd67cdd368b957e73a8156f7e1a10339f9813e314cb8b4549526070da/importlib_metadata-4.8.1.tar.gz"
+    sha256 "f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
   end
 
   resource "iso8601" do
@@ -99,8 +99,8 @@ class Datalad < Formula
   end
 
   resource "keyring" do
-    url "https://files.pythonhosted.org/packages/b0/b5/b27458e1d2adf2a11c6e95c67ac63f828e96fe7e166132e5dacbe03e88c0/keyring-23.0.1.tar.gz"
-    sha256 "045703609dd3fccfcdb27da201684278823b72af515aedec1a8515719a038cb8"
+    url "https://files.pythonhosted.org/packages/cc/24/c5402ba0c6380cc058980e2b73f0597ab6875692f185054a94244b7161ab/keyring-23.2.1.tar.gz"
+    sha256 "6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe"
   end
 
   resource "keyrings.alt" do
@@ -139,8 +139,8 @@ class Datalad < Formula
   end
 
   resource "python-gitlab" do
-    url "https://files.pythonhosted.org/packages/26/4a/82ad22c6e2a6b5f6834942d9e566fac6ad26e5c2f9898090ee138f4e96d2/python-gitlab-2.10.0.tar.gz"
-    sha256 "376b3e982381cec734471c502b3da2c6e7858a8df4d03c993499e6a7593950e6"
+    url "https://files.pythonhosted.org/packages/4f/47/5c51420baf1ea3141d7da32a0a92541a5073491c8da8bd309e9ca52c5e8d/python-gitlab-2.10.1.tar.gz"
+    sha256 "7afa7d7c062fa62c173190452265a30feefb844428efc58ea5244f3b9fc0d40f"
   end
 
   resource "requests" do
@@ -154,13 +154,13 @@ class Datalad < Formula
   end
 
   resource "simplejson" do
-    url "https://files.pythonhosted.org/packages/2f/58/2bc9d908d3b52bc53876b438055ff129e28cc8b1a83a669ccc87e515c0a5/simplejson-3.17.3.tar.gz"
-    sha256 "da72a452bcf4349fc467a12b54ab0e63e654a571cacc44084826d52bde12b6ee"
+    url "https://files.pythonhosted.org/packages/01/52/41c71718f941c9a5abebfaa24e3c14e3c0229327b7ebd21348989845ed8f/simplejson-3.17.5.tar.gz"
+    sha256 "91cfb43fb91ff6d1e4258be04eee84b51a4ef40a28d899679b9ea2556322fb50"
   end
 
   resource "tqdm" do
-    url "https://files.pythonhosted.org/packages/7f/e6/23e3f15ff29970dd64065a9a27bc809b1df727f7f9f6dfa3e36cf7975e58/tqdm-4.62.0.tar.gz"
-    sha256 "3642d483b558eec80d3c831e23953582c34d7e4540db86d9e5ed9dad238dabc6"
+    url "https://files.pythonhosted.org/packages/37/e5/1b54ef934d731576d0145bc8ae22da5b410f96922cec52b91cc29d3ff1b6/tqdm-4.62.2.tar.gz"
+    sha256 "a4d6d112e507ef98513ac119ead1159d286deab17dffedd96921412c2d236ff5"
   end
 
   resource "urllib3" do

--- a/Formula/n.rb
+++ b/Formula/n.rb
@@ -4,7 +4,7 @@ class N < Formula
   url "https://github.com/tj/n/archive/v7.3.1.tar.gz"
   sha256 "92754b32607571e4a8d610ac6df18f43bbe7380927d79e1ef640c516eca88458"
   license "MIT"
-  head "https://github.com/tj/n.git"
+  head "https://github.com/tj/n.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ff4148c324c6bba661668a8506f0cfa189d3ce2f62cab6ad548e5bf686af72b7"

--- a/Formula/nagios-plugins.rb
+++ b/Formula/nagios-plugins.rb
@@ -4,7 +4,7 @@ class NagiosPlugins < Formula
   url "https://www.nagios-plugins.org/download/nagios-plugins-2.3.3.tar.gz"
   sha256 "07859071632ded58c5135d613438137022232da75f8bdc1687f3f75da2fe597f"
   license "GPL-3.0"
-  head "https://github.com/nagios-plugins/nagios-plugins.git"
+  head "https://github.com/nagios-plugins/nagios-plugins.git", branch: "master"
 
   livecheck do
     url "https://nagios-plugins.org/download/"

--- a/Formula/nailgun.rb
+++ b/Formula/nailgun.rb
@@ -4,7 +4,7 @@ class Nailgun < Formula
   url "https://github.com/facebook/nailgun/archive/nailgun-all-1.0.1.tar.gz"
   sha256 "c05fc01d28c895d0003b8ec6151c10ee38690552dcfaeb304497836f558006d5"
   license "Apache-2.0"
-  head "https://github.com/facebook/nailgun.git"
+  head "https://github.com/facebook/nailgun.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, catalina:    "9e4e7836ebcef4beb89f43ba07ff7e1fffb0765b8843cda5338eca8b34bafed3"

--- a/Formula/nanomsg.rb
+++ b/Formula/nanomsg.rb
@@ -4,7 +4,7 @@ class Nanomsg < Formula
   url "https://github.com/nanomsg/nanomsg/archive/1.1.5.tar.gz"
   sha256 "218b31ae1534ab897cb5c419973603de9ca1a5f54df2e724ab4a188eb416df5a"
   license "MIT"
-  head "https://github.com/nanomsg/nanomsg.git"
+  head "https://github.com/nanomsg/nanomsg.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/nanorc.rb
+++ b/Formula/nanorc.rb
@@ -4,7 +4,7 @@ class Nanorc < Formula
   url "https://github.com/scopatz/nanorc/releases/download/2020.10.10/nanorc-2020.10.10.tar.gz"
   sha256 "cd674e9eb230e4ba306b418c22d1891d93a3d2ffdf22234748d3398da50dfe64"
   license "GPL-3.0"
-  head "https://github.com/scopatz/nanorc.git"
+  head "https://github.com/scopatz/nanorc.git", branch: "master"
 
   def install
     pkgshare.install Dir["*.nanorc"]

--- a/Formula/narwhal.rb
+++ b/Formula/narwhal.rb
@@ -4,7 +4,7 @@ class Narwhal < Formula
   url "https://github.com/280north/narwhal/archive/v0.3.2.tar.gz"
   sha256 "a26ac20097839a5c7b5de665678fb76699371eea433d6e3b820d4d8de2ad4937"
   license "MIT"
-  head "https://github.com/280north/narwhal.git"
+  head "https://github.com/280north/narwhal.git", branch: "master"
 
   conflicts_with "spidermonkey", because: "both install a js binary"
   conflicts_with "elixir-build", because: "both install `json` binaries"

--- a/Formula/natalie.rb
+++ b/Formula/natalie.rb
@@ -5,7 +5,7 @@ class Natalie < Formula
   sha256 "f7959915595495ce922b2b6987368118fa28ba7d13ac3961fd513ec8dfdb21c8"
   license "MIT"
   revision 1
-  head "https://github.com/krzyzanowskim/Natalie.git"
+  head "https://github.com/krzyzanowskim/Natalie.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "df7c39d8bcb8d60b095d9b9b90207042791d994f22a53c97e709aa16768a9b28"

--- a/Formula/nats-server.rb
+++ b/Formula/nats-server.rb
@@ -4,7 +4,7 @@ class NatsServer < Formula
   url "https://github.com/nats-io/nats-server/archive/refs/tags/v2.5.0.tar.gz"
   sha256 "6c0274798a63bc6cc8e9c6251cc615d55e58352b0c3124feb9dd5a1b48b6b4bc"
   license "Apache-2.0"
-  head "https://github.com/nats-io/nats-server.git"
+  head "https://github.com/nats-io/nats-server.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a9261b328cde6c7723cef7acd7c4eb735fe1f33e935ea66af5ba931e4bdecd6e"

--- a/Formula/nats-streaming-server.rb
+++ b/Formula/nats-streaming-server.rb
@@ -4,7 +4,7 @@ class NatsStreamingServer < Formula
   url "https://github.com/nats-io/nats-streaming-server/archive/refs/tags/v0.22.1.tar.gz"
   sha256 "116035f0c3c7e6154b7b1352d53ab16bd90b89afbce4afb70fe5d686ca4f24b0"
   license "Apache-2.0"
-  head "https://github.com/nats-io/nats-streaming-server.git"
+  head "https://github.com/nats-io/nats-streaming-server.git", branch: "main"
 
   bottle do
     rebuild 1

--- a/Formula/nave.rb
+++ b/Formula/nave.rb
@@ -4,7 +4,7 @@ class Nave < Formula
   url "https://github.com/isaacs/nave/archive/v3.2.2.tar.gz"
   sha256 "a8eb92bb47f6d00326b710f086aea23ae76ceadd277f79256263f524d3540ed1"
   license "ISC"
-  head "https://github.com/isaacs/nave.git"
+  head "https://github.com/isaacs/nave.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9e7f74d74b71447c296c6b5873047496a1988e4c7c20fef6af032f7621a15528"

--- a/Formula/nbsdgames.rb
+++ b/Formula/nbsdgames.rb
@@ -4,7 +4,7 @@ class Nbsdgames < Formula
   url "https://github.com/abakh/nbsdgames/archive/refs/tags/v4.1.2.tar.gz"
   sha256 "b4ba777791274af7db13d2827b254cf998a757468e119c6ee106ccbeafcd04c1"
   license :public_domain
-  head "https://github.com/abakh/nbsdgames.git"
+  head "https://github.com/abakh/nbsdgames.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4281d8274d3f05106a5e34a31db7498615e2b4ac89e52528a864d8d4c2fa0999"

--- a/Formula/ncompress.rb
+++ b/Formula/ncompress.rb
@@ -4,7 +4,7 @@ class Ncompress < Formula
   url "https://github.com/vapier/ncompress/archive/v5.0.tar.gz"
   sha256 "96ec931d06ab827fccad377839bfb91955274568392ddecf809e443443aead46"
   license "Unlicense"
-  head "https://github.com/vapier/ncompress.git"
+  head "https://github.com/vapier/ncompress.git", branch: "main"
 
   livecheck do
     url :stable

--- a/Formula/ncrack.rb
+++ b/Formula/ncrack.rb
@@ -4,7 +4,7 @@ class Ncrack < Formula
   url "https://github.com/nmap/ncrack/archive/0.7.tar.gz"
   sha256 "f3f971cd677c4a0c0668cb369002c581d305050b3b0411e18dd3cb9cc270d14a"
   license "GPL-2.0-only"
-  head "https://github.com/nmap/ncrack.git"
+  head "https://github.com/nmap/ncrack.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/ndenv.rb
+++ b/Formula/ndenv.rb
@@ -4,7 +4,7 @@ class Ndenv < Formula
   url "https://github.com/riywo/ndenv/archive/v0.4.0.tar.gz"
   sha256 "1a85e4c0c0eee24d709cbc7b5c9d50709bf51cf7fe996a1548797a4079e0b6e4"
   license "MIT"
-  head "https://github.com/riywo/ndenv.git"
+  head "https://github.com/riywo/ndenv.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6d36486433ad28c722a9d0e3b6e780e369beea2855a126c91abae2c1e83384c0"

--- a/Formula/ne.rb
+++ b/Formula/ne.rb
@@ -4,7 +4,7 @@ class Ne < Formula
   url "https://github.com/vigna/ne/archive/3.3.1.tar.gz"
   sha256 "931f01380b48e539b06d65d80ddf313cce67aab6d7b62462a548253ab9b3e10a"
   license "GPL-3.0"
-  head "https://github.com/vigna/ne.git"
+  head "https://github.com/vigna/ne.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "b55c5eec667c1297570a6ef49e989061983a068c4daad9c8e27a85898556b58d"

--- a/Formula/neatvi.rb
+++ b/Formula/neatvi.rb
@@ -5,7 +5,7 @@ class Neatvi < Formula
       tag:      "09",
       revision: "a3b79df332e3c5804ae57c0348549ff35a69f262"
   license "ISC"
-  head "https://repo.or.cz/neatvi.git"
+  head "https://repo.or.cz/neatvi.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "54c65ed58e6d27871850aa722ee40fe2d72af036bb255a41ba9d0299c8b84479"

--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -5,7 +5,7 @@ class Neko < Formula
   sha256 "850e7e317bdaf24ed652efeff89c1cb21380ca19f20e68a296c84f6bad4ee995"
   license "MIT"
   revision 6
-  head "https://github.com/HaxeFoundation/neko.git"
+  head "https://github.com/HaxeFoundation/neko.git", branch: "master"
 
   bottle do
     sha256                               arm64_big_sur: "db3b62ea32c9b528423997eb79bab7b96463f3074e5452499a1ea87f742129f0"

--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -4,7 +4,7 @@ class Neofetch < Formula
   url "https://github.com/dylanaraps/neofetch/archive/7.1.0.tar.gz"
   sha256 "58a95e6b714e41efc804eca389a223309169b2def35e57fa934482a6b47c27e7"
   license "MIT"
-  head "https://github.com/dylanaraps/neofetch.git"
+  head "https://github.com/dylanaraps/neofetch.git", branch: "master"
 
   bottle do
     rebuild 2

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -5,7 +5,7 @@ class Neomutt < Formula
   sha256 "77e177780fc2d8abb475d9cac4342c7e61d53c243f6ce2f9bc86d819fc962cdb"
   license "GPL-2.0-or-later"
   revision 2
-  head "https://github.com/neomutt/neomutt.git"
+  head "https://github.com/neomutt/neomutt.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "ae39b68a39ee90a2deae8e5364edaa5f9703b551120c9d0519598f7d170378e9"

--- a/Formula/neovim-remote.rb
+++ b/Formula/neovim-remote.rb
@@ -6,7 +6,7 @@ class NeovimRemote < Formula
   url "https://files.pythonhosted.org/packages/cc/d8/82aec85fc7ad0853afca2c88e73ecc7d3a50c66988c44aa9748ccbc9b689/neovim-remote-2.4.0.tar.gz"
   sha256 "f199ebb61c3decf462feed4e7d467094ed38d8afaf43620736b5983a12fe2427"
   license "MIT"
-  head "https://github.com/mhinz/neovim-remote.git"
+  head "https://github.com/mhinz/neovim-remote.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "eb32806679e25729e2106e7ee35082d41b460a49305e51402121a21a013f8924"

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -4,7 +4,7 @@ class Neovim < Formula
   url "https://github.com/neovim/neovim/archive/v0.5.0.tar.gz"
   sha256 "2294caa9d2011996499fbd70e4006e4ef55db75b99b6719154c09262e23764ef"
   license "Apache-2.0"
-  head "https://github.com/neovim/neovim.git"
+  head "https://github.com/neovim/neovim.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "8c2031ed12ca5a2af5d317f74a3878b2acdfc8b8bd61f8c58ca99b52bfc2f29a"

--- a/Formula/nestopia-ue.rb
+++ b/Formula/nestopia-ue.rb
@@ -4,7 +4,7 @@ class NestopiaUe < Formula
   url "https://github.com/0ldsk00l/nestopia/archive/1.51.1.tar.gz"
   sha256 "6c2198ed5f885b160bf7e22a777a5e139a7625444ec47625cd07a36627e94b3f"
   license "GPL-2.0-or-later"
-  head "https://github.com/0ldsk00l/nestopia.git"
+  head "https://github.com/0ldsk00l/nestopia.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "48cc9146b538dde455e89b91882abc5cb6e0a3bb5272d546c747df16a7399379"

--- a/Formula/net-snmp.rb
+++ b/Formula/net-snmp.rb
@@ -4,7 +4,7 @@ class NetSnmp < Formula
   url "https://downloads.sourceforge.net/project/net-snmp/net-snmp/5.9.1/net-snmp-5.9.1.tar.gz"
   sha256 "eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f"
   license "Net-SNMP"
-  head "https://github.com/net-snmp/net-snmp.git"
+  head "https://github.com/net-snmp/net-snmp.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -6,7 +6,7 @@ class Netcdf < Formula
   sha256 "679635119a58165c79bb9736f7603e2c19792dd848f19195bf6881492246d6d5"
   license "BSD-3-Clause"
   revision 2
-  head "https://github.com/Unidata/netcdf-c.git"
+  head "https://github.com/Unidata/netcdf-c.git", branch: "main"
 
   livecheck do
     url "https://www.unidata.ucar.edu/downloads/netcdf/"

--- a/Formula/nethack.rb
+++ b/Formula/nethack.rb
@@ -7,7 +7,7 @@ class Nethack < Formula
   version "3.6.6"
   sha256 "cfde0c3ab6dd7c22ae82e1e5a59ab80152304eb23fb06e3129439271e5643ed2"
   license "NGPL"
-  head "https://github.com/NetHack/NetHack.git"
+  head "https://github.com/NetHack/NetHack.git", branch: "NetHack-3.7"
 
   # The /download/ page loads the following page in an iframe and this contains
   # links to version directories which contain the archive files.

--- a/Formula/netlify-cli.rb
+++ b/Formula/netlify-cli.rb
@@ -6,7 +6,7 @@ class NetlifyCli < Formula
   url "https://registry.npmjs.org/netlify-cli/-/netlify-cli-6.8.10.tgz"
   sha256 "bea250205a00c79b939ef50cdbcd5c2edf8b9cd23c0429f3b97ade5ab529fee6"
   license "MIT"
-  head "https://github.com/netlify/cli.git"
+  head "https://github.com/netlify/cli.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "1705353014474fab897cb1cf5c38bcb4998d079247cd9c94831a1a087290f8bc"

--- a/Formula/netperf.rb
+++ b/Formula/netperf.rb
@@ -3,7 +3,7 @@ class Netperf < Formula
   homepage "https://hewlettpackard.github.io/netperf/"
   url "https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz"
   sha256 "4569bafa4cca3d548eb96a486755af40bd9ceb6ab7c6abd81cc6aa4875007c4e"
-  head "https://github.com/HewlettPackard/netperf.git"
+  head "https://github.com/HewlettPackard/netperf.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/never.rb
+++ b/Formula/never.rb
@@ -4,7 +4,7 @@ class Never < Formula
   url "https://github.com/never-lang/never/archive/v2.1.8.tar.gz"
   sha256 "3c03f8632c27456cd6bbcd238525cdfdc41197a26e1a4ff6ac0ef2cf01f4159b"
   license "MIT"
-  head "https://github.com/never-lang/never.git"
+  head "https://github.com/never-lang/never.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/newrelic-cli.rb
+++ b/Formula/newrelic-cli.rb
@@ -4,7 +4,7 @@ class NewrelicCli < Formula
   url "https://github.com/newrelic/newrelic-cli/archive/v0.34.36.tar.gz"
   sha256 "dc4af7cadf593286b8fa38e8696ad1d1e8cb883d9dd46a7b6f24d43aaa3afe1b"
   license "Apache-2.0"
-  head "https://github.com/newrelic/newrelic-cli.git"
+  head "https://github.com/newrelic/newrelic-cli.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7b46698c4948ac907996b24ef747d270fad2fe3258e4c72766235c74d45293f7"

--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -5,7 +5,7 @@ class Newsboat < Formula
   sha256 "62420688cca25618859548d10ff6df9ac75b9cf766699f37edd3e324d67c6ffb"
   license "MIT"
   revision 1
-  head "https://github.com/newsboat/newsboat.git"
+  head "https://github.com/newsboat/newsboat.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "56dfe1b2c6f47820764638c40cd9551b3c251a07baba3834479ae2fde9cbfd53"

--- a/Formula/nfdump.rb
+++ b/Formula/nfdump.rb
@@ -4,7 +4,7 @@ class Nfdump < Formula
   url "https://github.com/phaag/nfdump/archive/v1.6.23.tar.gz"
   sha256 "8c5a7959e66bb90fcbd8ad508933a14ebde4ccf7f4ae638d8f18c9473c63af33"
   license "BSD-3-Clause"
-  head "https://github.com/phaag/nfdump.git"
+  head "https://github.com/phaag/nfdump.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "0166cf87b2fac3b3d48f54a7b5d3dd2433e43fd0aa21500f485167e035b09d49"

--- a/Formula/nfpm.rb
+++ b/Formula/nfpm.rb
@@ -4,7 +4,7 @@ class Nfpm < Formula
   url "https://github.com/goreleaser/nfpm/archive/v2.6.0.tar.gz"
   sha256 "d5d4433e4a2767f990bec48845dd8f04839ea13989271a67674821737713af91"
   license "MIT"
-  head "https://github.com/goreleaser/nfpm.git"
+  head "https://github.com/goreleaser/nfpm.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "11cc7fe2db9485e1823d15379796c9fcb4b9414cc830fa5d18d55230f96e4365"

--- a/Formula/ngs.rb
+++ b/Formula/ngs.rb
@@ -4,7 +4,7 @@ class Ngs < Formula
   url "https://github.com/ngs-lang/ngs/archive/v0.2.12.tar.gz"
   sha256 "bd3f3b7cca4a36150405f26bb9bcc2fb41d0149388d3051472f159072485f962"
   license "GPL-3.0"
-  head "https://github.com/ngs-lang/ngs.git"
+  head "https://github.com/ngs-lang/ngs.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "fc20adda0f39a4e22d54081c55b3299dced4078c96f5e7869d1903ac66c843ea"

--- a/Formula/nicotine-plus.rb
+++ b/Formula/nicotine-plus.rb
@@ -6,7 +6,7 @@ class NicotinePlus < Formula
   url "https://files.pythonhosted.org/packages/ee/2d/d8fcc06fb78a294fbc399568fcec4a706c31a681b94ba25b009c8a4377cf/nicotine-plus-3.1.1.tar.gz"
   sha256 "ce8342fcbc4d6fd50b9c29465eaca45d35c8c7be0a3ef03f5c1d9a594d96ec34"
   license "GPL-3.0-or-later"
-  head "https://github.com/Nicotine-Plus/nicotine-plus.git"
+  head "https://github.com/Nicotine-Plus/nicotine-plus.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5219c66ab06bc074d62a61bafd3f7015eba1c25669486e72ff5f5be41e65e89b"

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -4,7 +4,7 @@ class Ninja < Formula
   url "https://github.com/ninja-build/ninja/archive/v1.10.2.tar.gz"
   sha256 "ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed"
   license "Apache-2.0"
-  head "https://github.com/ninja-build/ninja.git"
+  head "https://github.com/ninja-build/ninja.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/nlopt.rb
+++ b/Formula/nlopt.rb
@@ -4,7 +4,7 @@ class Nlopt < Formula
   url "https://github.com/stevengj/nlopt/archive/v2.7.0.tar.gz"
   sha256 "b881cc2a5face5139f1c5a30caf26b7d3cb43d69d5e423c9d78392f99844499f"
   license "LGPL-2.1"
-  head "https://github.com/stevengj/nlopt.git"
+  head "https://github.com/stevengj/nlopt.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "ff00418c72bb7cd562a176f90eeb9a4a4a4a98ea070e10c5ff83515f57a55e58"

--- a/Formula/nnn.rb
+++ b/Formula/nnn.rb
@@ -4,7 +4,7 @@ class Nnn < Formula
   url "https://github.com/jarun/nnn/archive/v4.2.tar.gz"
   sha256 "5675f9fe53bddfd92681ef88bf6c0fab3ad897f9e74dd6cdff32fe1fa62c687f"
   license "BSD-2-Clause"
-  head "https://github.com/jarun/nnn.git"
+  head "https://github.com/jarun/nnn.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "d9a3862cf7914262ba82dc0fa1b1480892525f68c08e89239a7ba00dfc4a7027"

--- a/Formula/node-build.rb
+++ b/Formula/node-build.rb
@@ -4,7 +4,7 @@ class NodeBuild < Formula
   url "https://github.com/nodenv/node-build/archive/v4.9.55.tar.gz"
   sha256 "091dea4ff1c6cee391dd184293c98a58397fcf2b1321eab59fa3846af97eebe7"
   license "MIT"
-  head "https://github.com/nodenv/node-build.git"
+  head "https://github.com/nodenv/node-build.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -4,7 +4,7 @@ class Node < Formula
   url "https://nodejs.org/dist/v16.9.1/node-v16.9.1.tar.xz"
   sha256 "97f50ec53c050e7ac97bdbe5586aaca380dd23064064c85a1f2017a35244131c"
   license "MIT"
-  head "https://github.com/nodejs/node.git"
+  head "https://github.com/nodejs/node.git", branch: "master"
 
   livecheck do
     url "https://nodejs.org/dist/"

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -4,7 +4,7 @@ class NodeExporter < Formula
   url "https://github.com/prometheus/node_exporter/archive/v1.2.2.tar.gz"
   sha256 "3b7b710dad97d9d2b4cb8c3f166ee1c86f629cce59062b09d4fb22459163ec86"
   license "Apache-2.0"
-  head "https://github.com/prometheus/node_exporter.git"
+  head "https://github.com/prometheus/node_exporter.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/nodebrew.rb
+++ b/Formula/nodebrew.rb
@@ -4,7 +4,7 @@ class Nodebrew < Formula
   url "https://github.com/hokaccha/nodebrew/archive/v1.1.0.tar.gz"
   sha256 "b2046d97392ed971254bee2026cfcf8fb59225f51b566ec4b77e9355a861c8a7"
   license "MIT"
-  head "https://github.com/hokaccha/nodebrew.git"
+  head "https://github.com/hokaccha/nodebrew.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/nodenv.rb
+++ b/Formula/nodenv.rb
@@ -4,7 +4,7 @@ class Nodenv < Formula
   url "https://github.com/nodenv/nodenv/archive/v1.4.0.tar.gz"
   sha256 "33e2f3e467219695ba114f75a7c769f3ee4e29b29c1c97a852aa001327ca9713"
   license "MIT"
-  head "https://github.com/nodenv/nodenv.git"
+  head "https://github.com/nodenv/nodenv.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c86512e5a1505eb10c79a4aeb618db66cc08a48ac855e9c0f9fb9fba7868d5e7"

--- a/Formula/nomino.rb
+++ b/Formula/nomino.rb
@@ -4,7 +4,7 @@ class Nomino < Formula
   url "https://github.com/yaa110/nomino/archive/1.1.0.tar.gz"
   sha256 "8c41276a2e27eca7222159c709e4e8b4e7c9e21c5cc029a0058d966865362548"
   license any_of: ["Apache-2.0", "MIT"]
-  head "https://github.com/yaa110/nomino.git"
+  head "https://github.com/yaa110/nomino.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b9bc4251a64b1dc2b091fd414aae0d6b8fddeedd1d6c1c81136aa13ba1b3466e"

--- a/Formula/notmuch-mutt.rb
+++ b/Formula/notmuch-mutt.rb
@@ -4,17 +4,17 @@ class NotmuchMutt < Formula
   url "https://notmuchmail.org/releases/notmuch-0.33.1.tar.xz"
   sha256 "2d905f03d9ee4abcd06dfae4c4d31e5fe623ed22b3ce4d9184cc0baed29b10d2"
   license "GPL-3.0-or-later"
-  head "https://git.notmuchmail.org/git/notmuch", using: :git
+  head "https://git.notmuchmail.org/git/notmuch", using: :git, branch: "master"
 
   livecheck do
     formula "notmuch"
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "244e14a00d9771201dd024dbbef450851a97c128a791f2693f9d7cd278da68d2"
-    sha256 cellar: :any,                 big_sur:       "7f4007b0e895f0726176e659d7ae16c46a5c1a9f9d338957a2cd443537a87429"
-    sha256 cellar: :any,                 catalina:      "4606a8de4f790a4cb395fb4730a75877a38e06a68c394c50386d78d2a4aced76"
-    sha256 cellar: :any,                 mojave:        "9767e63cf02da43304191762eed9fd0cae875f31b08937e6fa9a96b4535f49b8"
+    sha256 cellar: :any,                 arm64_big_sur: "6b1e9381cb44b8d8cd484c36d2e63edd64faed3e9c5ba53c87c1e05b843d4b02"
+    sha256 cellar: :any,                 big_sur:       "8e16de13ecf1f6da7f07a6c2f7ff9e3c3d1b10995c1466c3d4a6c61931fabe2d"
+    sha256 cellar: :any,                 catalina:      "39fac49da85eca7e3fa8b510a60b8d6c4ea2f9c175f857fc8d4a8cf84c7f601b"
+    sha256 cellar: :any,                 mojave:        "577eb3798b8181251c8decd970c9564066be1fb6f11664a8e126b9b95b5c6ede"
   end
 
   depends_on "notmuch"

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -4,7 +4,7 @@ class Notmuch < Formula
   url "https://notmuchmail.org/releases/notmuch-0.33.1.tar.xz"
   sha256 "2d905f03d9ee4abcd06dfae4c4d31e5fe623ed22b3ce4d9184cc0baed29b10d2"
   license "GPL-3.0-or-later"
-  head "https://git.notmuchmail.org/git/notmuch", using: :git
+  head "https://git.notmuchmail.org/git/notmuch", using: :git, branch: "master"
 
   livecheck do
     url "https://notmuchmail.org/releases/"

--- a/Formula/nq.rb
+++ b/Formula/nq.rb
@@ -4,7 +4,7 @@ class Nq < Formula
   url "https://github.com/chneukirchen/nq/archive/v0.4.tar.gz"
   sha256 "287d6700063b64cfa9db51df95e2a046736eb38c0d3b6e0af0a8e7da6df8880b"
   license "CC0-1.0"
-  head "https://github.com/chneukirchen/nq.git"
+  head "https://github.com/chneukirchen/nq.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "70578036134f31e789368935f42818ca3d081f24f35834e4a46a3aee4fe7e019"

--- a/Formula/nsnake.rb
+++ b/Formula/nsnake.rb
@@ -4,7 +4,7 @@ class Nsnake < Formula
   url "https://downloads.sourceforge.net/project/nsnake/GNU-Linux/nsnake-3.0.1.tar.gz"
   sha256 "e0a39e0e188a6a8502cb9fc05de3fa83dd4d61072c5b93a182136d1bccd39bb9"
   license "GPL-3.0"
-  head "https://github.com/alexdantas/nSnake.git"
+  head "https://github.com/alexdantas/nSnake.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -4,7 +4,7 @@ class Nsq < Formula
   url "https://github.com/nsqio/nsq/archive/v1.2.1.tar.gz"
   sha256 "5fd252be4e9bf5bc0962e5b67ef5ec840895e73b1748fd0c1610fa4950cb9ee1"
   license "MIT"
-  head "https://github.com/nsqio/nsq.git"
+  head "https://github.com/nsqio/nsq.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/nuclei.rb
+++ b/Formula/nuclei.rb
@@ -4,7 +4,7 @@ class Nuclei < Formula
   url "https://github.com/projectdiscovery/nuclei/archive/v2.5.1.tar.gz"
   sha256 "77d28a3628fda7b8b08e5b74f3d314050af75f91c98f5de273db7b490b5177ba"
   license "MIT"
-  head "https://github.com/projectdiscovery/nuclei.git"
+  head "https://github.com/projectdiscovery/nuclei.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "88172817dbaef26ad7178baf79ef0c5707707c10d2ec6ff0e54bc121c4f008be"

--- a/Formula/nudoku.rb
+++ b/Formula/nudoku.rb
@@ -4,7 +4,7 @@ class Nudoku < Formula
   url "https://github.com/jubalh/nudoku/archive/2.1.0.tar.gz"
   sha256 "eeff7f3adea5bfe7b88bf7683d68e9a597aabd1442d1621f21760c746400b924"
   license "GPL-3.0-or-later"
-  head "https://github.com/jubalh/nudoku.git"
+  head "https://github.com/jubalh/nudoku.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "daa1278f79f9fdf5cd8780ba68d3bf89982728c1ddf636f89475e89b14bd9c64"

--- a/Formula/numcpp.rb
+++ b/Formula/numcpp.rb
@@ -4,7 +4,7 @@ class Numcpp < Formula
   url "https://github.com/dpilger26/NumCpp/archive/Version_2.5.0.tar.gz"
   sha256 "50a18611c2b2abda613e757ef6bd7d7efba761e0265cb16aa9700b45b0236d38"
   license "MIT"
-  head "https://github.com/dpilger26/NumCpp.git"
+  head "https://github.com/dpilger26/NumCpp.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "98e4db2b2caa2f80ca5ad9c24d23065f69b3db75311be04ce22a633fc37cb8a2" # linuxbrew-core

--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -4,7 +4,7 @@ class Numpy < Formula
   url "https://files.pythonhosted.org/packages/3a/be/650f9c091ef71cb01d735775d554e068752d3ff63d7943b26316dc401749/numpy-1.21.2.zip"
   sha256 "423216d8afc5923b15df86037c6053bf030d15cc9e3224206ef868c2d63dd6dc"
   license "BSD-3-Clause"
-  head "https://github.com/numpy/numpy.git"
+  head "https://github.com/numpy/numpy.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "f500dc16bc97e85df8944d6542ba05c94d2c23c22fb427d5295925cd81edac8f"

--- a/Formula/nutcracker.rb
+++ b/Formula/nutcracker.rb
@@ -5,7 +5,7 @@ class Nutcracker < Formula
   sha256 "73f305d8525abbaaa6a5f203c1fba438f99319711bfcb2bb8b2f06f0d63d1633"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/twitter/twemproxy.git"
+  head "https://github.com/twitter/twemproxy.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "5063c8fb5c2f1327bb0979be76cf05be72b879113b69667d9d6548d1db6da44b"

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -4,7 +4,7 @@ class Nvm < Formula
   url "https://github.com/creationix/nvm/archive/v0.38.0.tar.gz"
   sha256 "35bb7bc74bf9efacde270ee5f52ef3c41fd585c5f8ddd57ca6e8e07e4f29fc74"
   license "MIT"
-  head "https://github.com/nvm-sh/nvm.git"
+  head "https://github.com/nvm-sh/nvm.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "38e81aabe1efb9a2eca50a1e12699f2245dbd0b8bed8bde7f0146c1c804103e1" # linuxbrew-core

--- a/Formula/oakc.rb
+++ b/Formula/oakc.rb
@@ -4,7 +4,7 @@ class Oakc < Formula
   url "https://static.crates.io/crates/oakc/oakc-0.6.1.crate"
   sha256 "1f4a90a3fd5c8ae32cb55c7a38730b6bfcf634f75e6ade0fd51c9db2a2431683"
   license "Apache-2.0"
-  head "https://github.com/adam-mcdaniel/oakc.git"
+  head "https://github.com/adam-mcdaniel/oakc.git", branch: "develop"
 
   livecheck do
     url "https://crates.io/api/v1/crates/oakc/versions"

--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -4,7 +4,7 @@ class Oauth2Proxy < Formula
   url "https://github.com/oauth2-proxy/oauth2_proxy/archive/v7.1.3.tar.gz"
   sha256 "b6d45f3b44a98002ce8f3b581ffd79ade33fb19f374093df43564464439257ad"
   license "MIT"
-  head "https://github.com/oauth2-proxy/oauth2-proxy.git"
+  head "https://github.com/oauth2-proxy/oauth2-proxy.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/oauth2l.rb
+++ b/Formula/oauth2l.rb
@@ -4,7 +4,7 @@ class Oauth2l < Formula
   url "https://github.com/google/oauth2l/archive/v1.2.2.tar.gz"
   sha256 "6bee262a59669be86e578190f4a7ce6f7b18d5082bd647de82c4a11257a91e83"
   license "Apache-2.0"
-  head "https://github.com/google/oauth2l.git"
+  head "https://github.com/google/oauth2l.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "97afa02857ded76e58750c9258dcdf6696cd341f4ef5da3fcef1b506d4af5d60"

--- a/Formula/objc-codegenutils.rb
+++ b/Formula/objc-codegenutils.rb
@@ -4,7 +4,7 @@ class ObjcCodegenutils < Formula
   url "https://github.com/square/objc-codegenutils/archive/v1.0.tar.gz"
   sha256 "98b8819e77e18029f1bda56622d42c162e52ef98f3ba4c6c8fcf5d40c256e845"
   license "Apache-2.0"
-  head "https://github.com/square/objc-codegenutils.git"
+  head "https://github.com/square/objc-codegenutils.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9301f21479af32f32469e8235780f85b74d3a5e7c783fecaef7bb896c734dd55"

--- a/Formula/objc-run.rb
+++ b/Formula/objc-run.rb
@@ -4,7 +4,7 @@ class ObjcRun < Formula
   url "https://github.com/iljaiwas/objc-run/archive/1.4.tar.gz"
   sha256 "6d02a31764c457c4a6a9f5df0963d733d611ba873fc32672151ee02a05acd6f2"
   license "MIT"
-  head "https://github.com/iljaiwas/objc-run.git"
+  head "https://github.com/iljaiwas/objc-run.git", branch: "master"
 
   def install
     bin.install "objc-run"

--- a/Formula/ocamlbuild.rb
+++ b/Formula/ocamlbuild.rb
@@ -5,7 +5,7 @@ class Ocamlbuild < Formula
   sha256 "87b29ce96958096c0a1a8eeafeb6268077b2d11e1bf2b3de0f5ebc9cf8d42e78"
   license "LGPL-2.0"
   revision 2
-  head "https://github.com/ocaml/ocamlbuild.git"
+  head "https://github.com/ocaml/ocamlbuild.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/oci-cli.rb
+++ b/Formula/oci-cli.rb
@@ -6,7 +6,7 @@ class OciCli < Formula
   url "https://files.pythonhosted.org/packages/58/63/2ae0966975943638c55ecf3831a7fbdc061f84ad627f28e849223003c5d0/oci-cli-3.0.4.tar.gz"
   sha256 "3d27318112b0e0a7b7b7959df36ebabe7c06e3dcf02ed82a22575b356625e225"
   license any_of: ["UPL-1.0", "Apache-2.0"]
-  head "https://github.com/oracle/oci-cli.git"
+  head "https://github.com/oracle/oci-cli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "f1a19e3ff48f0c5fca75500a0bd682131d5f200f1e57ba186001e3d14b50995c"

--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -4,7 +4,7 @@ class Ocp < Formula
   url "https://stian.cubic.org/ocp/ocp-0.2.90.tar.xz"
   sha256 "e5bb775648c4708c821cb8313932a8fef7dcf1b5035208e56e57779984d60911"
   license "GPL-2.0-or-later"
-  head "https://github.com/mywave82/opencubicplayer.git"
+  head "https://github.com/mywave82/opencubicplayer.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/ocproxy.rb
+++ b/Formula/ocproxy.rb
@@ -5,7 +5,7 @@ class Ocproxy < Formula
   sha256 "a7367647f07df33869e2f79da66b6f104f6495ae806b12a8b8d9ca82fb7899ac"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/cernekee/ocproxy.git"
+  head "https://github.com/cernekee/ocproxy.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/octant.rb
+++ b/Formula/octant.rb
@@ -5,7 +5,7 @@ class Octant < Formula
       tag:      "v0.23.0",
       revision: "fbe2be3b687b3e2199ea32753281c9de1f334171"
   license "Apache-2.0"
-  head "https://github.com/vmware-tanzu/octant.git"
+  head "https://github.com/vmware-tanzu/octant.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -3,7 +3,7 @@ class Ode < Formula
   homepage "https://www.ode.org/"
   url "https://bitbucket.org/odedevs/ode/downloads/ode-0.16.2.tar.gz"
   sha256 "b26aebdcb015e2d89720ef48e0cb2e8a3ca77915f89d853893e7cc861f810f22"
-  head "https://bitbucket.org/odedevs/ode.git"
+  head "https://bitbucket.org/odedevs/ode.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "3b69d29b04c4c733c4689be24f1ab4b49f646485650a6a55c10f2721de44e53b"

--- a/Formula/odin.rb
+++ b/Formula/odin.rb
@@ -5,7 +5,7 @@ class Odin < Formula
   sha256 "ae88c4dcbb8fdf37f51abc701d94fb4b2a8270f65be71063e0f85a321d54cdf0"
   license "BSD-2-Clause"
   revision 1
-  head "https://github.com/odin-lang/Odin.git"
+  head "https://github.com/odin-lang/Odin.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/offlineimap.rb
+++ b/Formula/offlineimap.rb
@@ -4,7 +4,7 @@ class Offlineimap < Formula
   url "https://files.pythonhosted.org/packages/09/12/73db8d38fea8ec3536cbccb8286b46b426639aff7e166840fa5e68e889e2/offlineimap-7.3.4.tar.gz"
   sha256 "5dbd7167b8729d87caa50bed63562868b6634b888348d9bc088a721530c82fef"
   license "GPL-2.0-or-later"
-  head "https://github.com/OfflineIMAP/offlineimap.git"
+  head "https://github.com/OfflineIMAP/offlineimap.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ddd56697d3c6e9caf9ce43cb18b4c8c5e2b71dda041363be7b3f02487700edd0"

--- a/Formula/oha.rb
+++ b/Formula/oha.rb
@@ -4,7 +4,7 @@ class Oha < Formula
   url "https://github.com/hatoo/oha/archive/v0.4.6.tar.gz"
   sha256 "b08f4953c6f77a80882dd9b13735ca4a63f14ada1b51d619f17e58a6fa085262"
   license "MIT"
-  head "https://github.com/hatoo/oha.git"
+  head "https://github.com/hatoo/oha.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "18b6d423dff719f2c56939eca2416d8a6235f1493e92529932f637a4286427fb"

--- a/Formula/ohcount.rb
+++ b/Formula/ohcount.rb
@@ -4,7 +4,7 @@ class Ohcount < Formula
   url "https://github.com/blackducksoftware/ohcount/archive/4.0.0.tar.gz"
   sha256 "d71f69fd025f5bae58040988108f0d8d84f7204edda1247013cae555bfdae1b9"
   license "GPL-2.0"
-  head "https://github.com/blackducksoftware/ohcount.git"
+  head "https://github.com/blackducksoftware/ohcount.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "43a0bac3974271a961f6cbb035aeb37e0f63e6fc05200bdf8b28064ca7faf128"

--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -5,7 +5,7 @@ class Ola < Formula
   sha256 "102aa3114562a2a71dbf7f77d2a0fb9fc47acc35d6248a70b6e831365ca71b13"
   license "GPL-2.0"
   revision 2
-  head "https://github.com/OpenLightingProject/ola.git"
+  head "https://github.com/OpenLightingProject/ola.git", branch: "master"
 
   bottle do
     sha256 big_sur:  "6c53064698383dd904dab9489cd0a5fe7f0c623f9f469f3580913bf6c16ed463"

--- a/Formula/omake.rb
+++ b/Formula/omake.rb
@@ -4,7 +4,7 @@ class Omake < Formula
   url "https://github.com/ocaml-omake/omake/archive/omake-0.10.3.tar.gz"
   sha256 "5f42aabdb4088b5c4e86c7a08e235dc7d537fd6b3064852154303bb92f5df70e"
   license "GPL-2.0-only"
-  head "https://github.com/ocaml-omake/omake.git"
+  head "https://github.com/ocaml-omake/omake.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/ompl.rb
+++ b/Formula/ompl.rb
@@ -4,7 +4,7 @@ class Ompl < Formula
   url "https://github.com/ompl/ompl/archive/1.5.2.tar.gz"
   sha256 "db1665dd2163697437ef155668fdde6101109e064a2d1a04148e45b3747d5f98"
   license "BSD-3-Clause"
-  head "https://github.com/ompl/ompl.git"
+  head "https://github.com/ompl/ompl.git", branch: "main"
 
   # We check the first-party download page because the "latest" GitHub release
   # isn't a reliable indicator of the latest version on this repository.

--- a/Formula/ondir.rb
+++ b/Formula/ondir.rb
@@ -4,7 +4,7 @@ class Ondir < Formula
   url "https://swapoff.org/files/ondir/ondir-0.2.3.tar.gz"
   sha256 "504a677e5b7c47c907f478d00f52c8ea629f2bf0d9134ac2a3bf0bbe64157ba3"
   license "GPL-2.0"
-  head "https://github.com/alecthomas/ondir.git"
+  head "https://github.com/alecthomas/ondir.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "135b0885a206244ce74e430ac0f2131b92742481d81f7774cc25377ca8da4b1e"

--- a/Formula/onednn.rb
+++ b/Formula/onednn.rb
@@ -4,7 +4,7 @@ class Onednn < Formula
   url "https://github.com/oneapi-src/oneDNN/archive/v2.3.2.tar.gz"
   sha256 "8cbade2dd955bc8f281d31a2e89e7ad7b11d73cd8281c30a64b2ff8e3a63f07e"
   license "Apache-2.0"
-  head "https://github.com/oneapi-src/onednn.git"
+  head "https://github.com/oneapi-src/onednn.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/oniguruma.rb
+++ b/Formula/oniguruma.rb
@@ -4,7 +4,7 @@ class Oniguruma < Formula
   url "https://github.com/kkos/oniguruma/releases/download/v6.9.7.1/onig-6.9.7.1.tar.gz"
   sha256 "6444204b9c34e6eb6c0b23021ce89a0370dad2b2f5c00cd44c342753e0b204d9"
   license "BSD-2-Clause"
-  head "https://github.com/kkos/oniguruma.git"
+  head "https://github.com/kkos/oniguruma.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/opa.rb
+++ b/Formula/opa.rb
@@ -4,7 +4,7 @@ class Opa < Formula
   url "https://github.com/open-policy-agent/opa/archive/v0.32.0.tar.gz"
   sha256 "307b256e8361199cc941c65476aaf1f40e0ca83b23b1cc32583d8e93d5e2cf4c"
   license "Apache-2.0"
-  head "https://github.com/open-policy-agent/opa.git"
+  head "https://github.com/open-policy-agent/opa.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b3fa8abc73bbe90449ab11e85dfab6bebb8696f79074c32b89cd53223f1956d2"

--- a/Formula/opam.rb
+++ b/Formula/opam.rb
@@ -4,7 +4,7 @@ class Opam < Formula
   url "https://github.com/ocaml/opam/releases/download/2.1.0/opam-full-2.1.0.tar.gz"
   sha256 "6102131a9b65536b713efba7f5498acb3802ae15fec3171cc2c98427cfc3926f"
   license "LGPL-2.1-only"
-  head "https://github.com/ocaml/opam.git"
+  head "https://github.com/ocaml/opam.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "123479f1d339a12438b69a3989fe7a071afb27199e0fc43c03dd48a931a16d87"

--- a/Formula/open-adventure.rb
+++ b/Formula/open-adventure.rb
@@ -5,7 +5,7 @@ class OpenAdventure < Formula
   url "http://www.catb.org/~esr/open-adventure/advent-1.9.tar.gz"
   sha256 "36466882af195d402b62deaa08e4cef26d1646cf1329f14503ea06fdc5c7219e"
   license "BSD-2-Clause"
-  head "https://gitlab.com/esr/open-adventure"
+  head "https://gitlab.com/esr/open-adventure", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/open-babel.rb
+++ b/Formula/open-babel.rb
@@ -6,7 +6,7 @@ class OpenBabel < Formula
   sha256 "c97023ac6300d26176c97d4ef39957f06e68848d64f1a04b0b284ccff2744f02"
   license "GPL-2.0"
   revision 1
-  head "https://github.com/openbabel/openbabel.git"
+  head "https://github.com/openbabel/openbabel.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "990abdbe32d92c4d6e7a17f1d5a2c1c4cd979f4daba30a8eba4a9e20a3e0d099"

--- a/Formula/open-completion.rb
+++ b/Formula/open-completion.rb
@@ -4,7 +4,7 @@ class OpenCompletion < Formula
   url "https://github.com/moshen/open-bash-completion/archive/v1.0.4.tar.gz"
   sha256 "23a8a30f9f65f5b3eb60aa6f2d1c60d7d0a858ea753a58f31ddb51d40e16b668"
   license "MIT"
-  head "https://github.com/moshen/open-bash-completion.git"
+  head "https://github.com/moshen/open-bash-completion.git", branch: "master"
 
   def install
     bash_completion.install "open"

--- a/Formula/open-scene-graph.rb
+++ b/Formula/open-scene-graph.rb
@@ -5,7 +5,7 @@ class OpenSceneGraph < Formula
   sha256 "aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12"
   license "LGPL-2.1-or-later" => { with: "WxWindows-exception-3.1" }
   revision 1
-  head "https://github.com/openscenegraph/OpenSceneGraph.git"
+  head "https://github.com/openscenegraph/OpenSceneGraph.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "83350482064d3e55281b5c4a808f4629ce0c243a49fb57e68e5f63d2d5a411c4"

--- a/Formula/open-tyrian.rb
+++ b/Formula/open-tyrian.rb
@@ -4,7 +4,7 @@ class OpenTyrian < Formula
   url "https://www.camanis.net/opentyrian/releases/opentyrian-2.1.20130907-src.tar.gz"
   sha256 "f54b6b3cedcefa187c9f605d6164aae29ec46a731a6df30d351af4c008dee45f"
   license "GPL-2.0"
-  head "https://github.com/opentyrian/opentyrian.git"
+  head "https://github.com/opentyrian/opentyrian.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -4,7 +4,7 @@ class OpenalSoft < Formula
   url "https://openal-soft.org/openal-releases/openal-soft-1.21.1.tar.bz2"
   sha256 "c8ad767e9a3230df66756a21cc8ebf218a9d47288f2514014832204e666af5d8"
   license "LGPL-2.0-or-later"
-  head "https://github.com/kcat/openal-soft.git"
+  head "https://github.com/kcat/openal-soft.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "7e15f3c0087f0bce3c5bcad1efd612ffb83327b3cd25702ffc474f6513307d73"

--- a/Formula/openclonk.rb
+++ b/Formula/openclonk.rb
@@ -5,7 +5,7 @@ class Openclonk < Formula
   sha256 "bc1a231d72774a7aa8819e54e1f79be27a21b579fb057609398f2aa5700b0732"
   license "ISC"
   revision 3
-  head "https://github.com/openclonk/openclonk.git"
+  head "https://github.com/openclonk/openclonk.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "ebd7f7efa0efc4c70b14071e98a5f2d314c16e5b6f28fe11257738619f0c813b"

--- a/Formula/opencoarrays.rb
+++ b/Formula/opencoarrays.rb
@@ -5,7 +5,7 @@ class Opencoarrays < Formula
   sha256 "6c200ca49808c75b0a2dfa984304643613b6bc77cc0044bee093f9afe03698f7"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/sourceryinstitute/opencoarrays.git"
+  head "https://github.com/sourceryinstitute/opencoarrays.git", branch: "main"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "043b88d4bf48347702c50ba3438389965196d9970216b9464561fb31628a0b71"

--- a/Formula/opencolorio.rb
+++ b/Formula/opencolorio.rb
@@ -4,7 +4,7 @@ class Opencolorio < Formula
   url "https://github.com/imageworks/OpenColorIO/archive/v2.1.0.tar.gz"
   sha256 "81fc7853a490031632a69c73716bc6ac271b395e2ba0e2587af9995c2b0efb5f"
   license "BSD-3-Clause"
-  head "https://github.com/imageworks/OpenColorIO.git"
+  head "https://github.com/imageworks/OpenColorIO.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "36f49aa701d4121185e300594128b1b55264b7f0d8da930f3e195668fa63ee2d"

--- a/Formula/openfpgaloader.rb
+++ b/Formula/openfpgaloader.rb
@@ -4,7 +4,7 @@ class Openfpgaloader < Formula
   url "https://github.com/trabucayre/openFPGALoader/archive/v0.5.0.tar.gz"
   sha256 "39c9686bdfcfa96b6bb1d8b37a8a53732372c16cda562036abe9930b61b29e97"
   license "Apache-2.0"
-  head "https://github.com/trabucayre/openFPGALoader.git"
+  head "https://github.com/trabucayre/openFPGALoader.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "77483712fb4bc07885f71696245d13d3bbb34255db2e94188588345b52f81866"

--- a/Formula/openh264.rb
+++ b/Formula/openh264.rb
@@ -5,7 +5,7 @@ class Openh264 < Formula
   sha256 "af173e90fce65f80722fa894e1af0d6b07572292e76de7b65273df4c0a8be678"
   license "BSD-2-Clause"
   revision 1
-  head "https://github.com/cisco/openh264.git"
+  head "https://github.com/cisco/openh264.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c63f32513ab056a1848184f11c0d82b1c233d81be4a9dd9f29df89029be9ea75"

--- a/Formula/openhmd.rb
+++ b/Formula/openhmd.rb
@@ -4,7 +4,7 @@ class Openhmd < Formula
   url "https://github.com/OpenHMD/OpenHMD/archive/0.3.0.tar.gz"
   sha256 "ec5c97ab456046a8aef3cde6d59e474603af398f1d064a66e364fe3c0b26a0fa"
   license "BSL-1.0"
-  head "https://github.com/OpenHMD/OpenHMD.git"
+  head "https://github.com/OpenHMD/OpenHMD.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "19e9b946bbefe306dc41aa803e5cb48aec3ab62bf334b8975e660f4a3644c0c7"

--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -4,7 +4,7 @@ class Openimageio < Formula
   url "https://github.com/OpenImageIO/oiio/archive/v2.2.18.0.tar.gz"
   sha256 "72597619f09b60cc2afc18f378b40fbec62701112957f43cff162dd9a52a26ce"
   license "BSD-3-Clause"
-  head "https://github.com/OpenImageIO/oiio.git"
+  head "https://github.com/OpenImageIO/oiio.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/openjazz.rb
+++ b/Formula/openjazz.rb
@@ -4,7 +4,7 @@ class Openjazz < Formula
   url "https://github.com/AlisterT/openjazz/archive/20190106.tar.gz"
   sha256 "27da3ab32cb6b806502a213c435e1b3b6ecebb9f099592f71caf6574135b1662"
   license "GPL-2.0"
-  head "https://github.com/AlisterT/openjazz.git"
+  head "https://github.com/AlisterT/openjazz.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "0c93957029786455fa5dcaa7441408e0f1f5e4e5503019b056959638f54b082a"

--- a/Formula/openjpeg.rb
+++ b/Formula/openjpeg.rb
@@ -4,7 +4,7 @@ class Openjpeg < Formula
   url "https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz"
   sha256 "8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d"
   license "BSD-2-Clause"
-  head "https://github.com/uclouvain/openjpeg.git"
+  head "https://github.com/uclouvain/openjpeg.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "b57a02c3bc4ee8a43e47df5015e6e40a04d7149e172806157e279b1b03c715ef"

--- a/Formula/openmodelica.rb
+++ b/Formula/openmodelica.rb
@@ -7,7 +7,7 @@ class Openmodelica < Formula
       revision: "11fcab4f2d6895f2db073572b2bff1a43177313f"
   license "GPL-3.0-only"
   revision 1
-  head "https://github.com/OpenModelica/OpenModelica.git"
+  head "https://github.com/OpenModelica/OpenModelica.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -4,7 +4,7 @@ class Openmsx < Formula
   url "https://github.com/openMSX/openMSX/releases/download/RELEASE_17_0/openmsx-17.0.tar.gz"
   sha256 "70ec6859522d8e3bbc97227abb98c87256ecda555b016d1da85cdd99072ce564"
   license "GPL-2.0"
-  head "https://github.com/openMSX/openMSX.git"
+  head "https://github.com/openMSX/openMSX.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/opensc.rb
+++ b/Formula/opensc.rb
@@ -4,7 +4,7 @@ class Opensc < Formula
   url "https://github.com/OpenSC/OpenSC/releases/download/0.22.0/opensc-0.22.0.tar.gz"
   sha256 "8d4e5347195ebea332be585df61dcc470331c26969e4b0447c851fb0844c7186"
   license "LGPL-2.1-or-later"
-  head "https://github.com/OpenSC/OpenSC.git"
+  head "https://github.com/OpenSC/OpenSC.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -2,7 +2,7 @@ class OpenshiftCli < Formula
   desc "OpenShift command-line interface tools"
   homepage "https://www.openshift.com/"
   license "Apache-2.0"
-  head "https://github.com/openshift/oc.git"
+  head "https://github.com/openshift/oc.git", branch: "master"
 
   stable do
     url "https://github.com/openshift/oc.git",

--- a/Formula/openttd.rb
+++ b/Formula/openttd.rb
@@ -4,7 +4,7 @@ class Openttd < Formula
   url "https://cdn.openttd.org/openttd-releases/1.11.2/openttd-1.11.2-source.tar.xz"
   sha256 "0fba935a2a815f4fe8cd6dc2e2ae33f72769538731228f848a63b3a6e9482e6d"
   license "GPL-2.0-only"
-  head "https://github.com/OpenTTD/OpenTTD.git"
+  head "https://github.com/OpenTTD/OpenTTD.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -5,7 +5,7 @@ class OperatorSdk < Formula
       tag:      "v1.12.0",
       revision: "d3b2761afdb78f629a7eaf4461b0fb8ae3b02860"
   license "Apache-2.0"
-  head "https://github.com/operator-framework/operator-sdk.git"
+  head "https://github.com/operator-framework/operator-sdk.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/or-tools.rb
+++ b/Formula/or-tools.rb
@@ -5,7 +5,7 @@ class OrTools < Formula
   sha256 "fa7700b614ea2a5b2b6e37b76874bd2c3f04a80f03cbbf7871a2d2d5cd3a6091"
   license "Apache-2.0"
   revision 2
-  head "https://github.com/google/or-tools.git"
+  head "https://github.com/google/or-tools.git", branch: "stable"
 
   livecheck do
     url :stable

--- a/Formula/orbit.rb
+++ b/Formula/orbit.rb
@@ -5,7 +5,7 @@ class Orbit < Formula
   sha256 "55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-only"]
   revision 1
-  head "https://gitlab.gnome.org/Archive/orbit2.git"
+  head "https://gitlab.gnome.org/Archive/orbit2.git", branch: "master"
 
   bottle do
     rebuild 3

--- a/Formula/ormolu.rb
+++ b/Formula/ormolu.rb
@@ -4,7 +4,7 @@ class Ormolu < Formula
   url "https://github.com/tweag/ormolu/archive/0.2.0.0.tar.gz"
   sha256 "04461449cb6ba79230ffebe9e432765b3a190dacf28b73c4931cbccbe516f8d0"
   license "BSD-3-Clause"
-  head "https://github.com/tweag/ormolu.git"
+  head "https://github.com/tweag/ormolu.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d8fd89b32a6dbe77698d25b8d5b6a9bde490e1c9e05b73079d9146ea4ab5c032"

--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -6,7 +6,7 @@ class Osc < Formula
   url "https://github.com/openSUSE/osc/archive/0.174.0.tar.gz"
   sha256 "9be35b347fa07ac1235aa364b0e1229c00d5e98e202923d7a8a796e3ca2756ad"
   license "GPL-2.0-or-later"
-  head "https://github.com/openSUSE/osc.git"
+  head "https://github.com/openSUSE/osc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "aff25f27cf63f10915f491f01a2404eb471e7c1f5a0e6215d3f663d57aa4636e"

--- a/Formula/osm2pgrouting.rb
+++ b/Formula/osm2pgrouting.rb
@@ -5,7 +5,7 @@ class Osm2pgrouting < Formula
   sha256 "e3a58bcacf0c8811e0dcf3cf3791a4a7cc5ea2a901276133eacf227b30fd8355"
   license "GPL-2.0-or-later"
   revision 1
-  head "https://github.com/pgRouting/osm2pgrouting.git"
+  head "https://github.com/pgRouting/osm2pgrouting.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "9bcbb99b700443c680e3d1bf0c150228022afbb390f85a0a8374362ff43ebdd5"

--- a/Formula/osm2pgsql.rb
+++ b/Formula/osm2pgsql.rb
@@ -4,7 +4,7 @@ class Osm2pgsql < Formula
   url "https://github.com/openstreetmap/osm2pgsql/archive/1.5.1.tar.gz"
   sha256 "4df0d332e5d77a9d363f2f06f199da0ac23a0dc7890b3472ea1b5123ac363f6e"
   license "GPL-2.0-only"
-  head "https://github.com/openstreetmap/osm2pgsql.git"
+  head "https://github.com/openstreetmap/osm2pgsql.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "ece6fdfa41191aa1f7f5c82b6c197e668e5550cfae6d72271bf0253f3a4d166f"

--- a/Formula/osmfilter.rb
+++ b/Formula/osmfilter.rb
@@ -6,7 +6,7 @@ class Osmfilter < Formula
       revision: "f341f5f237737594c1b024338f0a2fc04fabdff3"
   license "AGPL-3.0"
   revision 1 unless OS.mac?
-  head "https://gitlab.com/osm-c-tools/osmctools.git"
+  head "https://gitlab.com/osm-c-tools/osmctools.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4b37db3c9ebe77673bbd83fb7d2e6c215760450987df2ded64044eccf6f34d3b"

--- a/Formula/ospray.rb
+++ b/Formula/ospray.rb
@@ -4,7 +4,7 @@ class Ospray < Formula
   url "https://github.com/ospray/ospray/archive/v2.7.0.tar.gz"
   sha256 "bcaeb221b5dd383d27587ffaca7f75d7e0064f64017a0d73df90862b14b5704b"
   license "Apache-2.0"
-  head "https://github.com/ospray/ospray.git"
+  head "https://github.com/ospray/ospray.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -5,7 +5,7 @@ class OsrmBackend < Formula
   sha256 "6da276d609a54600bb37007fd98d14c2a48639f51dda0d962b5801dd0118dfbb"
   license "BSD-2-Clause"
   revision 1
-  head "https://github.com/Project-OSRM/osrm-backend.git"
+  head "https://github.com/Project-OSRM/osrm-backend.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/osxutils.rb
+++ b/Formula/osxutils.rb
@@ -4,7 +4,7 @@ class Osxutils < Formula
   url "https://github.com/specious/osxutils/archive/v1.9.0.tar.gz"
   sha256 "9c11d989358ed5895d9af7644b9295a17128b37f41619453026f67e99cb7ecab"
   license "GPL-2.0"
-  head "https://github.com/specious/osxutils.git"
+  head "https://github.com/specious/osxutils.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c5d4050cda7e5ede43231c7195ffa1eb06bf5e3b5a1efa6acf8243a0e8ee424a"

--- a/Formula/ott.rb
+++ b/Formula/ott.rb
@@ -5,7 +5,7 @@ class Ott < Formula
   sha256 "3203f1b3eeb30e6aead9f63f6df22f5ead2407964ac9bb3cd5b0ae78df4568f8"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/ott-lang/ott.git"
+  head "https://github.com/ott-lang/ott.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/overdrive.rb
+++ b/Formula/overdrive.rb
@@ -4,7 +4,7 @@ class Overdrive < Formula
   url "https://github.com/chbrown/overdrive/archive/2.1.1.tar.gz"
   sha256 "74ec42df2c5dda56bfe04c0f8b831d21fd1511c0ef2839dd2bd84d1fda2b8b6b"
   license "MIT"
-  head "https://github.com/chbrown/overdrive.git"
+  head "https://github.com/chbrown/overdrive.git", branch: "master"
 
   depends_on "tidy-html5"
   uses_from_macos "curl"

--- a/Formula/overmind.rb
+++ b/Formula/overmind.rb
@@ -4,7 +4,7 @@ class Overmind < Formula
   url "https://github.com/DarthSim/overmind/archive/v2.2.2.tar.gz"
   sha256 "1d8afd960f91dcbb9e3c529f69aa3f1be89931b2c888a78ad69915faeb523f47"
   license "MIT"
-  head "https://github.com/DarthSim/overmind.git"
+  head "https://github.com/DarthSim/overmind.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "00af66eeee076ae3bccba58a690dc73f908b6af7ea0bfebf1fc6b81c5a88c445"

--- a/Formula/ox.rb
+++ b/Formula/ox.rb
@@ -4,7 +4,7 @@ class Ox < Formula
   url "https://github.com/curlpipe/ox/archive/0.2.5.tar.gz"
   sha256 "873eb447029508bc3fd1d7dda8803d79a7b107a7a903399947f4eac6ae671176"
   license "GPL-2.0-only"
-  head "https://github.com/curlpipe/ox.git"
+  head "https://github.com/curlpipe/ox.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b2d8f1cf845e18a1068b939792814aaa0de01557bf62f55a54f399fbfec397f6"

--- a/Formula/oysttyer.rb
+++ b/Formula/oysttyer.rb
@@ -3,7 +3,7 @@ class Oysttyer < Formula
   homepage "https://github.com/oysttyer/oysttyer"
   url "https://github.com/oysttyer/oysttyer/archive/2.10.0.tar.gz"
   sha256 "3c0ce1c7b112f2db496cc75a6e76c67f1cad956f9e7812819c6ae7a979b2baea"
-  head "https://github.com/oysttyer/oysttyer.git"
+  head "https://github.com/oysttyer/oysttyer.git", branch: "master"
 
   def install
     bin.install "oysttyer.pl" => "oysttyer"


### PR DESCRIPTION
Merge Homebrew/homebrew-core into Homebrew/linuxbrew-core

+ [ ] bison
+ [ ] notmuch-mutt
+ [ ] osmfilter
+ [ ] datalad
+ [ ] n
+ [ ] nagios-plugins
+ [ ] nailgun
+ [ ] nanomsg
+ [ ] nanorc
+ [ ] narwhal
+ [ ] natalie
+ [ ] nats-server
+ [ ] nats-streaming-server
+ [ ] nave
+ [ ] nbsdgames
+ [ ] ncompress
+ [ ] ncrack
+ [ ] ndenv
+ [ ] ne
+ [ ] neatvi
+ [ ] neko
+ [ ] neofetch
+ [ ] neomutt
+ [ ] neovim-remote
+ [ ] neovim
+ [ ] nestopia-ue
+ [ ] net-snmp
+ [ ] netcdf
+ [ ] nethack
+ [ ] netlify-cli
+ [ ] netperf
+ [ ] never
+ [ ] newrelic-cli
+ [ ] newsboat
+ [ ] nfdump
+ [ ] nfpm
+ [ ] ngs
+ [ ] nicotine-plus
+ [ ] ninja
+ [ ] nlopt
+ [ ] nnn
+ [ ] node-build
+ [ ] node
+ [ ] node_exporter
+ [ ] nodebrew
+ [ ] nodenv
+ [ ] nomino
+ [ ] notmuch
+ [ ] nq
+ [ ] nsnake
+ [ ] nsq
+ [ ] nuclei
+ [ ] nudoku
+ [ ] numcpp
+ [ ] numpy
+ [ ] nutcracker
+ [ ] nvm
+ [ ] oakc
+ [ ] oauth2_proxy
+ [ ] oauth2l
+ [ ] objc-codegenutils
+ [ ] objc-run
+ [ ] ocamlbuild
+ [ ] oci-cli
+ [ ] ocp
+ [ ] ocproxy
+ [ ] octant
+ [ ] ode
+ [ ] odin
+ [ ] offlineimap
+ [ ] oha
+ [ ] ohcount
+ [ ] ola
+ [ ] omake
+ [ ] ompl
+ [ ] ondir
+ [ ] onednn
+ [ ] oniguruma
+ [ ] opa
+ [ ] opam
+ [ ] open-adventure
+ [ ] open-babel
+ [ ] open-completion
+ [ ] open-scene-graph
+ [ ] open-tyrian
+ [ ] openal-soft
+ [ ] openclonk
+ [ ] opencoarrays
+ [ ] opencolorio
+ [ ] openfpgaloader
+ [ ] openh264
+ [ ] openhmd
+ [ ] openimageio
+ [ ] openjazz
+ [ ] openjpeg
+ [ ] openmodelica
+ [ ] openmsx
+ [ ] opensc
+ [ ] openshift-cli
+ [ ] openttd
+ [ ] operator-sdk
+ [ ] or-tools
+ [ ] orbit
+ [ ] ormolu
+ [ ] osc
+ [ ] osm2pgrouting
+ [ ] osm2pgsql
+ [ ] ospray
+ [ ] osrm-backend
+ [ ] osxutils
+ [ ] ott
+ [ ] overdrive
+ [ ] overmind
+ [ ] ox
+ [ ] oysttyer